### PR TITLE
feat: DM CHATHISTORY support

### DIFF
--- a/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
@@ -2695,6 +2695,12 @@ sealed class FreeqEvent {
         companion object
     }
     
+    data class ChatHistoryTarget(
+        val `nick`: kotlin.String, 
+        val `timestamp`: kotlin.String?) : FreeqEvent() {
+        companion object
+    }
+    
     data class Notice(
         val `text`: kotlin.String) : FreeqEvent() {
         companion object
@@ -2780,10 +2786,14 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
             17 -> FreeqEvent.BatchEnd(
                 FfiConverterString.read(buf),
                 )
-            18 -> FreeqEvent.Notice(
+            18 -> FreeqEvent.ChatHistoryTarget(
+                FfiConverterString.read(buf),
+                FfiConverterOptionalString.read(buf),
+                )
+            19 -> FreeqEvent.Notice(
                 FfiConverterString.read(buf),
                 )
-            19 -> FreeqEvent.Disconnected(
+            20 -> FreeqEvent.Disconnected(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -2924,6 +2934,14 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
                 + FfiConverterString.allocationSize(value.`id`)
             )
         }
+        is FreeqEvent.ChatHistoryTarget -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`nick`)
+                + FfiConverterOptionalString.allocationSize(value.`timestamp`)
+            )
+        }
         is FreeqEvent.Notice -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
@@ -3041,13 +3059,19 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
                 FfiConverterString.write(value.`id`, buf)
                 Unit
             }
-            is FreeqEvent.Notice -> {
+            is FreeqEvent.ChatHistoryTarget -> {
                 buf.putInt(18)
+                FfiConverterString.write(value.`nick`, buf)
+                FfiConverterOptionalString.write(value.`timestamp`, buf)
+                Unit
+            }
+            is FreeqEvent.Notice -> {
+                buf.putInt(19)
                 FfiConverterString.write(value.`text`, buf)
                 Unit
             }
             is FreeqEvent.Disconnected -> {
-                buf.putInt(19)
+                buf.putInt(20)
                 FfiConverterString.write(value.`reason`, buf)
                 Unit
             }

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -591,6 +591,10 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 state.connectionState.value = ConnectionState.Registered
                 state.nick.value = event.nick
                 state.autoJoinChannels.toList().forEach { state.joinChannel(it) }
+                // Fetch DM conversation list if authenticated
+                if (state.authenticatedDID.value != null) {
+                    state.sendRaw("CHATHISTORY TARGETS * * 50")
+                }
             }
 
             is FreeqEvent.Authenticated -> {
@@ -887,6 +891,11 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 else
                     state.getOrCreateDM(batch.target)
                 sorted.forEach { ch.appendIfNew(it) }
+            }
+
+            is FreeqEvent.ChatHistoryTarget -> {
+                // Create DM buffer for each conversation partner
+                state.getOrCreateDM(event.nick)
             }
         }
     }

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -1088,6 +1088,17 @@ export function MessageList() {
     const t2 = setTimeout(scrollBottom, 300);
     const t3 = setTimeout(scrollBottom, 600); // after CHATHISTORY arrives
     const t4 = setTimeout(scrollBottom, 1200); // slow networks
+
+    // DM buffers don't get NAMES/366 so history isn't auto-fetched.
+    // Request it on first activation if the buffer has no messages.
+    const isDM = activeChannel !== 'server' && !activeChannel.startsWith('#') && !activeChannel.startsWith('&');
+    if (isDM) {
+      const ch = useStore.getState().channels.get(activeChannel.toLowerCase());
+      if (!ch || ch.messages.length === 0) {
+        requestHistory(activeChannel);
+      }
+    }
+
     return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); clearTimeout(t4); };
   }, [activeChannel]);
 

--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -358,6 +358,10 @@ export function requestHistory(channel: string, before?: string) {
   }
 }
 
+export function requestDmTargets(limit = 50) {
+  raw(`CHATHISTORY TARGETS * * ${limit}`);
+}
+
 export function rawCommand(line: string) {
   raw(line);
 }
@@ -498,6 +502,10 @@ async function handleLine(rawLine: string) {
         if (ch.trim()) raw(`JOIN ${ch.trim()}`);
       }
       autoJoinChannels = [];
+      // Fetch DM conversation list if authenticated
+      if (saslDid) {
+        requestDmTargets();
+      }
       // Restore last active channel after joins complete
       const savedActive = localStorage.getItem('freeq-active-channel');
       if (savedActive && savedActive !== 'server') {
@@ -819,6 +827,18 @@ async function handleLine(rawLine: string) {
         store.startBatch(ref.slice(1), msg.params[1] || '', msg.params[2] || '');
       } else if (ref.startsWith('-')) {
         store.endBatch(ref.slice(1));
+      }
+      break;
+    }
+
+    // ── CHATHISTORY (TARGETS response) ──
+    case 'CHATHISTORY': {
+      const sub = msg.params[0];
+      if (sub === 'TARGETS' && msg.params[1]) {
+        const targetNick = msg.params[1];
+        const timeTag = msg.tags['time'];
+        const lastTs = timeTag ? new Date(timeTag) : null;
+        store.addDmTarget(targetNick, lastTs);
       }
       break;
     }

--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -836,9 +836,7 @@ async function handleLine(rawLine: string) {
       const sub = msg.params[0];
       if (sub === 'TARGETS' && msg.params[1]) {
         const targetNick = msg.params[1];
-        const timeTag = msg.tags['time'];
-        const lastTs = timeTag ? new Date(timeTag) : null;
-        store.addDmTarget(targetNick, lastTs);
+        store.addDmTarget(targetNick);
       }
       break;
     }

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -169,6 +169,9 @@ export interface Store {
   incrementMentions: (channel: string) => void;
   clearUnread: (channel: string) => void;
 
+  // Actions — DM targets
+  addDmTarget: (nick: string, lastTs: Date | null) => void;
+
   // Actions — batches
   startBatch: (id: string, type: string, target: string) => void;
   addBatchMessage: (id: string, msg: Message) => void;
@@ -316,6 +319,17 @@ export const useStore = create<Store>((set, get) => ({
     const ch = getOrCreateChannel(channels, name);
     ch.isJoined = true;
     channels.set(name.toLowerCase(), ch);
+    return { channels };
+  }),
+
+  addDmTarget: (nick, _lastTs) => set((s) => {
+    const channels = new Map(s.channels);
+    const key = nick.toLowerCase();
+    if (!channels.has(key)) {
+      const ch = getOrCreateChannel(channels, nick);
+      ch.isJoined = true;
+      channels.set(key, ch);
+    }
     return { channels };
   }),
 

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -170,7 +170,7 @@ export interface Store {
   clearUnread: (channel: string) => void;
 
   // Actions — DM targets
-  addDmTarget: (nick: string, lastTs: Date | null) => void;
+  addDmTarget: (nick: string) => void;
 
   // Actions — batches
   startBatch: (id: string, type: string, target: string) => void;
@@ -322,7 +322,7 @@ export const useStore = create<Store>((set, get) => ({
     return { channels };
   }),
 
-  addDmTarget: (nick, _lastTs) => set((s) => {
+  addDmTarget: (nick) => set((s) => {
     const channels = new Map(s.channels);
     const key = nick.toLowerCase();
     if (!channels.has(key)) {

--- a/freeq-sdk-ffi/src/freeq.udl
+++ b/freeq-sdk-ffi/src/freeq.udl
@@ -56,6 +56,7 @@ interface FreeqEvent {
     UserQuit(string nick, string reason);
     BatchStart(string id, string batch_type, string target);
     BatchEnd(string id);
+    ChatHistoryTarget(string nick, string? timestamp);
     Notice(string text);
     Disconnected(string reason);
 };

--- a/freeq-sdk-ffi/src/lib.rs
+++ b/freeq-sdk-ffi/src/lib.rs
@@ -117,6 +117,10 @@ pub enum FreeqEvent {
     BatchEnd {
         id: String,
     },
+    ChatHistoryTarget {
+        nick: String,
+        timestamp: Option<String>,
+    },
     Notice {
         text: String,
     },
@@ -493,6 +497,10 @@ fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
             target: target.clone(),
         },
         Event::BatchEnd { id } => FreeqEvent::BatchEnd { id: id.clone() },
+        Event::ChatHistoryTarget { nick, timestamp } => FreeqEvent::ChatHistoryTarget {
+            nick: nick.clone(),
+            timestamp: timestamp.clone(),
+        },
         Event::Disconnected { reason } => FreeqEvent::Disconnected {
             reason: reason.clone(),
         },

--- a/freeq-sdk/src/client.rs
+++ b/freeq-sdk/src/client.rs
@@ -254,8 +254,7 @@ impl ClientHandle {
 
     /// Request DM conversation list (CHATHISTORY TARGETS).
     pub async fn chathistory_targets(&self, limit: usize) -> Result<()> {
-        self.raw(&format!("CHATHISTORY TARGETS * * {limit}"))
-            .await
+        self.raw(&format!("CHATHISTORY TARGETS * * {limit}")).await
     }
 
     /// Send a reaction emoji to a specific message.
@@ -1123,13 +1122,16 @@ where
                         }
                         "CHATHISTORY" => {
                             // CHATHISTORY TARGETS <nick> — DM conversation list
+                            #[allow(clippy::collapsible_if)]
                             if msg.params.first().map(|s| s.as_str()) == Some("TARGETS") {
                                 if let Some(nick) = msg.params.get(1) {
                                     let timestamp = msg.tags.get("time").cloned();
-                                    let _ = event_tx.send(Event::ChatHistoryTarget {
-                                        nick: nick.clone(),
-                                        timestamp,
-                                    }).await;
+                                    let _ = event_tx
+                                        .send(Event::ChatHistoryTarget {
+                                            nick: nick.clone(),
+                                            timestamp,
+                                        })
+                                        .await;
                                 }
                             }
                         }

--- a/freeq-sdk/src/client.rs
+++ b/freeq-sdk/src/client.rs
@@ -252,6 +252,12 @@ impl ClientHandle {
             .await
     }
 
+    /// Request DM conversation list (CHATHISTORY TARGETS).
+    pub async fn chathistory_targets(&self, limit: usize) -> Result<()> {
+        self.raw(&format!("CHATHISTORY TARGETS * * {limit}"))
+            .await
+    }
+
     /// Send a reaction emoji to a specific message.
     pub async fn react(&self, target: &str, emoji: &str, msgid: &str) -> Result<()> {
         let mut tags = std::collections::HashMap::new();
@@ -1113,6 +1119,18 @@ where
                                     .to_string();
                                 let target = msg.params[0].clone();
                                 let _ = event_tx.send(Event::TagMsg { from, target, tags: msg.tags.clone() }).await;
+                            }
+                        }
+                        "CHATHISTORY" => {
+                            // CHATHISTORY TARGETS <nick> — DM conversation list
+                            if msg.params.first().map(|s| s.as_str()) == Some("TARGETS") {
+                                if let Some(nick) = msg.params.get(1) {
+                                    let timestamp = msg.tags.get("time").cloned();
+                                    let _ = event_tx.send(Event::ChatHistoryTarget {
+                                        nick: nick.clone(),
+                                        timestamp,
+                                    }).await;
+                                }
                             }
                         }
                         "FAIL" => {

--- a/freeq-sdk/src/event.rs
+++ b/freeq-sdk/src/event.rs
@@ -59,6 +59,14 @@ pub enum Event {
         id: String,
     },
 
+    /// A DM conversation target from CHATHISTORY TARGETS.
+    /// `nick` is the display nick of the conversation partner.
+    /// `timestamp` is the ISO 8601 time of the last message (from server-time tag).
+    ChatHistoryTarget {
+        nick: String,
+        timestamp: Option<String>,
+    },
+
     /// NAMES list for a channel (one 353 reply; may arrive in multiple parts).
     Names {
         channel: String,

--- a/freeq-server/tests/dm_history.rs
+++ b/freeq-server/tests/dm_history.rs
@@ -1,0 +1,238 @@
+//! DM history tests: canonical key, persistence, dm_conversations.
+//!
+//! Tests cover:
+//! - Canonical DM key computation (alphabetical sorting, determinism)
+//! - DM message storage and retrieval via existing messages table
+//! - Isolation between DM conversations and channels
+//! - dm_conversations() listing, ordering, limits, filtering
+//! - BEFORE/AFTER/LATEST/BETWEEN subcommands with DM keys
+//! - Tags, msgid, and encryption-at-rest with DM messages
+
+use std::collections::HashMap;
+
+use freeq_server::db::{canonical_dm_key, Db};
+
+fn make_db() -> Db {
+    Db::open_memory().unwrap()
+}
+
+#[test]
+fn canonical_key_alphabetical_order() {
+    let k1 = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    let k2 = canonical_dm_key("did:plc:bob", "did:plc:alice");
+    assert_eq!(k1, k2, "Key should be the same regardless of argument order");
+    assert_eq!(k1, "dm:did:plc:alice,did:plc:bob");
+}
+
+#[test]
+fn canonical_key_same_did() {
+    let k = canonical_dm_key("did:plc:alice", "did:plc:alice");
+    assert_eq!(k, "dm:did:plc:alice,did:plc:alice");
+}
+
+#[test]
+fn canonical_key_deterministic() {
+    let k1 = canonical_dm_key("did:plc:xyz", "did:plc:abc");
+    let k2 = canonical_dm_key("did:plc:xyz", "did:plc:abc");
+    assert_eq!(k1, k2);
+}
+
+#[test]
+fn dm_messages_stored_and_retrieved() {
+    let db = make_db();
+    let key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+
+    db.insert_message(&key, "alice!user@host", "hello bob", 1000, &HashMap::new(), Some("msg1"))
+        .unwrap();
+    db.insert_message(&key, "bob!user@host", "hi alice", 1001, &HashMap::new(), Some("msg2"))
+        .unwrap();
+
+    let msgs = db.get_messages(&key, 10, None).unwrap();
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(msgs[0].text, "hello bob");
+    assert_eq!(msgs[1].text, "hi alice");
+}
+
+#[test]
+fn dm_messages_isolated_from_channels() {
+    let db = make_db();
+    let dm_key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+
+    db.insert_message(&dm_key, "alice!user@host", "dm message", 1000, &HashMap::new(), Some("msg1"))
+        .unwrap();
+    db.insert_message("#general", "alice!user@host", "channel message", 1001, &HashMap::new(), Some("msg2"))
+        .unwrap();
+
+    let dm_msgs = db.get_messages(&dm_key, 10, None).unwrap();
+    let ch_msgs = db.get_messages("#general", 10, None).unwrap();
+    assert_eq!(dm_msgs.len(), 1);
+    assert_eq!(ch_msgs.len(), 1);
+    assert_eq!(dm_msgs[0].text, "dm message");
+    assert_eq!(ch_msgs[0].text, "channel message");
+}
+
+#[test]
+fn dm_messages_isolated_between_conversations() {
+    let db = make_db();
+    let key_ab = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    let key_ac = canonical_dm_key("did:plc:alice", "did:plc:charlie");
+
+    db.insert_message(&key_ab, "alice", "to bob", 1000, &HashMap::new(), Some("msg1"))
+        .unwrap();
+    db.insert_message(&key_ac, "alice", "to charlie", 1001, &HashMap::new(), Some("msg2"))
+        .unwrap();
+
+    let ab = db.get_messages(&key_ab, 10, None).unwrap();
+    let ac = db.get_messages(&key_ac, 10, None).unwrap();
+    assert_eq!(ab.len(), 1);
+    assert_eq!(ac.len(), 1);
+    assert_eq!(ab[0].text, "to bob");
+    assert_eq!(ac[0].text, "to charlie");
+}
+
+#[test]
+fn dm_conversations_lists_for_did() {
+    let db = make_db();
+    let key_ab = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    let key_ac = canonical_dm_key("did:plc:alice", "did:plc:charlie");
+    let key_bc = canonical_dm_key("did:plc:bob", "did:plc:charlie");
+
+    db.insert_message(&key_ab, "alice", "hi bob", 1000, &HashMap::new(), None).unwrap();
+    db.insert_message(&key_ac, "alice", "hi charlie", 2000, &HashMap::new(), None).unwrap();
+    db.insert_message(&key_bc, "bob", "hi charlie", 3000, &HashMap::new(), None).unwrap();
+
+    // Alice should see 2 conversations (ab, ac) but not bc
+    let alice_convos = db.dm_conversations("did:plc:alice", 50).unwrap();
+    assert_eq!(alice_convos.len(), 2);
+    // Ordered by most recent
+    assert_eq!(alice_convos[0].0, key_ac); // ts 2000
+    assert_eq!(alice_convos[1].0, key_ab); // ts 1000
+
+    // Bob should see 2 conversations (ab, bc)
+    let bob_convos = db.dm_conversations("did:plc:bob", 50).unwrap();
+    assert_eq!(bob_convos.len(), 2);
+    assert_eq!(bob_convos[0].0, key_bc); // ts 3000
+    assert_eq!(bob_convos[1].0, key_ab); // ts 1000
+
+    // Charlie should see 2 conversations (ac, bc)
+    let charlie_convos = db.dm_conversations("did:plc:charlie", 50).unwrap();
+    assert_eq!(charlie_convos.len(), 2);
+}
+
+#[test]
+fn dm_conversations_respects_limit() {
+    let db = make_db();
+    for i in 0..5 {
+        let partner = format!("did:plc:partner{i}");
+        let key = canonical_dm_key("did:plc:alice", &partner);
+        db.insert_message(&key, "alice", &format!("msg {i}"), 1000 + i, &HashMap::new(), None)
+            .unwrap();
+    }
+
+    let convos = db.dm_conversations("did:plc:alice", 3).unwrap();
+    assert_eq!(convos.len(), 3);
+}
+
+#[test]
+fn dm_conversations_empty_for_unknown_did() {
+    let db = make_db();
+    let key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    db.insert_message(&key, "alice", "hello", 1000, &HashMap::new(), None).unwrap();
+
+    let convos = db.dm_conversations("did:plc:nobody", 50).unwrap();
+    assert!(convos.is_empty());
+}
+
+#[test]
+fn dm_conversations_excludes_channels() {
+    let db = make_db();
+    let dm_key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    db.insert_message(&dm_key, "alice", "dm msg", 1000, &HashMap::new(), None).unwrap();
+    db.insert_message("#general", "alice", "channel msg", 2000, &HashMap::new(), None).unwrap();
+
+    let convos = db.dm_conversations("did:plc:alice", 50).unwrap();
+    assert_eq!(convos.len(), 1);
+    assert!(convos[0].0.starts_with("dm:"));
+}
+
+#[test]
+fn dm_conversations_excludes_deleted() {
+    let db = make_db();
+    let key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    db.insert_message(&key, "alice", "msg1", 1000, &HashMap::new(), Some("del1")).unwrap();
+    db.insert_message(&key, "alice", "msg2", 2000, &HashMap::new(), Some("keep1")).unwrap();
+
+    // Delete one message
+    db.soft_delete_message(&key, "del1").unwrap();
+
+    // Conversation should still appear (one message remains)
+    let convos = db.dm_conversations("did:plc:alice", 50).unwrap();
+    assert_eq!(convos.len(), 1);
+    assert_eq!(convos[0].1, 2000); // latest non-deleted timestamp
+}
+
+#[test]
+fn dm_history_before_after_latest() {
+    let db = make_db();
+    let key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    for i in 0..10 {
+        db.insert_message(&key, "alice", &format!("msg-{i}"), 1000 + i, &HashMap::new(), None)
+            .unwrap();
+    }
+
+    // BEFORE ts=1005 limit=3 -> messages at 1002,1003,1004
+    let before = db.get_messages(&key, 3, Some(1005)).unwrap();
+    assert_eq!(before.len(), 3);
+    assert_eq!(before[0].text, "msg-2");
+    assert_eq!(before[2].text, "msg-4");
+
+    // AFTER ts=1005 limit=3 -> messages at 1006,1007,1008
+    let after = db.get_messages_after(&key, 1005, 3).unwrap();
+    assert_eq!(after.len(), 3);
+    assert_eq!(after[0].text, "msg-6");
+
+    // LATEST limit=3 -> last 3 messages
+    let latest = db.get_messages(&key, 3, None).unwrap();
+    assert_eq!(latest.len(), 3);
+    assert_eq!(latest[2].text, "msg-9");
+
+    // BETWEEN 1003..1007 limit=10 (exclusive bounds: 1004,1005,1006)
+    let between = db.get_messages_between(&key, 1003, 1007, 10).unwrap();
+    assert_eq!(between.len(), 3);
+    assert_eq!(between[0].text, "msg-4");
+    assert_eq!(between[2].text, "msg-6");
+}
+
+#[test]
+fn dm_with_tags_and_msgid() {
+    let db = make_db();
+    let key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+    let mut tags = HashMap::new();
+    tags.insert("msgid".to_string(), "dm001".to_string());
+    tags.insert("+freeq.at/sig".to_string(), "sig123".to_string());
+
+    db.insert_message(&key, "alice!user@host", "signed dm", 1000, &tags, Some("dm001"))
+        .unwrap();
+
+    let msgs = db.get_messages(&key, 10, None).unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].text, "signed dm");
+    assert_eq!(msgs[0].msgid.as_deref(), Some("dm001"));
+    assert_eq!(msgs[0].tags.get("+freeq.at/sig").unwrap(), "sig123");
+}
+
+#[test]
+fn dm_encrypted_roundtrip() {
+    let key: [u8; 32] = [0xAB; 32];
+    let db = Db::open_encrypted_memory(key).unwrap();
+    let dm_key = canonical_dm_key("did:plc:alice", "did:plc:bob");
+
+    db.insert_message(&dm_key, "alice", "secret dm", 1000, &HashMap::new(), None).unwrap();
+
+    let msgs = db.get_messages(&dm_key, 10, None).unwrap();
+    assert_eq!(msgs[0].text, "secret dm");
+
+    // Verify raw storage is encrypted
+    let raw = db.get_raw_message_text(&dm_key, 1000).unwrap();
+    assert!(raw.starts_with("EAR1:"));
+}

--- a/freeq-windows-core/src/event.rs
+++ b/freeq-windows-core/src/event.rs
@@ -265,6 +265,9 @@ pub fn convert_event(event: &freeq_sdk::event::Event) -> DomainEvent {
         Event::WhoisReply { nick, info } => DomainEvent::Notice {
             text: format!("WHOIS {nick}: {info}"),
         },
+        Event::ChatHistoryTarget { nick, timestamp } => DomainEvent::Notice {
+            text: format!("DM: {nick} (last: {})", timestamp.as_deref().unwrap_or("?")),
+        },
         Event::RawLine(line) => DomainEvent::Notice {
             text: line.clone(),
         },


### PR DESCRIPTION
# CHATHISTORY for DMs

## Problem

Channel CHATHISTORY is fully implemented — clients can request message history for any channel they're a member of. DMs have no equivalent. When a user reconnects or switches devices, all DM conversations are gone. Clients have no way to:

1. Retrieve past DM messages
2. Discover which DM conversations exist
3. Resume a DM conversation after reconnect

For freeq to be a viable replacement for Discord/Slack, persistent DM history is essential.

## IRCv3 Alignment

This proposal follows the [IRCv3 CHATHISTORY specification](https://ircv3.net/specs/extensions/chathistory), which already supports DM targets. Key points from the spec:

- When the target is a **nick** (not a channel), the server returns history of messages between the requesting user and that nick, including outgoing "self messages."
- The [`TARGETS` subcommand](https://github.com/ircv3/ircv3-specifications/pull/450) lists both channels and DM correspondents with available history, ordered by most recent message.
- The spec recommends: *"Servers SHOULD use secure identification mechanisms such as account names, internal account identifiers, or certificate fingerprints to match content to users"* rather than relying solely on nicknames.

### Related IRCv3 extensions

| Extension | Purpose | freeq status |
|-----------|---------|-------------|
| [`account-notify`](https://ircv3.net/specs/extensions/account-notify.html) | Broadcast account login/logout | Implemented |
| [`extended-join`](https://ircv3.net/specs/extensions/extended-join.html) | Include account in JOIN messages | Implemented |
| [`chathistory`](https://ircv3.net/specs/extensions/chathistory) | History retrieval (channels + DMs) | Channels only → **This PR** |

### Prior art: Ergo (Oragono)

[Ergo](https://github.com/ergochat/ergo) implements the closest model to what we want:

- **Always-on clients**: Users remain present on the server when disconnected, able to receive DMs (store-and-forward).
- **Account-gated persistence**: Only registered/authenticated users get DM history. Guest users can send/receive DMs in real-time but have no persistence.
- **Device IDs**: Per-device message replay — each device gets only the messages it missed.
- **Account-indexed history**: DM history is tied to the account, not the transient nick. Nick changes don't break conversation continuity.
- **CHATHISTORY TARGETS**: Clients discover missed DM conversations on reconnect.

We adopt the same model, substituting **DID** for Ergo's NickServ account.

## Design

### Core principle: DID-indexed, auth-gated

- DM history is indexed by **DID pair**, not nick pair. This survives nick changes and reconnects.
- Only **DID-authenticated users** (SASL `ATPROTO-CHALLENGE`) can retrieve DM history.
- **Guest users** can still send and receive DMs in real-time via standard `PRIVMSG <nick>` — no existing IRC behavior breaks. They just don't get history.
- **Both participants must be authenticated** for persistence. The canonical key requires two DIDs — if either side is a guest, no key can be computed and the conversation is ephemeral for both parties. Clients should indicate this to the user (e.g. "Messages with guest users are not saved").
- **Divergence from Ergo**: Ergo requires only *one* party to be registered (per-account mailbox model — the registered side gets history, the unregistered side doesn't). We require *both* because the canonical key model needs two DIDs. This is a stricter policy but simpler to implement and avoids unstable nick-based keys for the guest side.
- DM storage uses the same `messages` table, `insert_message()`, and encryption as channels — no special treatment.

### 1. Canonical DM key in `channel` column

Rather than adding new columns or separate queries for DMs, we store DM messages in the existing `messages` table using a **canonical DM key** in the `channel` column:

```
dm:<did_a>,<did_b>
```

where the two DIDs are **alphabetically sorted**. For example, a conversation between `did:plc:abc123` and `did:plc:xyz789`:

```
dm:did:plc:abc123,did:plc:xyz789
```

This key is deterministic — given any two DIDs, there is exactly one canonical key. Both participants' messages (sent and received) are stored under the same key.

**Why this works:**
- No namespace collision with channels (`#`/`&` prefix) or raw DIDs (`did:` prefix) — the `dm:` prefix is unambiguous.
- No schema migration — uses the existing `channel` column in the `messages` table.
- No new query code — the existing `insert_message()` and `get_messages()` work as-is. DMs are just another "channel" from the storage layer's perspective.
- No separate `dm_history()` method — the dead code at `db.rs:581` (scaffolded but never wired up) was deleted, not rewritten.

**Why a single table (for now):**

Ergo uses separate tables for channels (`sequence`) and DMs (`conversations`), with a mailbox-per-account model. We considered this but chose a single table for MVP:

- **Simplicity**: The `messages` table, `insert_message()`, and `get_messages()` already work. Adding a parallel storage path for DMs doubles the surface area for bugs with no functional benefit.
- **Existing patterns**: Channel CHATHISTORY is proven and battle-tested. DM CHATHISTORY reuses the exact same code path — the only difference is the target key.
- **Schema stability**: No migration needed. No nullable columns. No backfill.
- **Query performance**: The existing index on `(channel, timestamp)` covers DM lookups efficiently — each canonical key maps to exactly one conversation.

The tradeoff: `CHATHISTORY TARGETS` (listing a user's DM conversations) requires scanning the `messages` table for distinct `dm:` keys containing the user's DID. This is fine for moderate volumes. If it becomes a bottleneck, we add a `dm_correspondents` tracking table as an optimization — a denormalized index of `(did, partner_did, last_message_at)` maintained on insert. This is deferred to post-MVP.

### 2. Extend CHATHISTORY to accept nick/DID targets

`handle_chathistory()` previously rejected non-channel targets. That restriction is removed. If the target has no `#` prefix:

1. Resolve the target to a DID (nick→DID lookup via current session or historical mapping; if target is already a DID, use as-is)
2. Compute the canonical key: `dm:<sorted(requester_did, target_did)>`
3. Call the existing `get_messages()` with that key — same code path as channel history

```
CHATHISTORY LATEST alice 50
CHATHISTORY BEFORE alice timestamp=2026-02-28T00:00:00Z 100
CHATHISTORY AFTER alice msgid=01JXXXXXXXXX 50
CHATHISTORY BETWEEN alice timestamp=... timestamp=... 100
```

**Target resolution**: When the target is a nick, resolve to DID first (via current session lookup or historical mapping). When the target is a DID directly, use it as-is. This means `CHATHISTORY LATEST did:plc:abc123 50` also works.

**Authorization**: Server verifies the requesting user is DID-authenticated and is one of the two participants. Reject with `ERR_NOPRIVS` if not.

**Self messages**: Include outgoing messages (echo) in results, per the IRCv3 spec.

**Nick rewriting**: If a participant's nick changed since the stored message, rewrite the source/target to the current nick in the response (DID remains the stable identifier underneath).

### 3. CHATHISTORY TARGETS for DM discovery

Implements the `TARGETS` subcommand per the IRCv3 spec:

```
CHATHISTORY TARGETS timestamp=2026-02-01T00:00:00Z timestamp=2026-02-28T23:59:59Z 50
```

Returns both channels and DM correspondents with available history, ordered by most recent message timestamp. Response uses `draft/chathistory-targets` batch type.

## S2S Federation

DM history follows the **same pattern as channel history**: both sides store, each server answers its own users' queries. No cross-server history protocol is needed.

When Alice (server A) DMs Bob (server B):

1. **Server A** stores the message (sender's copy) — Alice's outgoing DM history
2. S2S relay delivers the message to server B
3. **Server B** stores the message (recipient's copy) — Bob's incoming DM history
4. Alice's `CHATHISTORY LATEST bob` → queries server A's DB (has both sent + received)
5. Bob's `CHATHISTORY LATEST alice` → queries server B's DB (has both sent + received)

## Backwards Compatibility

| Client type | DM send | DM receive | DM history | DM list |
|-------------|---------|------------|------------|---------|
| Standard IRC client (guest) | `PRIVMSG <nick>` | Yes | No | No |
| Standard IRC client (authenticated) | `PRIVMSG <nick>` | Yes | `CHATHISTORY` | `CHATHISTORY TARGETS` |
| freeq web/android (guest) | Yes | Yes | No | No |
| freeq web/android (authenticated) | Yes | Yes | Yes | Yes |

- No existing IRC behavior changes. `PRIVMSG <nick>` works exactly as before for all clients.
- `CHATHISTORY` and `TARGETS` are only available to clients that negotiate the `draft/chathistory` capability.
- Guest users experience no regression — they can still send/receive DMs in real-time.

### Deployment order

Server and clients can be deployed in any order — no coordination required:

- **New client → old server**: Client sends `CHATHISTORY TARGETS`, old server silently ignores it (standard IRC behavior for unknown commands). DM list is empty, no crash.
- **Old client → new server**: Server persists DM history but no client asks for it. Zero behavior change for existing clients.
- **FFI bindings**: Compile-time boundary only — always shipped in lockstep with the native lib inside the app binary. No runtime wire compatibility concern.

## Commits

1. `feat: server-side DM CHATHISTORY support` — DB persistence, handle_chathistory() for DM targets, CHATHISTORY TARGETS subcommand, auth gate, tests
2. `feat(sdk): add ChatHistoryTarget event and chathistory_targets() method` — SDK + Windows core
3. `feat(tui): add /msgs command for DM conversation listing`
4. `feat(web): DM conversation discovery via CHATHISTORY TARGETS`
5. `feat(web): auto-load DM history on buffer activation`
6. `feat(ffi): add ChatHistoryTarget event to UniFFI bridge`
7. `feat(android): DM conversation discovery via CHATHISTORY TARGETS`
8. `feat(ios): DM conversation discovery via CHATHISTORY TARGETS`

## Open Questions

- [ ] DM history retention policy? (Keep forever? TTL? User-configurable?)

## References

- IRCv3 CHATHISTORY spec: https://ircv3.net/specs/extensions/chathistory
- IRCv3 CHATHISTORY TARGETS PR: https://github.com/ircv3/ircv3-specifications/pull/450
- Ergo IRC server: https://github.com/ergochat/ergo

🤖 Co-Authored by: [Claude Code](https://claude.com/claude-code)