### PR TITLE
fix: web client shows delete placeholder instead of removing message

### DIFF
--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -440,7 +440,7 @@ function isGrouped(msgs: Message[], i: number): boolean {
   if (i === 0) return false;
   const prev = msgs[i - 1];
   const curr = msgs[i];
-  if (prev.isSystem || curr.isSystem) return false;
+  if (prev.isSystem || curr.isSystem || prev.deleted || curr.deleted) return false;
   if (prev.from !== curr.from) return false;
   if (curr.timestamp.getTime() - prev.timestamp.getTime() > 5 * 60 * 1000) return false;
   return true;
@@ -991,7 +991,11 @@ export function MessageList() {
               </div>
             )}
             {shouldShowDateSep(messages, i) && <DateSeparator date={msg.timestamp} />}
-            {msg.isSystem ? (
+            {msg.deleted ? (
+              <div className="px-4 py-0.5 text-xs italic text-[var(--text-muted)] opacity-50">
+                Message from {msg.from} deleted
+              </div>
+            ) : msg.isSystem ? (
               <SystemMessage msg={msg} />
             ) : isGrouped(messages, i) ? (
               <GroupedMessage msg={msg} channel={activeChannel} onNickClick={onNickClick} />

--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -291,6 +291,7 @@ export function sendEdit(target: string, originalMsgId: string, newText: string)
 }
 
 export function sendDelete(target: string, msgId: string) {
+  useStore.getState().deleteMessage(target, msgId);
   const line = format('TAGMSG', [target], { '+draft/delete': msgId });
   raw(line);
 }

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -540,7 +540,9 @@ export const useStore = create<Store>((set, get) => ({
     const channels = new Map(s.channels);
     const ch = channels.get(channel.toLowerCase());
     if (!ch) return { channels };
-    ch.messages = ch.messages.filter((m) => m.id !== msgId);
+    ch.messages = ch.messages.map((m) =>
+      m.id === msgId ? { ...m, deleted: true, text: '' } : m
+    );
     channels.set(channel.toLowerCase(), { ...ch });
     return { channels };
   }),


### PR DESCRIPTION
## Summary
- Deleted messages now show an italic "Message from {nick} deleted" placeholder instead of being silently removed from the list
- Added optimistic local delete in `sendDelete` since the server doesn't echo delete TAGMSGs back to the sender
- Deleted messages break message grouping (same as system messages)

## Test plan
- [x] Delete own message → placeholder appears immediately
- [x] Other user deletes message → placeholder appears via TAGMSG
- [x] Deleted messages don't group with adjacent messages
- [x] Reconnect after delete → message excluded from CHATHISTORY (expected)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>