### PR TITLE
Add architecture map and comprehensive Windows native app documentation

### DIFF
--- a/docs/step2-architecture-map.md
+++ b/docs/step2-architecture-map.md
@@ -1,0 +1,180 @@
+# Architecture Map: SDK + iOS + TUI
+
+## 1) Shared SDK (`freeq-sdk`)
+
+### Purpose
+`freeq-sdk` is the protocol/client core used by multiple clients. It exposes IRC connectivity, AT Protocol auth flows, event streaming, and higher-level helpers (media tags, bot framework, E2EE primitives). The crate is explicitly structured as reusable modules under `src/lib.rs`. 
+
+### Core layers
+
+1. **Connection + transport (`client.rs`)**
+   - `ConnectConfig` defines server/nick/TLS/web-token inputs.
+   - Establishes **TCP** or **TLS** via `establish_connection`.
+   - Optional **iroh QUIC** transport path behind feature flag (`iroh-transport`).
+   - Main lifecycle: `connect` / `connect_with_stream` spawns async runtime task that:
+     - negotiates `CAP LS`
+     - does registration (`NICK`/`USER`)
+     - performs SASL (web-token or challenge signer)
+     - runs read/write loop
+     - emits typed `Event` values.
+
+2. **Application command surface (`ClientHandle`)**
+   - Channel joins, messaging, raw IRC command passthrough.
+   - IRCv3-tag helpers: replies, edit/delete, typing indicators, reactions, CHATHISTORY requests, pin/topic/mode helpers.
+
+3. **Auth subsystem (`auth.rs`, `oauth.rs`, `pds.rs`)**
+   - `ChallengeSigner` trait abstracts signing backend.
+   - Implementations include key-based signer (`KeySigner`) and PDS/OAuth-backed signers.
+   - OAuth module handles DPoP key/proof flow and session caching.
+   - PDS module provides session creation/verification for app-password and related flows.
+
+4. **Event contract (`event.rs`)**
+   - SDK emits a single `Event` enum consumed by UIs/bots.
+   - Includes connection/auth lifecycle, chat messages, tag messages, membership/mode/topic updates, batch/history events, raw lines, disconnect notices.
+
+5. **Extra capability modules**
+   - `bot.rs`: command router framework (permissions, rate limiting, helpers).
+   - `media.rs`: rich media/message tag encoding helpers.
+   - `ratchet.rs`, `x3dh.rs`, `e2ee.rs`, `e2ee_did.rs`: E2EE building blocks.
+   - `p2p.rs`: optional p2p features.
+
+### Dataflow (SDK)
+1. Caller supplies `ConnectConfig` + optional signer.
+2. SDK opens transport, negotiates capabilities/auth.
+3. Caller sends outbound `Command`s through `ClientHandle`.
+4. SDK parses inbound IRC lines into high-level `Event`s over channel receiver.
+
+---
+
+## 2) TUI Client (`freeq-tui`)
+
+### High-level architecture
+
+`freeq-tui` is a Rust terminal app that composes:
+
+- **Core protocol/auth/media logic** from `freeq-sdk`
+- **UI state machine** in `app.rs`
+- **Rendering** in `ui.rs` (ratatui)
+- **Input editing layer** in `editor.rs`
+- **Config/session persistence** in `config.rs`
+
+### Runtime flow
+
+1. **Startup / identity resolution (`main.rs`)**
+   - Parse CLI flags (server, nick, auth options, iroh, channels, vi mode).
+   - Merge CLI + persisted config + last session.
+   - Build signer via one of:
+     - OAuth cached/interactive flow
+     - app-password PDS session
+     - crypto key auth
+     - guest mode.
+
+2. **Transport selection (`main.rs`)**
+   - If `--iroh-addr` given, use iroh.
+   - Else probe server capabilities for iroh and auto-upgrade when available.
+   - Else use TCP/TLS connect path.
+
+3. **Client bind (`main.rs`)**
+   - Calls SDK `connect_with_stream` to get `(ClientHandle, EventReceiver)`.
+   - Auto-joins saved/resolved channels.
+
+4. **Event loop (`run_app`)**
+   - Multiplexes terminal key events + SDK events + background task results.
+   - Updates `App` state in memory (buffers, users, unread counts, transport status, reconnect info).
+   - Renders each frame via `ui::draw`.
+
+5. **Reconnect + persistence**
+   - Tracks reconnect backoff state in `App`/`ReconnectInfo`.
+   - Persists channel/session info on exit.
+
+### TUI state model (`app.rs`)
+
+- Central `App` struct holds:
+  - buffer map (`status`, channels, DMs)
+  - current editor state/history
+  - connection + transport metadata
+  - auth DID, media uploader, optional p2p handles
+  - image cache / async background result channels
+- Buffers are append-only deques with capped retention (`MAX_MESSAGES`).
+- Batch history (CHATHISTORY BATCH) is staged and merged in-order.
+
+### TUI boundaries
+
+- **northbound**: user keyboard commands / slash commands / editor
+- **southbound**: SDK `ClientHandle` commands
+- **inbound domain events**: SDK `Event` stream
+- **render boundary**: pure-ish draw pass from `App` state to terminal frame.
+
+---
+
+## 3) iOS Client (`freeq-ios`)
+
+### High-level architecture
+
+The iOS app is a SwiftUI shell around the Rust SDK through a UniFFI-generated bridge.
+
+- **SwiftUI composition root**: `freeqApp.swift` + `ContentView.swift`
+- **Global app store/state**: `Models/AppState.swift`
+- **UI feature surfaces**: `Views/*`
+- **Rust bridge artifact**: `FreeqSDK.xcframework` + generated Swift bindings (`Generated/freeq.swift`)
+- **Rust FFI implementation**: `freeq-sdk-ffi`
+
+### Rust↔Swift bridge design
+
+1. `freeq-sdk-ffi` wraps SDK types and exposes:
+   - `FreeqClient` class for connect/join/send/raw operations.
+   - `EventHandler` callback trait and FFI-safe event/value structs.
+   - Event conversion from SDK `Event` -> FFI `FreeqEvent`.
+2. UniFFI generates Swift bindings.
+3. iOS app links `FreeqSDK.xcframework` and calls these generated APIs.
+
+### iOS runtime flow
+
+1. **App launch (`freeqApp.swift`)**
+   - Instantiates `AppState` + `NetworkMonitor` as environment objects.
+   - Handles OAuth callback URL (`freeq://auth?...`) and stores broker/session tokens.
+
+2. **Root routing (`ContentView.swift`)**
+   - Chooses between connect screen, reconnecting screen, and chat tabs based on `connectionState` and saved-session state.
+
+3. **Session + connection orchestration (`AppState`)**
+   - Loads persistent values from `UserDefaults` + secrets from Keychain.
+   - Maintains `FreeqClient` instance.
+   - Supports broker-token session refresh (`/session`) to get fresh SASL web-token.
+   - Connects/disconnects, joins/parts, sends IRC raw/tagged commands.
+   - Tracks channels/DMs, unread counts, read markers, typing state, MOTD, reconnect backoff.
+
+4. **Event ingestion (`SwiftEventHandler`)**
+   - Implements FFI `EventHandler` and hops all events to main thread.
+   - Reduces each `FreeqEvent` into `AppState` mutations (messages, names, topic, modes, reaction/delete/edit tags, disconnect handling).
+
+### iOS state model
+
+- `AppState` is effectively a **single store** (`ObservableObject`) for connection + chat state.
+- `ChannelState` objects carry per-channel messages/members/topic/typing info.
+- UI components subscribe to `@Published` properties and render declaratively.
+
+---
+
+## 4) Cross-project relationship map
+
+- `freeq-sdk` is the protocol/runtime core.
+- `freeq-tui` links it directly (native Rust consumer).
+- `freeq-ios` consumes it indirectly through `freeq-sdk-ffi` + UniFFI-generated Swift layer.
+
+### Shared event-driven pattern
+
+Both clients follow the same model:
+
+1. Connect and obtain command handle + event stream.
+2. Send outbound commands through the handle.
+3. Reduce inbound events into client-local state.
+4. Render state (terminal widgets or SwiftUI views).
+
+### Key architectural difference
+
+- **TUI**: in-process Rust all the way down.
+- **iOS**: SwiftUI state/store on top, Rust core over FFI boundary.
+
+This means iOS has extra bridge concerns (thread hops, FFI-safe type mapping, artifact generation), while TUI can use SDK types directly.
+

--- a/docs/windows-cli-setup-and-run.md
+++ b/docs/windows-cli-setup-and-run.md
@@ -1,0 +1,363 @@
+# Freeq Windows App — Command-Line Setup, Build, and Launch Guide
+
+This guide is for the next developer to bootstrap the native Windows app workflow from the CLI:
+
+1. Set up tooling on Windows.
+2. Build the Rust bridge/core (`freeq-windows-core`).
+3. Build and run the WinUI app (`freeq-windows-app`).
+4. Troubleshoot common issues.
+
+> This repo currently contains architecture/design docs for the Windows app. If `freeq-windows-core/` and `freeq-windows-app/` are not yet present, follow the **Scaffold** section first.
+
+---
+
+## 1) Prerequisites (Windows)
+
+Open **PowerShell 7** as your normal user (not admin unless required by your org policy).
+
+## 1.1 Required software
+
+Install these tools first:
+
+- **Git**
+- **Rust toolchain** (stable)
+- **Visual Studio 2022 Build Tools** or full VS 2022 with:
+  - MSVC C++ toolchain
+  - Windows 10/11 SDK
+- **.NET SDK 8+**
+- **Windows App SDK / WinUI 3 workload** (via Visual Studio installer)
+- **Cargo tools**:
+  - `cargo-nextest` (optional, faster tests)
+  - `cargo-watch` (optional)
+
+Recommended install commands (if `winget` is available):
+
+```powershell
+winget install --id Git.Git -e
+winget install --id Rustlang.Rustup -e
+winget install --id Microsoft.DotNet.SDK.8 -e
+winget install --id Microsoft.VisualStudio.2022.BuildTools -e
+```
+
+After installing Rust:
+
+```powershell
+rustup default stable
+rustup toolchain install stable-x86_64-pc-windows-msvc
+rustup target add x86_64-pc-windows-msvc
+```
+
+Verify environment:
+
+```powershell
+git --version
+rustc -V
+cargo -V
+dotnet --info
+```
+
+---
+
+## 2) Clone and prepare repository
+
+```powershell
+git clone https://github.com/<your-org>/freeq.git
+cd freeq
+```
+
+Optional: use a dedicated branch for Windows work.
+
+```powershell
+git checkout -b feat/windows-bootstrap
+```
+
+---
+
+## 3) Current repo baseline checks
+
+Before touching Windows-specific projects, verify the workspace is healthy:
+
+```powershell
+cargo check
+cargo test
+```
+
+If tests are too slow locally:
+
+```powershell
+cargo test -p freeq-sdk
+cargo test -p freeq-tui
+```
+
+---
+
+## 4) Scaffold missing Windows projects (if needed)
+
+If these folders already exist, skip to section 5.
+
+- `freeq-windows-core/`
+- `freeq-windows-app/`
+
+## 4.1 Create Rust bridge crate
+
+From repo root:
+
+```powershell
+cargo new freeq-windows-core --lib
+```
+
+Add it to workspace `Cargo.toml` members list.
+
+In `freeq-windows-core/Cargo.toml`, set:
+
+```toml
+[lib]
+crate-type = ["cdylib", "rlib"]
+```
+
+Add dependencies (minimum):
+
+```toml
+[dependencies]
+freeq-sdk = { path = "../freeq-sdk" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+rusqlite = { workspace = true }
+parking_lot = "0.12"
+dashmap = "6"
+```
+
+## 4.2 Create WinUI app solution
+
+Use Visual Studio templates from CLI (`dotnet new` availability depends on installed templates):
+
+```powershell
+mkdir freeq-windows-app
+cd freeq-windows-app
+
+# List templates to confirm WinUI template name on your machine
+dotnet new list | Select-String -Pattern "winui|windows"
+```
+
+If WinUI template exists (example):
+
+```powershell
+dotnet new winui3 -n Freeq.Windows.App
+```
+
+If templates are missing, create via Visual Studio once, then return to CLI for all builds/runs.
+
+Return to repo root:
+
+```powershell
+cd ..
+```
+
+---
+
+## 5) Build Rust Windows core from CLI
+
+From repo root:
+
+```powershell
+cargo build -p freeq-windows-core --release --target x86_64-pc-windows-msvc
+```
+
+Expected artifact:
+
+- `target/x86_64-pc-windows-msvc/release/freeq_windows_core.dll`
+
+(plus `.lib` import library and `.pdb` in debug builds)
+
+For debug iteration:
+
+```powershell
+cargo build -p freeq-windows-core --target x86_64-pc-windows-msvc
+```
+
+---
+
+## 6) Wire Rust DLL into WinUI app output
+
+Your WinUI app must find `freeq_windows_core.dll` at runtime.
+
+## 6.1 Quick manual copy (works immediately)
+
+Example debug output path:
+
+```powershell
+$rustDll = "target/x86_64-pc-windows-msvc/debug/freeq_windows_core.dll"
+$appOut  = "freeq-windows-app/Freeq.Windows.App/bin/x64/Debug/net8.0-windows10.0.19041.0"
+Copy-Item $rustDll $appOut -Force
+```
+
+## 6.2 Preferred: automate in app `.csproj`
+
+Add a post-build target to copy from repo `target` into app output directory.
+
+High-level idea:
+
+- `AfterTargets="Build"`
+- `Copy SourceFiles="...freeq_windows_core.dll" DestinationFolder="$(OutDir)"`
+
+Use separate paths for Debug/Release.
+
+---
+
+## 7) Build WinUI app from CLI
+
+From repo root (or app folder):
+
+```powershell
+dotnet build .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+```
+
+Release build:
+
+```powershell
+dotnet build .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Release -p:Platform=x64
+```
+
+---
+
+## 8) Launch app from CLI
+
+Run directly with `dotnet run`:
+
+```powershell
+dotnet run --project .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+```
+
+Or run built executable manually:
+
+```powershell
+.\freeq-windows-app\Freeq.Windows.App\bin\x64\Debug\net8.0-windows10.0.19041.0\Freeq.Windows.App.exe
+```
+
+---
+
+## 9) Suggested developer loop
+
+For day-to-day iteration:
+
+1. Terminal A (Rust core checks):
+
+```powershell
+cargo check -p freeq-windows-core
+```
+
+2. Terminal B (Rust core build):
+
+```powershell
+cargo build -p freeq-windows-core --target x86_64-pc-windows-msvc
+```
+
+3. Terminal C (WinUI run):
+
+```powershell
+dotnet run --project .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+```
+
+When interop signatures change, rebuild both Rust and .NET sides.
+
+---
+
+## 10) Optional packaging (MSIX) from CLI
+
+Once app packaging project is configured:
+
+```powershell
+dotnet publish .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Release -p:Platform=x64
+```
+
+If using dedicated packaging project (`.wapproj`), build it with MSBuild:
+
+```powershell
+msbuild .\freeq-windows-app\Freeq.Windows.Package\Freeq.Windows.Package.wapproj /p:Configuration=Release /p:Platform=x64
+```
+
+---
+
+## 11) Troubleshooting
+
+## 11.1 `DllNotFoundException: freeq_windows_core.dll`
+
+- Confirm DLL copied into app output folder.
+- Confirm architecture matches (`x64` app + `x86_64` Rust build).
+- Confirm C runtime/toolchain installed.
+
+Check quickly:
+
+```powershell
+Get-ChildItem .\freeq-windows-app\Freeq.Windows.App\bin\x64\Debug\net8.0-windows10.0.19041.0\freeq_windows_core.dll
+```
+
+## 11.2 `The specified framework 'Microsoft.WindowsAppSDK' was not found`
+
+- Install/repair Windows App SDK + WinUI workload via Visual Studio Installer.
+- Reopen terminal after installation.
+
+## 11.3 Rust link errors (`link.exe` not found)
+
+Open “x64 Native Tools Command Prompt for VS 2022” or ensure VS Build Tools are correctly installed.
+
+## 11.4 Interop crashes on callback
+
+- Validate calling convention (`Cdecl` vs `StdCall`) matches Rust export.
+- Ensure callback delegate is pinned/not GC-collected.
+- Ensure UTF-8 marshaling and null checks.
+
+---
+
+## 12) Minimum CI commands (Windows runner)
+
+Use these in GitHub Actions/Azure Pipelines on `windows-latest`:
+
+```powershell
+cargo check -p freeq-windows-core --target x86_64-pc-windows-msvc
+cargo test -p freeq-windows-core --target x86_64-pc-windows-msvc
+
+dotnet build .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Release -p:Platform=x64
+```
+
+Add artifact upload for:
+
+- Rust DLL output
+- WinUI app binaries / MSIX
+
+---
+
+## 13) Quick command reference
+
+From repo root:
+
+```powershell
+# Rust
+cargo build -p freeq-windows-core --target x86_64-pc-windows-msvc
+cargo build -p freeq-windows-core --release --target x86_64-pc-windows-msvc
+
+# .NET / WinUI
+dotnet build .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+dotnet run --project .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+
+# Full fast sanity
+cargo check -p freeq-windows-core
+dotnet build .\freeq-windows-app\Freeq.Windows.App\Freeq.Windows.App.csproj -c Debug -p:Platform=x64
+```
+
+---
+
+## 14) Handoff checklist for next developer
+
+- [ ] All prerequisites installed and verified.
+- [ ] `freeq-windows-core` builds in Debug and Release.
+- [ ] WinUI app builds in Debug and Release.
+- [ ] Rust DLL is copied automatically to app output.
+- [ ] `dotnet run` launches app from CLI.
+- [ ] Basic connect/send flow works in local test environment.
+- [ ] Troubleshooting notes updated with any machine-specific gotchas.
+

--- a/docs/windows-native-app-code-design.md
+++ b/docs/windows-native-app-code-design.md
@@ -1,0 +1,579 @@
+# Freeq Native Windows App — Detailed Technical Code Design
+
+## 1) Scope and design intent
+
+This document translates the Windows technical plan into an implementation-ready code design:
+
+- concrete crate/project boundaries
+- key structs/classes/interfaces
+- FFI envelope formats and lifecycle rules
+- reducer and state-store mechanics
+- threading/concurrency model
+- persistence schema
+- UI ViewModel composition
+- observability and failure handling paths
+
+The design targets **WinUI 3 + Rust SDK** and reuses existing `freeq-sdk` command/event semantics.
+
+---
+
+## 2) Solution layout
+
+```text
+/workspace/freeq
+  /freeq-windows-core        # New Rust crate (cdylib + internal modules)
+  /freeq-windows-app         # New WinUI 3 solution (.sln)
+  /docs/windows-native-app-code-design.md
+```
+
+### 2.1 Rust crate targets
+
+`freeq-windows-core/Cargo.toml`:
+- `crate-type = ["cdylib", "rlib"]`
+- depends on `freeq-sdk`, `tokio`, `serde`, `serde_json`, `rusqlite`, `tracing`
+
+### 2.2 C# solution projects
+
+- `Freeq.Windows.App` (WinUI 3 front-end)
+- `Freeq.Windows.Interop` (P/Invoke and marshaling)
+- `Freeq.Windows.Domain` (DTOs + ViewModel contracts)
+
+---
+
+## 3) Rust core architecture (`freeq-windows-core`)
+
+## 3.1 Module map
+
+```text
+src/
+  lib.rs
+  bridge/
+    abi.rs               # extern "C" exports + handle map
+    envelope.rs          # JSON event envelope + command payloads
+    callback.rs          # callback registry and safe dispatch
+  runtime/
+    client_runtime.rs    # sdk connect/command/event tasks
+    reconnect.rs         # reconnect policy state machine
+  state/
+    app_state.rs         # canonical in-memory state
+    reducer.rs           # event -> mutation logic
+    projections.rs       # snapshots/diffs for UI
+  persistence/
+    db.rs                # sqlite open/migrate/transactions
+    message_store.rs     # message inserts/queries
+    session_store.rs     # settings/session persistence
+  services/
+    typing.rs            # typing indicator timers/debouncing
+    batching.rs          # event coalescing to UI frame window
+  errors.rs
+```
+
+## 3.2 Root app container
+
+```rust
+pub struct AppCore {
+    pub id: u64,
+    pub runtime: tokio::runtime::Runtime,
+    pub state: parking_lot::RwLock<AppState>,
+    pub sdk_handle: parking_lot::Mutex<Option<freeq_sdk::client::ClientHandle>>,
+    pub callback: CallbackSink,
+    pub db: Db,
+    pub reconnect: parking_lot::Mutex<ReconnectController>,
+}
+```
+
+Responsibilities:
+- own process-level resources per client instance
+- coordinate SDK event ingestion and command dispatch
+- persist/update state and emit UI deltas
+
+## 3.3 Canonical state structures
+
+```rust
+pub struct AppState {
+    pub connection: ConnectionState,
+    pub identity: IdentityState,
+    pub conversations: indexmap::IndexMap<String, ConversationState>,
+    pub active_conversation: Option<String>,
+    pub unread: std::collections::HashMap<String, u32>,
+    pub read_markers: std::collections::HashMap<String, String>,
+    pub motd: Vec<String>,
+    pub ui_flags: UiFlags,
+}
+
+pub enum ConversationKind { Channel, Direct }
+
+pub struct ConversationState {
+    pub id: String,                     // #chan or nick
+    pub kind: ConversationKind,
+    pub title: String,
+    pub topic: Option<String>,
+    pub members: Vec<MemberState>,
+    pub messages: std::collections::VecDeque<MessageState>,
+    pub typing_users: std::collections::HashMap<String, i64>,
+    pub last_activity_ms: i64,
+}
+
+pub struct MessageState {
+    pub msgid: String,
+    pub from: String,
+    pub text: String,
+    pub ts_ms: i64,
+    pub reply_to: Option<String>,
+    pub edited: bool,
+    pub deleted: bool,
+    pub reactions: std::collections::HashMap<String, std::collections::BTreeSet<String>>,
+}
+```
+
+Rules:
+- keep canonical state in Rust (single source of truth)
+- UI consumes snapshots + incremental diffs
+- message retention bounded per conversation (configurable cap)
+
+## 3.4 Reducer design
+
+`reduce(state: &mut AppState, event: DomainEvent) -> Vec<StateDiff>`
+
+Reducer characteristics:
+- deterministic, pure-ish mutation logic
+- no blocking I/O inside reducer
+- returns minimal typed diffs used by UI
+
+`StateDiff` examples:
+- `ConnectionChanged { old, new }`
+- `ConversationUpserted { id }`
+- `MessageInserted { conv_id, msgid, index }`
+- `MessageUpdated { conv_id, msgid, fields }`
+- `UnreadChanged { conv_id, unread }`
+
+## 3.5 Domain event adapter
+
+`freeq-sdk::event::Event` maps to internal `DomainEvent`:
+
+```rust
+pub enum DomainEvent {
+    Connected,
+    Registered { nick: String },
+    Authenticated { did: String },
+    Message(IncomingMessage),
+    Tag(TagEvent),
+    Joined { channel: String, nick: String },
+    Parted { channel: String, nick: String },
+    Names { channel: String, members: Vec<MemberState> },
+    Topic { channel: String, topic: String },
+    Mode { channel: String, mode: String, arg: Option<String> },
+    Disconnected { reason: String },
+}
+```
+
+Adapter responsibilities:
+- normalize tags (`+draft/edit`, `+draft/delete`, `+react`, `+typing`)
+- normalize DM target naming for self/peer direction
+- stamp missing timestamps with monotonic fallback
+
+---
+
+## 4) FFI/API contract
+
+## 4.1 Handle lifecycle
+
+- `freeq_win_create_client(config_json)` allocates `AppCore`, returns handle (`u64`).
+- Handle table is global `DashMap<u64, Arc<AppCore>>`.
+- `freeq_win_destroy_client(handle)` unregisters callback, disconnects, drops runtime tasks.
+
+## 4.2 Exported C ABI
+
+```rust
+#[no_mangle]
+pub extern "C" fn freeq_win_create_client(config_json: *const c_char) -> u64;
+#[no_mangle]
+pub extern "C" fn freeq_win_destroy_client(handle: u64);
+#[no_mangle]
+pub extern "C" fn freeq_win_connect(handle: u64) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_disconnect(handle: u64) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_join(handle: u64, channel: *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_send_message(handle: u64, target: *const c_char, text: *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_send_raw(handle: u64, line: *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_request_history(handle: u64, mode_json: *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn freeq_win_get_snapshot_json(handle: u64) -> *mut c_char;
+#[no_mangle]
+pub extern "C" fn freeq_win_free_string(ptr: *mut c_char);
+#[no_mangle]
+pub extern "C" fn freeq_win_subscribe_events(handle: u64, cb: EventCallback, user_data: *mut c_void) -> i32;
+```
+
+Error codes (`i32`):
+- `0` success
+- `1` invalid handle
+- `2` invalid argument
+- `3` not connected
+- `4` internal error
+
+## 4.3 Event envelope
+
+All callbacks send UTF-8 JSON:
+
+```json
+{
+  "version": 1,
+  "seq": 1024,
+  "timestamp_ms": 1730000000000,
+  "type": "state_diffs",
+  "payload": {
+    "diffs": [
+      {"kind": "message_inserted", "conv_id": "#general", "msgid": "abc", "index": 442}
+    ]
+  }
+}
+```
+
+Envelope types:
+- `state_diffs`
+- `error`
+- `log` (debug builds only)
+- `stats` (optional)
+
+## 4.4 Callback contract
+
+```c
+typedef void (*EventCallback)(const char* json, void* user_data);
+```
+
+Constraints:
+- callback may be invoked from non-UI thread
+- payload memory owned by Rust for duration of call only
+- callback must return quickly; UI side should enqueue and return
+
+---
+
+## 5) Concurrency and task model
+
+## 5.1 Rust task topology
+
+Per `AppCore` instance:
+1. SDK connection task (`connect_with_stream` + event rx loop)
+2. Command executor task (bounded mpsc from ABI calls)
+3. Diff batching task (collect diffs for 16ms window)
+4. Persistence task (async write queue)
+5. Reconnect supervisor task
+
+## 5.2 Queue sizing and backpressure
+
+- command queue: 512
+- raw event queue: 4096
+- diff queue: 2048
+- persistence queue: 2048
+
+Policy:
+- prefer coalescing over dropping for `typing`/`unread` churn
+- allow drop of `log`/debug stats under pressure
+- never drop connect/disconnect/auth/message events silently (emit pressure warning)
+
+## 5.3 UI thread safety
+
+- C# interop receives callback on worker thread
+- pushes envelope onto `Channel<EventEnvelope>`
+- `DispatcherQueue.TryEnqueue` applies diffs on main thread
+
+---
+
+## 6) Persistence design
+
+## 6.1 SQLite schema (initial)
+
+```sql
+CREATE TABLE IF NOT EXISTS conversations (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  title TEXT NOT NULL,
+  topic TEXT,
+  last_activity_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  msgid TEXT PRIMARY KEY,
+  conv_id TEXT NOT NULL,
+  from_nick TEXT NOT NULL,
+  text TEXT NOT NULL,
+  ts_ms INTEGER NOT NULL,
+  reply_to TEXT,
+  edited INTEGER NOT NULL DEFAULT 0,
+  deleted INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conv_ts ON messages(conv_id, ts_ms);
+
+CREATE TABLE IF NOT EXISTS reactions (
+  msgid TEXT NOT NULL,
+  emoji TEXT NOT NULL,
+  nick TEXT NOT NULL,
+  PRIMARY KEY (msgid, emoji, nick)
+);
+
+CREATE TABLE IF NOT EXISTS app_kv (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+```
+
+`app_kv` keys:
+- `server_addr`
+- `nick`
+- `auto_join_json`
+- `read_markers_json`
+- `theme`
+
+## 6.2 Write model
+
+- append new messages in batched transaction every 100ms or 100 events
+- upsert conversation metadata on activity
+- reaction/edit/delete mutate existing rows
+
+## 6.3 Snapshot load model
+
+Startup sequence:
+1. load session config from `app_kv`
+2. load recent conversations sorted by activity
+3. load last N messages per conversation (config default 300)
+4. build initial `AppState`
+
+---
+
+## 7) Security design
+
+## 7.1 Secret boundaries
+
+Rust core never persists broker token in plaintext DB.
+
+Windows app stores secrets via platform API:
+- Credential Locker (preferred) or DPAPI-protected secure file
+
+Rust receives token only when needed:
+- `freeq_win_set_web_token(handle, token)`
+
+## 7.2 Logging hygiene
+
+- redact tokens and DIDs where configured
+- production log level defaults to `warn`
+- debug logs opt-in in settings
+
+---
+
+## 8) WinUI 3 application code design
+
+## 8.1 Composition root
+
+`App.xaml.cs`:
+- configure DI container
+- initialize interop service
+- open main `ShellWindow`
+- register toast and deep-link handlers
+
+## 8.2 ViewModel tree
+
+```text
+ShellViewModel
+  ├─ ConnectionViewModel
+  ├─ ConversationListViewModel
+  ├─ ActiveConversationViewModel
+  │    ├─ MessageListViewModel
+  │    ├─ ComposerViewModel
+  │    └─ MemberListViewModel
+  └─ SettingsViewModel
+```
+
+Interfaces:
+
+```csharp
+public interface ICoreBridge {
+    ulong CreateClient(ClientConfig config);
+    void Connect(ulong handle);
+    void Disconnect(ulong handle);
+    void SendMessage(ulong handle, string target, string text);
+    void Join(ulong handle, string channel);
+    void SendRaw(ulong handle, string line);
+    AppSnapshot GetSnapshot(ulong handle);
+    IAsyncEnumerable<EventEnvelope> Subscribe(ulong handle, CancellationToken ct);
+}
+```
+
+## 8.3 Diff applier
+
+`StateDiffApplier` service:
+- accepts envelope diffs
+- updates in-memory observable stores
+- minimizes `ObservableCollection` churn
+- preserves scroll anchor for active timeline
+
+## 8.4 Virtualized timeline
+
+Implementation details:
+- `ItemsRepeater` with `RecyclePool`
+- message row template selector:
+  - normal
+  - compact same-sender continuation
+  - system event
+  - deleted placeholder
+- incremental load trigger when near top => request `CHATHISTORY BEFORE`
+
+## 8.5 Input and command routing
+
+`ComposerViewModel` commands:
+- `SendMessageCommand`
+- `SendTypingCommand` (debounced)
+- `EditMessageCommand`
+- `DeleteMessageCommand`
+- `ReactCommand`
+
+Slash command parser in UI layer for local commands:
+- `/join`, `/part`, `/nick`, `/topic`, `/raw` (debug-gated)
+
+---
+
+## 9) Error handling and reconnect flow
+
+## 9.1 Error taxonomy
+
+- `RecoverableNetwork`
+- `AuthExpired`
+- `AuthRejected`
+- `ProtocolViolation`
+- `Internal`
+
+## 9.2 Reconnect state machine
+
+```text
+Disconnected
+  -> Connecting
+  -> Registered
+  -> (network loss) BackoffWaiting
+  -> Connecting
+```
+
+Backoff schedule:
+- base 1s, multiplier 2, max 30s, jitter ±20%
+
+Rules:
+- clear backoff after stable connection window (>= 60s)
+- on auth rejection, force token refresh before reconnect attempt
+
+## 9.3 User-facing status
+
+- inline status banner in shell
+- transient toast for recoverable disconnect
+- blocking auth dialog when credentials invalid
+
+---
+
+## 10) Telemetry and diagnostics
+
+## 10.1 Core metrics
+
+- `startup_ms`
+- `connect_ms`
+- `event_queue_depth`
+- `diff_batch_size`
+- `event_to_ui_ms`
+- `sqlite_flush_ms`
+- `dropped_events_total{type}`
+
+## 10.2 Diagnostics channels
+
+- rotating local log files
+- optional JSON performance trace dump
+- in-app diagnostics pane (dev mode)
+
+---
+
+## 11) Test design
+
+## 11.1 Rust tests
+
+- reducer property tests:
+  - edits must target existing or become no-op append policy
+  - delete sets tombstone state
+- queue-pressure tests for batching/coalescing
+- reconnect policy unit tests with deterministic clock
+- DB migration tests from schema v1->vN
+
+## 11.2 Interop tests (C#)
+
+- P/Invoke smoke:
+  - create/destroy handle
+  - connect/disconnect cycle
+  - callback subscription and envelope parse
+- string memory tests for `get_snapshot_json/free_string`
+
+## 11.3 UI tests
+
+- conversation switch preserves draft text
+- typing indicator appears/disappears within timeout
+- history prepend keeps viewport stable
+- theme switch applies without restart
+
+---
+
+## 12) Incremental implementation plan (code-first)
+
+## Milestone A: Core bridge loop
+- create crate + ABI exports
+- connect + inbound message callback
+- C# shell renders plain list of messages
+
+## Milestone B: Canonical state + diffs
+- reducer and `StateDiff` model
+- snapshot load + incremental diff application
+- unread counts and active conversation
+
+## Milestone C: Persistence and reconnect
+- sqlite writes/reads
+- reconnect supervisor
+- session restore on relaunch
+
+## Milestone D: Rich IRC features
+- reply/edit/delete/reaction
+- member/topic/mode views
+- typing indicators
+
+## Milestone E: polish/perf hardening
+- virtualization tuning
+- queue telemetry + perf budgets
+- accessibility + keyboard navigation pass
+
+---
+
+## 13) Open design decisions
+
+1. **Interop payload format**
+   - default JSON for flexibility
+   - optional binary codec (MessagePack) only if profiling proves needed
+
+2. **Single vs multi-window**
+   - v1 single window for complexity control
+   - design state store to support multi-window projection later
+
+3. **Media pipeline timing**
+   - defer uploads/previews until core text workflows are stable
+
+4. **E2EE integration path**
+   - keep adapter seam in `services/crypto_adapter.rs`
+   - enable only with clear UX and key management policy
+
+---
+
+## 14) Definition of done (v1)
+
+- Authenticated and guest connect flows stable
+- Channel/DM chat with history, reactions, edit/delete, typing
+- Session persistence + reconnect behavior validated
+- 60fps scroll maintained on large history datasets
+- Crash-free and memory budget targets met
+- Installer (MSIX) and update channel working
+

--- a/docs/windows-native-app-technical-plan.md
+++ b/docs/windows-native-app-technical-plan.md
@@ -1,0 +1,390 @@
+# Freeq Native Windows App — Detailed Technical Plan
+
+## 0) Executive summary
+
+Build a **modern, stylish, high-performance native Windows desktop app** for Freeq by reusing the existing Rust client SDK (`freeq-sdk`) as the protocol/auth core, with a Windows-native UI shell and platform integrations.
+
+**Recommended stack:**
+- **Core engine:** Rust (`freeq-sdk`) + optional thin app-core crate (`freeq-windows-core`)
+- **UI shell:** **WinUI 3 (Windows App SDK)** for native Fluent visuals and best Windows integration
+- **Bridge:** C ABI / FFI boundary from Rust core to C#/WinRT host
+
+This plan optimizes for:
+1. Native look/feel (Fluent, acrylic/mica, system integrations)
+2. Smooth performance on message-heavy channels
+3. Reliable auth/session handling via AT Protocol web-token flow
+4. Fast iteration with strict layering to preserve SDK reuse
+
+---
+
+## 1) Product goals, non-goals, and success metrics
+
+## 1.1 Goals
+- Native Windows desktop chat app with polished Fluent design.
+- Full parity for core chat workflows:
+  - connect/auth/guest
+  - channel + DM messaging
+  - history, reactions, edit/delete, typing
+  - member/topic display
+- Excellent runtime performance:
+  - low-latency input/send
+  - smooth scrolling with large histories
+  - predictable memory behavior
+- Stable reconnect behavior and robust session persistence.
+
+## 1.2 Non-goals (v1)
+- No Linux/macOS target from this codebase (Windows-first).
+- No full plugin ecosystem in v1.
+- No custom rendering engine; rely on native UI virtualization.
+
+## 1.3 Success metrics
+- Cold start to interactive UI: **< 1.5s** on mid-tier hardware.
+- Time-to-first-message after connect: **< 400ms** average (excluding network).
+- 60fps scrolling in 10k-message channels with virtualization enabled.
+- Crash-free sessions: **> 99.5%**.
+
+---
+
+## 2) Architectural overview
+
+## 2.1 High-level layers
+
+1. **Protocol & transport layer (Rust SDK)**
+   - Existing `freeq-sdk` handles connection, CAP/SASL, event stream, commands.
+
+2. **Windows app core (new Rust crate: `freeq-windows-core`)**
+   - Stateful reducer around SDK events
+   - Domain stores for channels/DMs/unread/read pointers
+   - Command API exposed over FFI
+   - Background services (reconnect policy, cache writes, media pipeline)
+
+3. **Interop layer**
+   - C ABI exports from Rust (`cdylib`)
+   - C# interop wrappers (`DllImport`, safe marshaling)
+   - Event callback channel with batched payloads
+
+4. **UI shell (WinUI 3)**
+   - MVVM pattern (Views + ViewModels)
+   - Virtualized message list
+   - Fluent theming, animations, adaptive layout
+
+5. **Platform services**
+   - Windows Credential Locker / DPAPI for secrets
+   - Toast notifications, jump list/deep links, tray integration
+
+## 2.2 Why WinUI 3 for this app
+- Best native Windows fidelity (Fluent controls/materials).
+- Solid virtualization primitives for large message timelines.
+- Strong integration with notifications, title bar, app lifecycle.
+
+---
+
+## 3) Repository and crate/project structure
+
+## 3.1 New additions
+- `freeq-windows-core/` (Rust)
+- `freeq-windows-app/` (C# WinUI 3 solution)
+- `docs/windows-native-app-technical-plan.md` (this plan)
+
+## 3.2 `freeq-windows-core` modules
+- `bridge/`
+  - FFI-safe types, ABI exports, callback registry
+- `state/`
+  - app state model + reducers
+- `services/`
+  - reconnect, persistence, notifications adapter hooks
+- `store/`
+  - sqlite/json caches
+- `commands/`
+  - connect/send/join/part/history/reaction/edit/delete
+- `metrics/`
+  - perf counters + optional telemetry emitters
+
+## 3.3 `freeq-windows-app` (WinUI) structure
+- `App.xaml.cs` (startup/lifecycle)
+- `Shell/` (navigation, title bar, command bar)
+- `Features/`
+  - `Auth/`
+  - `Chats/`
+  - `Settings/`
+  - `Discover/` (optional phase 2)
+- `Infrastructure/`
+  - FFI wrappers, dispatcher bridge, DI config
+- `Design/`
+  - shared styles, theme resources, tokens
+
+---
+
+## 4) Data model and event flow
+
+## 4.1 Core state entities
+- `ConnectionState` (disconnected/connecting/connected/registered)
+- `IdentityState` (nick, DID, auth mode)
+- `ConversationState`
+  - channel or DM metadata
+  - message list model
+  - members, topic, typing map
+  - unread + last-read markers
+- `SessionState`
+  - server endpoint
+  - auto-join list
+  - persisted UI settings
+
+## 4.2 Event pipeline
+1. Rust SDK emits `Event` stream.
+2. `freeq-windows-core` converts to internal domain events.
+3. Reducer updates canonical state.
+4. App-core emits **batched UI diffs** to WinUI bridge (avoid 1 event = 1 UI mutation).
+5. ViewModels apply diffs on UI thread.
+
+## 4.3 Outbound command pipeline
+1. User action -> ViewModel command.
+2. Command forwarded to app-core API.
+3. app-core invokes SDK `ClientHandle`/raw command helpers.
+4. Optimistic UI updates only where safe (input clear, pending send marker).
+
+---
+
+## 5) FFI and interop contract
+
+## 5.1 ABI strategy
+- Use stable C ABI exports from Rust.
+- Pass JSON payloads for complex structures to reduce marshaling complexity.
+- Keep primitive hot paths (connect/send/join) as direct typed calls.
+
+## 5.2 Core exported API surface (v1)
+- `freeq_win_create_client(config_json) -> handle`
+- `freeq_win_connect(handle)`
+- `freeq_win_disconnect(handle)`
+- `freeq_win_send_message(handle, target, text)`
+- `freeq_win_send_raw(handle, line)`
+- `freeq_win_join(handle, channel)` / `part`
+- `freeq_win_request_history(handle, target, mode_json)`
+- `freeq_win_set_web_token(handle, token)`
+- `freeq_win_subscribe_events(handle, callback, user_data)`
+- `freeq_win_get_snapshot(handle) -> json`
+
+## 5.3 Threading model
+- Rust runtime owns network/event tasks.
+- Callback invocations occur on background thread.
+- C# bridge posts updates onto DispatcherQueue for UI-safe mutation.
+
+## 5.4 Safety/reliability controls
+- Versioned event envelope schema (`version`, `type`, `payload`).
+- Backpressure: bounded event queue + coalescing.
+- Strict ownership/lifetime rules for handles and callback teardown.
+
+---
+
+## 6) UI/UX plan (modern + stylish)
+
+## 6.1 Design language
+- Fluent 2 styling.
+- Mica/Acrylic surfaces where appropriate.
+- Dynamic theme sync (light/dark/system accent).
+- Rounded cards, subtle depth, motion easing.
+
+## 6.2 Primary shell
+- Left rail: conversations + badges + quick filters.
+- Main pane: message timeline + typing/footer composer.
+- Optional right pane: members/topic/details.
+- Adaptive collapse for smaller windows.
+
+## 6.3 Message timeline
+- Virtualized list (ItemsRepeater/ListView with recycling).
+- Grouping by day and sender run.
+- Inline chips for reactions, edited/deleted status.
+- Reply context cards and jump-to-parent affordance.
+
+## 6.4 Composer
+- Markdown-lite formatting shortcuts.
+- Enter to send / Shift+Enter newline.
+- Upload/attach button placeholder for phase 2.
+- Typing indicator debounce (3s guard).
+
+## 6.5 Delight/polish
+- Non-blocking subtle animations for navigation and state changes.
+- Skeleton placeholders for history fetch.
+- Toast banners for transient errors with action buttons.
+
+---
+
+## 7) Performance strategy
+
+## 7.1 Rendering performance
+- Virtualize conversation list and message list from day 1.
+- Avoid full-collection resets; apply incremental diffs.
+- Keep ViewModels immutable-ish for predictable updates.
+
+## 7.2 Data performance
+- Append-only message storage with capped in-memory windows.
+- LRU for avatars/media thumbnails.
+- Background persistence batching (e.g., flush every N events or T ms).
+
+## 7.3 Network/runtime performance
+- Reuse SDK async pipeline; avoid blocking calls on UI thread.
+- Batch inbound events (e.g., 16ms frame-window) before UI dispatch.
+- Reconnect backoff: 1,2,4,8,16,30s cap with jitter.
+
+## 7.4 Instrumentation
+- Track:
+  - event-to-render latency
+  - dropped/coalesced events
+  - reconnect attempts
+  - list virtualization metrics
+- Debug perf overlay in dev builds.
+
+---
+
+## 8) Security and identity
+
+## 8.1 Auth modes
+- Primary: broker/web-token SASL flow (AT Protocol OAuth path).
+- Secondary: guest mode.
+
+## 8.2 Secret handling
+- Store broker token / sensitive material via Windows secure storage (Credential Locker or DPAPI-protected blob).
+- Never log raw tokens.
+- Zeroize sensitive buffers when feasible in Rust.
+
+## 8.3 Privacy defaults
+- Minimize persisted plaintext in logs.
+- User-controllable diagnostic logging toggle.
+
+---
+
+## 9) Persistence and offline behavior
+
+## 9.1 Persisted artifacts
+- Settings: theme, server, window/layout prefs, auto-join.
+- Session: nick/handle and secure auth credential references.
+- Cache: recent message windows, read pointers, avatar cache index.
+
+## 9.2 Storage choice
+- SQLite for message metadata/read pointers/unread counters.
+- File cache directory for media thumbnails.
+
+## 9.3 Offline strategy
+- On startup with no network, load last cached conversations.
+- Queue unsent drafts per conversation (optional v1.1).
+
+---
+
+## 10) Platform integrations (Windows-first)
+
+- Windows toast notifications for mentions/DMs.
+- Badge count on taskbar icon.
+- Deep link handler for `freeq://` auth callbacks.
+- System tray minimize-to-tray behavior (optional v1).
+- Global keyboard shortcuts for quick switcher (Ctrl+K).
+
+---
+
+## 11) Delivery roadmap
+
+## Phase 0 — Foundation (1–2 weeks)
+- Create `freeq-windows-core` skeleton and FFI scaffolding.
+- Build minimal WinUI shell + bridge health checks.
+- Connect/disconnect happy path.
+
+## Phase 1 — Core chat MVP (2–4 weeks)
+- Auth (broker token + guest), channel list, message timeline, send message.
+- Join/part, history latest/before, unread/read tracking.
+- Basic settings and persistence.
+
+## Phase 2 — Rich IRCv3 features (2–3 weeks)
+- Typing, reactions, edit/delete, replies.
+- Member list/topic/mode updates.
+- Improved reconnect + failure UX.
+
+## Phase 3 — Polish + performance (2 weeks)
+- Virtualization tuning and batching improvements.
+- UI polish, animations, accessibility pass.
+- Crash/telemetry dashboards and release hardening.
+
+## Phase 4 — Optional enhancements
+- Media upload/preview pipeline.
+- E2EE controls if server/client policy allows.
+- Discover/community surfaces.
+
+---
+
+## 12) QA and testing strategy
+
+## 12.1 Rust core tests
+- Reducer unit tests for event->state transitions.
+- Reconnect policy tests.
+- Serialization/versioning tests for event envelopes.
+
+## 12.2 Interop tests
+- ABI smoke tests in CI (`create/connect/send/disconnect`).
+- High-volume event flood test for callback stability.
+
+## 12.3 UI tests
+- Playwright/WinAppDriver-style smoke for:
+  - login flow
+  - open channel
+  - send message
+  - reconnect state transitions
+
+## 12.4 Manual test matrix
+- Windows 11 stable + Windows 10 compatibility where feasible.
+- High DPI, multi-monitor, resize stress.
+- Light/dark/accessibility contrast modes.
+
+---
+
+## 13) CI/CD and release plan
+
+- Build pipeline:
+  - Rust core checks (`fmt`, `clippy`, tests)
+  - WinUI app build + signing verification
+  - Integration smoke run
+- Packaging:
+  - MSIX for Store/sideload friendly distribution
+  - Optional winget manifest updates
+- Release channels:
+  - Canary -> Beta -> Stable ring progression
+
+---
+
+## 14) Risks and mitigations
+
+1. **FFI complexity / threading bugs**
+   - Mitigation: strict event envelope, dedicated dispatcher bridge, heavy stress tests.
+
+2. **UI perf regressions under heavy channels**
+   - Mitigation: virtualization-first design, diff batching, perf budgets in CI.
+
+3. **Auth flow edge cases on callback/deep linking**
+   - Mitigation: explicit callback state machine + retry UX + diagnostic telemetry.
+
+4. **SDK evolution drift vs app-core contract**
+   - Mitigation: versioned adapter layer and compatibility tests pinned to SDK events.
+
+---
+
+## 15) Immediate next steps (implementation-ready)
+
+1. Create `freeq-windows-core` crate with:
+   - client bootstrap
+   - event subscription callback
+   - connect/disconnect/send/join primitives
+2. Generate a WinUI 3 app shell with a basic chat window and status panel.
+3. Implement first interop loop:
+   - connect to server
+   - render incoming messages in virtualized list
+   - send message from composer
+4. Add telemetry hooks for startup/connect/render timings.
+5. Start Phase 1 feature branch with weekly milestone demos.
+
+---
+
+## 16) Notes on alignment with existing codebase
+
+- This plan intentionally reuses the existing architecture already validated in:
+  - `freeq-sdk` event-driven client model
+  - `freeq-tui` state reducer/event loop shape
+  - `freeq-ios` bridge + app-state pattern
+- The Windows app should adopt the same **command handle + event stream + state reducer** pattern to maximize shared understanding and reduce protocol bugs.
+


### PR DESCRIPTION
### Motivation

- Provide a single-source architecture reference that describes the shared `freeq-sdk`, the Rust TUI client, and the iOS UniFFI bridge to unify cross-platform design decisions. 
- Document the recommended approach and implementation details for a Windows-native client that reuses the existing Rust SDK, reducing ambiguity for future implementers. 
- Supply an actionable developer guide to bootstrap, build, and run the Windows app from the CLI to accelerate onboarding and CI setup.

### Description

- Add `docs/step2-architecture-map.md` which outlines the `freeq-sdk` layers, TUI runtime/state model, and the iOS UniFFI bridge with event/command flow. 
- Add `docs/windows-cli-setup-and-run.md` containing step-by-step CLI instructions, prerequisites, scaffold commands, build/run examples, troubleshooting, and minimal CI commands (including `cargo build`/`cargo test` and `dotnet build`). 
- Add `docs/windows-native-app-code-design.md` with a detailed Rust/C# code design, module maps, FFI/ABI contract (exported functions and JSON envelope), state/reducer model, SQLite schema, concurrency/queues, and test plans. 
- Add `docs/windows-native-app-technical-plan.md` with the high-level product goals, architecture overview, delivery roadmap, risk mitigations, and test/CI recommendations for the Windows client.

### Testing

- No automated tests were executed as part of this docs-only change. 
- The Windows CLI guide documents the basic CI commands to use on a Windows runner such as `cargo check -p freeq-windows-core --target x86_64-pc-windows-msvc`, `cargo test -p freeq-windows-core --target x86_64-pc-windows-msvc`, and `dotnet build` for the WinUI project. 
- The design doc includes planned automated test targets (reducer unit tests, ABI smoke tests, DB migration tests) to be implemented alongside the `freeq-windows-core` implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37773dc648330b6d4fa4684a2d15d)