### PR TITLE
Android: sync event handlers with iOS (TagMsg, reactions, typing)

### DIFF
--- a/freeq-android/freeq/build.gradle.kts
+++ b/freeq-android/freeq/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     // Browser (Chrome Custom Tabs for OAuth)
     implementation("androidx.browser:browser:1.7.0")
 
+    // Emoji picker
+    implementation("androidx.emoji2:emoji2-emojipicker:1.5.0")
+
     // JNA (required by UniFFI-generated Kotlin bindings)
     implementation("net.java.dev.jna:jna:5.13.0@aar")
 

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -652,7 +652,7 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                     }
                 } else if (text.startsWith("MOTD:") && state.collectingMotd) {
                     state.motdLines.add(text.removePrefix("MOTD:"))
-                } else if (!state.collectingMotd) {
+                } else if (!state.collectingMotd && text.isNotBlank()) {
                     // Server error or notice — show to user
                     state.errorMessage.value = text
                 }

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -413,6 +413,14 @@ class AppState(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun awayMessage(nick: String): String? {
+        for (ch in channels) {
+            val member = ch.members.firstOrNull { it.nick.equals(nick, ignoreCase = true) }
+            if (member?.awayMsg != null) return member.awayMsg
+        }
+        return null
+    }
+
     fun updateAwayStatus(nick: String, awayMsg: String?) {
         for (ch in channels) {
             val idx = ch.members.indexOfFirst { it.nick.equals(nick, ignoreCase = true) }

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -652,6 +652,9 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                     }
                 } else if (text.startsWith("MOTD:") && state.collectingMotd) {
                     state.motdLines.add(text.removePrefix("MOTD:"))
+                } else if (!state.collectingMotd) {
+                    // Server error or notice — show to user
+                    state.errorMessage.value = text
                 }
             }
 

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -28,11 +28,14 @@ data class ChatMessage(
 data class MemberInfo(
     val nick: String,
     val isOp: Boolean,
-    val isVoiced: Boolean
+    val isHalfop: Boolean = false,
+    val isVoiced: Boolean,
+    val awayMsg: String? = null
 ) {
     val prefix: String
         get() = when {
             isOp -> "@"
+            isHalfop -> "%"
             isVoiced -> "+"
             else -> ""
         }
@@ -68,6 +71,42 @@ class ChannelState(val name: String) {
             messages.add(msg)
         }
     }
+
+    fun applyEdit(originalId: String, newId: String?, newText: String) {
+        val idx = findMessage(originalId) ?: return
+        messages[idx] = messages[idx].copy(text = newText, isEdited = true)
+        if (newId != null) messageIds.add(newId)
+    }
+
+    fun applyDelete(msgId: String) {
+        val idx = findMessage(msgId) ?: return
+        messages[idx] = messages[idx].copy(isDeleted = true, text = "")
+    }
+
+    fun applyReaction(msgId: String, emoji: String, from: String): Boolean {
+        val idx = findMessage(msgId) ?: return true
+        val msg = messages[idx]
+        // Build entirely new collections — mutating in place causes old.equals(new)
+        // to be true on the data class, so LazyColumn skips recomposition.
+        val newReactions = mutableMapOf<String, MutableSet<String>>()
+        var added = true
+        for ((e, nicks) in msg.reactions) {
+            if (e == emoji) {
+                val newNicks = nicks.toMutableSet()
+                if (from in newNicks) { newNicks.remove(from); added = false }
+                else { newNicks.add(from); added = true }
+                if (newNicks.isNotEmpty()) newReactions[e] = newNicks
+            } else {
+                newReactions[e] = nicks.toMutableSet()
+            }
+        }
+        if (emoji !in msg.reactions) {
+            newReactions[emoji] = mutableSetOf(from)
+            added = true
+        }
+        messages[idx] = msg.copy(reactions = newReactions)
+        return added
+    }
 }
 
 // ── Connection state ──
@@ -101,6 +140,9 @@ class AppState(application: Application) : AndroidViewModel(application) {
     val lastReadMessageIds = mutableStateMapOf<String, String>()
     val lastReadTimestamps = mutableStateMapOf<String, Long>()
     var isDarkTheme = mutableStateOf(true)
+
+    val batches = mutableMapOf<String, BatchBuffer>()
+    data class BatchBuffer(val target: String, val messages: MutableList<ChatMessage> = mutableListOf())
 
     private var client: FreeqClient? = null
     private var lastTypingSent: Long = 0
@@ -243,17 +285,20 @@ class AppState(application: Application) : AndroidViewModel(application) {
     }
 
     fun sendReaction(target: String, msgId: String, emoji: String) {
-        sendRaw("@+react=$emoji;+reply=$msgId TAGMSG $target")
+        val ch = channels.firstOrNull { it.name.equals(target, ignoreCase = true) }
+            ?: dmBuffers.firstOrNull { it.name.equals(target, ignoreCase = true) }
+        val added = ch?.applyReaction(msgId, emoji, nick.value) ?: true
+        if (added) {
+            sendRaw("@+react=$emoji;+reply=$msgId TAGMSG $target")
+        }
     }
 
     fun deleteMessage(target: String, msgId: String) {
-        sendRaw("@+draft/delete=$msgId TAGMSG $target")
+        // Optimistic local delete — server doesn't echo TAGMSG to sender
         val ch = channels.firstOrNull { it.name.equals(target, ignoreCase = true) }
             ?: dmBuffers.firstOrNull { it.name.equals(target, ignoreCase = true) }
-        val idx = ch?.findMessage(msgId)
-        if (ch != null && idx != null) {
-            ch.messages[idx] = ch.messages[idx].copy(isDeleted = true)
-        }
+        ch?.applyDelete(msgId)
+        sendRaw("@+draft/delete=$msgId TAGMSG $target")
     }
 
     fun sendTyping(target: String) {
@@ -335,6 +380,40 @@ class AppState(application: Application) : AndroidViewModel(application) {
             stale.forEach { ch.typingUsers.remove(it) }
         }
     }
+
+    fun renameUser(oldNick: String, newNick: String) {
+        for (ch in channels) {
+            val idx = ch.members.indexOfFirst { it.nick.equals(oldNick, ignoreCase = true) }
+            if (idx >= 0) {
+                ch.members[idx] = ch.members[idx].copy(nick = newNick)
+            }
+            ch.typingUsers.remove(oldNick)?.let { ch.typingUsers[newNick] = it }
+        }
+        val dmIdx = dmBuffers.indexOfFirst { it.name.equals(oldNick, ignoreCase = true) }
+        if (dmIdx >= 0) {
+            val old = dmBuffers[dmIdx]
+            val renamed = ChannelState(newNick)
+            renamed.messages.addAll(old.messages)
+            renamed.members.addAll(old.members)
+            renamed.topic.value = old.topic.value
+            renamed.typingUsers.putAll(old.typingUsers)
+            dmBuffers.removeAt(dmIdx)
+            dmBuffers.add(renamed)
+            unreadCounts.remove(old.name)?.let { unreadCounts[newNick] = it }
+        }
+        if (nick.value.equals(oldNick, ignoreCase = true)) {
+            nick.value = newNick
+        }
+    }
+
+    fun updateAwayStatus(nick: String, awayMsg: String?) {
+        for (ch in channels) {
+            val idx = ch.members.indexOfFirst { it.nick.equals(nick, ignoreCase = true) }
+            if (idx >= 0) {
+                ch.members[idx] = ch.members[idx].copy(awayMsg = awayMsg)
+            }
+        }
+    }
 }
 
 // ── Event handler ──
@@ -412,26 +491,6 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 val ircMsg = event.msg
                 val isSelf = ircMsg.fromNick.equals(state.nick.value, ignoreCase = true)
 
-                // Edit: update existing message in-place
-                val editTarget = ircMsg.replacesMsgid
-                if (editTarget != null) {
-                    val ch = if (ircMsg.target.startsWith("#")) {
-                        state.channels.firstOrNull { it.name.equals(ircMsg.target, ignoreCase = true) }
-                    } else {
-                        val bufferName = if (isSelf) ircMsg.target else ircMsg.fromNick
-                        state.dmBuffers.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
-                    }
-                    val idx = ch?.findMessage(editTarget)
-                    if (ch != null && idx != null) {
-                        ch.messages[idx] = ch.messages[idx].copy(
-                            text = ircMsg.text,
-                            isEdited = true
-                        )
-                    }
-                    ch?.typingUsers?.remove(ircMsg.fromNick)
-                    return
-                }
-
                 val msg = ChatMessage(
                     id = ircMsg.msgid ?: UUID.randomUUID().toString(),
                     from = ircMsg.fromNick,
@@ -440,6 +499,39 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                     timestamp = Date(ircMsg.timestampMs),
                     replyTo = ircMsg.replyTo
                 )
+
+                // Handle edits (prefer editOf, fall back to replacesMsgid)
+                val editTarget = ircMsg.editOf ?: ircMsg.replacesMsgid
+                if (editTarget != null) {
+                    val batchId = ircMsg.batchId
+                    if (batchId != null) {
+                        state.batches[batchId]?.let { batch ->
+                            val idx = batch.messages.indexOfFirst { it.id == editTarget }
+                            if (idx >= 0) {
+                                batch.messages[idx] = batch.messages[idx].copy(text = ircMsg.text, isEdited = true)
+                            } else {
+                                batch.messages.add(msg)
+                            }
+                        }
+                        return
+                    }
+                    val ch = if (ircMsg.target.startsWith("#")) {
+                        state.channels.firstOrNull { it.name.equals(ircMsg.target, ignoreCase = true) }
+                    } else {
+                        val bufferName = if (isSelf) ircMsg.target else ircMsg.fromNick
+                        state.dmBuffers.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                    }
+                    ch?.applyEdit(editTarget, ircMsg.msgid, ircMsg.text)
+                    ch?.typingUsers?.remove(ircMsg.fromNick)
+                    return
+                }
+
+                // If part of CHATHISTORY batch, buffer for later merge
+                val batchId = ircMsg.batchId
+                if (batchId != null && state.batches.containsKey(batchId)) {
+                    state.batches[batchId]?.messages?.add(msg)
+                    return
+                }
 
                 if (ircMsg.target.startsWith("#")) {
                     val ch = state.getOrCreateChannel(ircMsg.target)
@@ -470,7 +562,7 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 val ch = state.getOrCreateChannel(event.channel)
                 ch.members.clear()
                 ch.members.addAll(event.members.map {
-                    MemberInfo(nick = it.nick, isOp = it.isOp, isVoiced = it.isVoiced)
+                    MemberInfo(nick = it.nick, isOp = it.isOp, isHalfop = it.isHalfop, isVoiced = it.isVoiced, awayMsg = it.awayMsg)
                 })
                 AvatarCache.prefetchAll(event.members.map { it.nick })
             }
@@ -481,7 +573,21 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
             }
 
             is FreeqEvent.ModeChanged -> {
-                // Rely on NAMES to refresh member status
+                val nick = event.arg ?: return
+                val ch = state.channels.firstOrNull { it.name.equals(event.channel, ignoreCase = true) } ?: return
+                val idx = ch.members.indexOfFirst { it.nick.equals(nick, ignoreCase = true) }
+                if (idx >= 0) {
+                    val m = ch.members[idx]
+                    ch.members[idx] = when (event.mode) {
+                        "+o" -> m.copy(isOp = true)
+                        "-o" -> m.copy(isOp = false)
+                        "+h" -> m.copy(isHalfop = true)
+                        "-h" -> m.copy(isHalfop = false)
+                        "+v" -> m.copy(isVoiced = true)
+                        "-v" -> m.copy(isVoiced = false)
+                        else -> m
+                    }
+                }
             }
 
             is FreeqEvent.Kicked -> {
@@ -522,6 +628,72 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 if (event.reason.isNotEmpty()) {
                     state.errorMessage.value = "Disconnected: ${event.reason}"
                 }
+            }
+
+            is FreeqEvent.TagMsg -> {
+                val tags = event.msg.tags.associate { it.key to it.value }
+                val target = event.msg.target
+                val from = event.msg.from
+                // Typing indicators (ignore self)
+                tags["+typing"]?.let { typing ->
+                    if (!from.equals(state.nick.value, ignoreCase = true)) {
+                        val bufferName = if (target.startsWith("#")) target else from
+                        val ch = if (bufferName.startsWith("#"))
+                            state.channels.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                        else
+                            state.dmBuffers.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                        ch?.let {
+                            if (typing == "active") it.typingUsers[from] = Date()
+                            else if (typing == "done") it.typingUsers.remove(from)
+                        }
+                    }
+                }
+
+                // Message deletion (ignore self — already handled optimistically by deleteMessage)
+                tags["+draft/delete"]?.let { deleteId ->
+                    if (!from.equals(state.nick.value, ignoreCase = true)) {
+                        val bufferName = if (target.startsWith("#")) target else from
+                        val ch = if (bufferName.startsWith("#"))
+                            state.channels.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                        else
+                            state.dmBuffers.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                        ch?.applyDelete(deleteId)
+                    }
+                }
+
+                // Reactions (ignore self — already handled optimistically by sendReaction)
+                val emoji = tags["+react"]
+                val replyId = tags["+reply"]
+                if (emoji != null && replyId != null && !from.equals(state.nick.value, ignoreCase = true)) {
+                    val bufferName = if (target.startsWith("#")) target else from
+                    val ch = if (bufferName.startsWith("#"))
+                        state.channels.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                    else
+                        state.dmBuffers.firstOrNull { it.name.equals(bufferName, ignoreCase = true) }
+                    ch?.applyReaction(replyId, emoji, from)
+                }
+            }
+
+            is FreeqEvent.NickChanged -> {
+                state.renameUser(event.oldNick, event.newNick)
+            }
+
+            is FreeqEvent.AwayChanged -> {
+                state.updateAwayStatus(event.nick, event.awayMsg)
+            }
+
+            is FreeqEvent.BatchStart -> {
+                state.batches[event.id] = AppState.BatchBuffer(target = event.target)
+            }
+
+            is FreeqEvent.BatchEnd -> {
+                val batch = state.batches.remove(event.id) ?: return
+                val sorted = batch.messages.sortedBy { it.timestamp }
+                val ch = if (batch.target.startsWith("#"))
+                    state.getOrCreateChannel(batch.target)
+                else
+                    state.getOrCreateDM(batch.target)
+                sorted.forEach { ch.appendIfNew(it) }
             }
         }
     }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/FreeqApp.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/FreeqApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import com.freeq.model.AppState
 import com.freeq.model.ConnectionState
+import com.freeq.ui.components.MotdDialog
 import com.freeq.ui.navigation.MainScreen
 import com.freeq.ui.screens.ConnectScreen
 import com.freeq.ui.theme.FreeqTheme
@@ -21,5 +22,7 @@ fun FreeqApp(appState: AppState) {
             ConnectionState.Connected,
             ConnectionState.Registered -> MainScreen(appState)
         }
+
+        MotdDialog(appState)
     }
 }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/ChannelSettingsSheet.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/ChannelSettingsSheet.kt
@@ -1,0 +1,258 @@
+package com.freeq.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Tag
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.freeq.model.AppState
+import com.freeq.model.AvatarCache
+import com.freeq.model.ChannelState
+import com.freeq.ui.theme.FreeqColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChannelSettingsSheet(
+    channelState: ChannelState,
+    appState: AppState,
+    onDismiss: () -> Unit,
+    onLeave: () -> Unit
+) {
+    val topic by channelState.topic
+    var editingTopic by remember { mutableStateOf(false) }
+    var topicDraft by remember { mutableStateOf(topic) }
+    val myNick = appState.nick.value
+    val isOp = channelState.members.any {
+        it.nick.equals(myNick, ignoreCase = true) && it.isOp
+    }
+    val ops = channelState.members.filter { it.isOp }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            // ── Channel Header ──
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = FreeqColors.accent.copy(alpha = 0.15f),
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            Icons.Default.Tag,
+                            contentDescription = null,
+                            tint = FreeqColors.accent,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+                Column {
+                    Text(
+                        text = channelState.name,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                    Text(
+                        text = "${channelState.members.size} members",
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // ── Topic Section ──
+            Card(
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            "TOPIC",
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            letterSpacing = 1.sp
+                        )
+                        if (isOp && !editingTopic) {
+                            IconButton(
+                                onClick = {
+                                    topicDraft = topic
+                                    editingTopic = true
+                                },
+                                modifier = Modifier.size(28.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Edit,
+                                    contentDescription = "Edit topic",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    if (editingTopic) {
+                        OutlinedTextField(
+                            value = topicDraft,
+                            onValueChange = { topicDraft = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            minLines = 1,
+                            maxLines = 5,
+                            textStyle = LocalTextStyle.current.copy(fontSize = 14.sp)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            TextButton(onClick = { editingTopic = false }) {
+                                Text("Cancel")
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Button(
+                                onClick = {
+                                    appState.sendRaw("TOPIC ${channelState.name} :$topicDraft")
+                                    editingTopic = false
+                                },
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = FreeqColors.accent
+                                )
+                            ) {
+                                Text("Save")
+                            }
+                        }
+                    } else {
+                        Text(
+                            text = topic.ifEmpty { "No topic set" },
+                            fontSize = 14.sp,
+                            color = if (topic.isEmpty())
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                            else MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                }
+            }
+
+            // ── Operators Section ──
+            if (ops.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            "OPERATORS (${ops.size})",
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            letterSpacing = 1.sp
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        ops.forEach { op ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            ) {
+                                UserAvatar(nick = op.nick, size = 28.dp)
+                                Text(
+                                    text = op.nick,
+                                    fontSize = 14.sp,
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                if (AvatarCache.avatarUrl(op.nick) != null) {
+                                    Icon(
+                                        Icons.Default.CheckCircle,
+                                        contentDescription = "Verified",
+                                        tint = FreeqColors.accent,
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                                Icon(
+                                    Icons.Default.Shield,
+                                    contentDescription = "Operator",
+                                    tint = FreeqColors.warning,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Leave Channel ──
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    appState.partChannel(channelState.name)
+                    onDismiss()
+                    onLeave()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = FreeqColors.danger),
+                contentPadding = PaddingValues(vertical = 14.dp)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.Logout,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    "Leave Channel",
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
@@ -85,12 +86,14 @@ private fun MemberRow(member: MemberInfo, onMemberClick: ((String) -> Unit)? = n
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        // Online dot
+        val isAway = member.awayMsg != null
+
+        // Presence dot — yellow if away, green if available
         Box(
             modifier = Modifier
                 .size(8.dp)
                 .clip(CircleShape)
-                .background(FreeqColors.success)
+                .background(if (isAway) FreeqColors.warning else FreeqColors.success)
         )
 
         UserAvatar(nick = member.nick, size = 32.dp)
@@ -111,7 +114,8 @@ private fun MemberRow(member: MemberInfo, onMemberClick: ((String) -> Unit)? = n
                 Text(
                     text = member.nick,
                     fontSize = 14.sp,
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = if (isAway) MaterialTheme.colorScheme.onSurfaceVariant
+                        else MaterialTheme.colorScheme.onBackground
                 )
                 if (AvatarCache.avatarUrl(member.nick) != null) {
                     Icon(
@@ -121,6 +125,29 @@ private fun MemberRow(member: MemberInfo, onMemberClick: ((String) -> Unit)? = n
                         modifier = Modifier.size(13.dp)
                     )
                 }
+                if (isAway) {
+                    Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = FreeqColors.warning.copy(alpha = 0.15f)
+                    ) {
+                        Text(
+                            text = "Away",
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = FreeqColors.warning,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp)
+                        )
+                    }
+                }
+            }
+            // Away message text
+            if (isAway && member.awayMsg?.isNotEmpty() == true) {
+                Text(
+                    text = member.awayMsg!!,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    maxLines = 1
+                )
             }
         }
     }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,6 +16,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.freeq.model.AvatarCache
 import com.freeq.model.MemberInfo
 import com.freeq.ui.theme.FreeqColors
 
@@ -110,6 +113,14 @@ private fun MemberRow(member: MemberInfo, onMemberClick: ((String) -> Unit)? = n
                     fontSize = 14.sp,
                     color = MaterialTheme.colorScheme.onBackground
                 )
+                if (AvatarCache.avatarUrl(member.nick) != null) {
+                    Icon(
+                        Icons.Default.CheckCircle,
+                        contentDescription = "Verified",
+                        tint = FreeqColors.accent,
+                        modifier = Modifier.size(13.dp)
+                    )
+                }
             }
         }
     }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MemberList.kt
@@ -141,9 +141,9 @@ private fun MemberRow(member: MemberInfo, onMemberClick: ((String) -> Unit)? = n
                 }
             }
             // Away message text
-            if (isAway && member.awayMsg?.isNotEmpty() == true) {
+            if (isAway && !member.awayMsg.isNullOrEmpty()) {
                 Text(
-                    text = member.awayMsg!!,
+                    text = member.awayMsg,
                     fontSize = 12.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                     maxLines = 1

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -198,10 +199,20 @@ private fun MessageBubble(
         else -> Modifier
     }
 
+    val accentColor = FreeqColors.accent
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .then(bgModifier)
+            .then(
+                if (isMention) Modifier.drawBehind {
+                    drawRect(
+                        color = accentColor,
+                        topLeft = androidx.compose.ui.geometry.Offset.Zero,
+                        size = androidx.compose.ui.geometry.Size(3.dp.toPx(), size.height)
+                    )
+                } else Modifier
+            )
             .padding(
                 start = 16.dp,
                 end = 16.dp,

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
@@ -26,8 +26,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.freeq.model.AppState
+import com.freeq.model.AvatarCache
 import com.freeq.model.ChannelState
 import com.freeq.model.ChatMessage
+import com.freeq.model.MemberInfo
 import com.freeq.ui.theme.FreeqColors
 import com.freeq.ui.theme.Theme
 import java.text.SimpleDateFormat
@@ -268,6 +270,14 @@ private fun MessageBubble(
                             color = Theme.nickColor(msg.from),
                             modifier = Modifier.clickable { onNickClick?.invoke(msg.from) }
                         )
+                        if (AvatarCache.avatarUrl(msg.from) != null) {
+                            Icon(
+                                Icons.Default.CheckCircle,
+                                contentDescription = "Verified",
+                                tint = FreeqColors.accent,
+                                modifier = Modifier.size(14.dp)
+                            )
+                        }
                         Text(
                             text = formatTime(msg.timestamp),
                             fontSize = 11.sp,

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
@@ -259,12 +259,15 @@ private fun MessageBubble(
             ) {
                 // Header: nick + time
                 if (showHeader) {
+                    val memberPrefix = channelState.members
+                        .firstOrNull { it.nick.equals(msg.from, ignoreCase = true) }
+                        ?.prefix ?: ""
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Text(
-                            text = msg.from,
+                            text = memberPrefix + msg.from,
                             fontSize = 14.sp,
                             fontWeight = FontWeight.SemiBold,
                             color = Theme.nickColor(msg.from),

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
@@ -104,9 +104,22 @@ fun MessageList(
         }
     }
 
-    // Auto-scroll to bottom on new messages only if already near bottom
+    // On first load, scroll to last-read position (or bottom if none)
+    var initialScrollDone by remember { mutableStateOf(false) }
     LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty() && scrollToMessageId == null && isNearBottom) {
+        if (!initialScrollDone && messages.isNotEmpty()) {
+            val targetIdx = if (lastReadId != null) {
+                val idx = messages.indexOfFirst { it.id == lastReadId }
+                if (idx >= 0) idx else messages.size - 1
+            } else if (lastReadTimestamp > 0) {
+                val idx = messages.indexOfLast { it.timestamp.time <= lastReadTimestamp }
+                if (idx >= 0) idx else messages.size - 1
+            } else {
+                messages.size - 1
+            }
+            listState.scrollToItem(targetIdx)
+            initialScrollDone = true
+        } else if (initialScrollDone && messages.isNotEmpty() && scrollToMessageId == null && isNearBottom && !listState.isScrollInProgress) {
             listState.animateScrollToItem(messages.size - 1)
         }
     }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MessageList.kt
@@ -3,7 +3,9 @@ package com.freeq.ui.components
 import android.view.ContextThemeWrapper
 import androidx.compose.foundation.background
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -174,6 +176,7 @@ fun MessageList(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MessageBubble(
     msg: ChatMessage,
@@ -266,7 +269,15 @@ private fun MessageBubble(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .clickable { showMenu = true }
+                    .combinedClickable(
+                        onClick = { showMenu = true },
+                        onDoubleClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            appState.activeChannel.value?.let { target ->
+                                appState.sendReaction(target, msg.id, "\u2764\uFE0F")
+                            }
+                        }
+                    )
             ) {
                 // Header: nick + time
                 if (showHeader) {

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/MotdDialog.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/MotdDialog.kt
@@ -1,0 +1,49 @@
+package com.freeq.ui.components
+
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.freeq.model.AppState
+
+@Composable
+fun MotdDialog(appState: AppState) {
+    if (!appState.showMotd.value) return
+
+    AlertDialog(
+        onDismissRequest = { dismissMotd(appState) },
+        title = { Text("Message of the Day") },
+        confirmButton = {
+            TextButton(onClick = { dismissMotd(appState) }) {
+                Text("OK")
+            }
+        },
+        text = {
+            LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
+                items(appState.motdLines.toList()) { line ->
+                    if (line.isBlank()) {
+                        Spacer(Modifier.height(8.dp))
+                    } else {
+                        Text(
+                            text = line,
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+            }
+        }
+    )
+}
+
+private fun dismissMotd(appState: AppState) {
+    appState.showMotd.value = false
+    val content = appState.motdLines.joinToString("\n")
+    val hash = content.hashCode().toString(36)
+    appState.prefs.edit().putString("motd_seen_hash", hash).apply()
+}

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/UserProfileSheet.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/UserProfileSheet.kt
@@ -1,7 +1,9 @@
 package com.freeq.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -77,6 +79,33 @@ fun UserProfileSheet(
                         contentDescription = "Verified",
                         tint = FreeqColors.accent,
                         modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+
+            // Away status
+            appState.awayMessage(nick)?.let { awayMsg ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(8.dp)
+                            .background(FreeqColors.warning, CircleShape)
+                    )
+                    Text(
+                        text = "Away",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = FreeqColors.warning
+                    )
+                }
+                if (awayMsg.isNotEmpty()) {
+                    Text(
+                        text = awayMsg,
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/navigation/MainScreen.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/navigation/MainScreen.kt
@@ -36,6 +36,16 @@ fun MainScreen(appState: AppState) {
 
     val totalUnread = appState.unreadCounts.values.sum()
 
+    // Snackbar for server errors/notices
+    val snackbarHostState = remember { SnackbarHostState() }
+    val errorMessage by appState.errorMessage
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            snackbarHostState.showSnackbar(it, duration = SnackbarDuration.Short)
+            appState.errorMessage.value = null
+        }
+    }
+
     // Handle pending navigation from notification tap
     val pendingNav = appState.pendingNavigation.value
     LaunchedEffect(pendingNav) {
@@ -49,6 +59,7 @@ fun MainScreen(appState: AppState) {
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
             if (showBottomBar) {
                 NavigationBar(

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatDetailScreen.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -16,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.freeq.model.AppState
+import com.freeq.ui.components.ChannelSettingsSheet
 import com.freeq.ui.components.ComposeBar
 import com.freeq.ui.components.MemberList
 import com.freeq.ui.components.MessageList
@@ -37,6 +39,7 @@ fun ChatDetailScreen(
 
     var showMembers by remember { mutableStateOf(false) }
     var showSearch by remember { mutableStateOf(false) }
+    var showChannelSettings by remember { mutableStateOf(false) }
     var profileSheetNick by remember { mutableStateOf<String?>(null) }
     var scrollToMessageId by remember { mutableStateOf<String?>(null) }
     val isChannel = channelName.startsWith("#")
@@ -65,7 +68,11 @@ fun ChatDetailScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Column {
+                    Column(
+                        modifier = if (isChannel && channelState != null)
+                            Modifier.clickable { showChannelSettings = true }
+                        else Modifier
+                    ) {
                         Text(
                             channelName,
                             fontSize = 17.sp,
@@ -204,6 +211,19 @@ fun ChatDetailScreen(
                     } else {
                         onNavigateToChat?.invoke(channel)
                     }
+                }
+            )
+        }
+
+        // Channel settings sheet
+        if (showChannelSettings && isChannel) {
+            ChannelSettingsSheet(
+                channelState = channelState,
+                appState = appState,
+                onDismiss = { showChannelSettings = false },
+                onLeave = {
+                    appState.activeChannel.value = null
+                    onBack()
                 }
             )
         }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/screens/SettingsTab.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/screens/SettingsTab.kt
@@ -1,6 +1,7 @@
 package com.freeq.ui.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -8,12 +9,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -291,6 +294,60 @@ fun SettingsTab(appState: AppState) {
                             "0.1",
                             fontSize = 14.sp,
                             color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+
+                    val uriHandler = LocalUriHandler.current
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { uriHandler.openUri("https://freeq.at") },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Language,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            "Website",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            Icons.AutoMirrored.Filled.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { uriHandler.openUri("https://github.com/chad/freeq") },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Code,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            "Source Code",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            Icons.AutoMirrored.Filled.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- Regenerated Kotlin FFI bindings to pick up new event types (TagMsg, NickChanged, AwayChanged, BatchStart/BatchEnd)
- Added Android event handlers matching iOS: typing indicators, message deletion, reactions, nick changes, away status, batch history, mode changes
- Quick-react emoji row and full emoji picker (androidx.emoji2) in message context menu
- Optimistic local state for reactions (with toggle) and deletes, ignoring server echo-message to prevent double-application
- Fixed Compose recomposition bug: build new reaction collections instead of mutating in place

### iOS parity features
- Verified badges in message headers, member list, and profile sheet (avatar cache presence)
- Away status display in member list and profile sheet
- Nick prefix (@/+/%) in message headers
- Mention left border accent
- Website and source code links in settings
- Double-tap message to react with heart emoji
- Server error notices surfaced via snackbar (with empty notice filter)
- Bold (`**text**`) and inline code (`` `code` ``) text formatting
- Scroll-to-bottom FAB with latest message preview
- Swipe-to-reply gesture on messages
- Skeleton shimmer loading for empty channels
- Channel settings bottom sheet (topic view/edit, operators, leave channel)

### Infrastructure
- DID field on MemberInfo (prep for account-notify)
- Auto-reconnect with exponential backoff (2s → 30s cap)
- MOTD collection and display dialog (hash-based dedup)
- Restore scroll position to last-read message on channel entry

## Test plan
- [x] Reactions: add/toggle/remove from Android and web
- [x] Delete/edit messages across clients
- [x] Nick change updates member list
- [x] Full emoji picker with dark theme
- [x] Verified badges show for users with avatars
- [x] Away status shows in member list
- [x] Bold and inline code render correctly
- [x] Scroll-to-bottom FAB appears when scrolled up, shows preview
- [x] Swipe right on message triggers reply
- [x] Skeleton loading shows on empty channel
- [x] Channel settings sheet opens on tap, topic editable for ops
- [x] Scroll position restores to last-read on channel re-entry
- [x] Auto-reconnect fires on disconnect with backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)