### PR TITLE
fix(server): pins API returns message content via live lookup

### DIFF
--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -703,12 +703,19 @@ async fn api_channel_pins(
             let pins: Vec<serde_json::Value> = ch
                 .pins
                 .iter()
-                .map(|p| {
-                    serde_json::json!({
+                .filter_map(|p| {
+                    // Look up current message content from history
+                    let msg = ch.history.iter().find(|m| m.msgid.as_deref() == Some(&p.msgid))?;
+                    Some(serde_json::json!({
                         "msgid": p.msgid,
+                        "from": msg.from,
+                        "text": msg.text,
+                        "timestamp": chrono::DateTime::from_timestamp(msg.timestamp as i64, 0)
+                            .map(|dt| dt.to_rfc3339())
+                            .unwrap_or_default(),
                         "pinned_by": p.pinned_by,
                         "pinned_at": p.pinned_at,
-                    })
+                    }))
                 })
                 .collect();
             Ok(Json(


### PR DESCRIPTION
## Summary
- Pins API now returns message content (`from`, `text`, `timestamp`) via live lookup from channel history
- Pins for deleted messages are silently filtered out (using `filter_map`)
- Fixes iOS pinned messages view which was already expecting these fields

## Test plan
- [ ] Create a pin via `/pin <msgid>` as an op
- [ ] GET `/api/v1/channels/{name}/pins` returns `from`, `text`, `timestamp`
- [ ] Delete a pinned message, verify it no longer appears in pins response