### PR TITLE
fix: allow removing reactions by toggling

### DIFF
--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -884,14 +884,13 @@ async function handleLine(rawLine: string) {
         break;
       }
       // Handle reactions — +reply tag references the target message
+      // Skip self-echoes: the optimistic update in sendReaction already toggled locally.
       const reaction = msg.tags['+react'];
-      if (reaction) {
+      if (reaction && !isSelf) {
         const reactTarget = msg.tags['+reply'];
         if (reactTarget) {
           store.addReaction(bufName, reactTarget, reaction, from);
         } else {
-          // No +reply — reaction to the channel generally.
-          // Attach to the most recent non-system message.
           const ch = store.channels.get(bufName.toLowerCase());
           if (ch) {
             const lastMsg = [...ch.messages].reverse().find((m) => !m.isSystem && !m.deleted);

--- a/freeq-app/src/store.test.ts
+++ b/freeq-app/src/store.test.ts
@@ -433,11 +433,11 @@ describe('reactions', () => {
     expect(m.reactions?.get('🎉')?.has('me')).toBe(true);
   });
 
-  it('duplicate self-reaction does not double-count', () => {
+  it('duplicate self-reaction toggles off', () => {
     useStore.getState().addReaction('#react', 'rmsg', '👍', 'me');
     useStore.getState().addReaction('#react', 'rmsg', '👍', 'me');
     const ch = useStore.getState().channels.get('#react')!;
     const m = ch.messages.find(m => m.id === 'rmsg')!;
-    expect(m.reactions?.get('👍')?.size).toBe(1);
+    expect(m.reactions?.has('👍')).toBe(false);
   });
 });

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -692,7 +692,7 @@ export const useStore = create<Store>((set, get) => ({
   }),
 
   addReaction: (channel, msgId, emoji, fromNick) => set((s) => {
-    if (!emoji || !emoji.trim()) return {}; // Reject empty emoji
+    if (!emoji || !emoji.trim()) return {};
     const channels = new Map(s.channels);
     const ch = channels.get(channel.toLowerCase());
     if (!ch) return { channels };
@@ -700,8 +700,14 @@ export const useStore = create<Store>((set, get) => ({
       if (m.id !== msgId) return m;
       const reactions = new Map(m.reactions || []);
       const nicks = new Set(reactions.get(emoji) || []);
-      nicks.add(fromNick);
-      reactions.set(emoji, nicks);
+      if (nicks.has(fromNick)) {
+        nicks.delete(fromNick);
+        if (nicks.size === 0) reactions.delete(emoji);
+        else reactions.set(emoji, nicks);
+      } else {
+        nicks.add(fromNick);
+        reactions.set(emoji, nicks);
+      }
       return { ...m, reactions };
     });
     channels.set(channel.toLowerCase(), { ...ch });

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -148,7 +148,10 @@ pub(super) fn handle_tagmsg(
             .as_secs();
         let emoji = emoji.clone();
         let target_msgid = target_msgid.clone();
-        state.with_db(|db| db.store_reaction(&target_msgid, &channel, &nick, did.as_deref(), &emoji, ts));
+        let was_new = state.with_db(|db| db.store_reaction(&target_msgid, &channel, &nick, did.as_deref(), &emoji, ts));
+        if was_new == Some(false) {
+            state.with_db(|db| db.remove_reaction(&target_msgid, &nick, &emoji));
+        }
     }
 
     let hostmask = conn.hostmask();

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -843,7 +843,8 @@ impl Db {
 
     // ── Reactions ──────────────────────────────────────────────────────
 
-    /// Store a reaction. Upsert — duplicate (msgid, nick, emoji) is ignored.
+    /// Store a reaction. Returns `true` if a new row was inserted, `false` if a
+    /// duplicate `(msgid, nick, emoji)` already existed (INSERT OR IGNORE).
     pub fn store_reaction(
         &self,
         target_msgid: &str,
@@ -852,13 +853,13 @@ impl Db {
         reactor_did: Option<&str>,
         emoji: &str,
         timestamp: u64,
-    ) -> SqlResult<()> {
-        self.conn.execute(
+    ) -> SqlResult<bool> {
+        let inserted = self.conn.execute(
             "INSERT OR IGNORE INTO reactions (target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp as i64],
         )?;
-        Ok(())
+        Ok(inserted > 0)
     }
 
     /// Remove a reaction.

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2346,7 +2346,10 @@ pub(crate) async fn process_s2s_message(
                 let emoji = emoji.clone();
                 let target_msgid = target_msgid.clone();
                 let channel = target.clone();
-                state.with_db(|db| db.store_reaction(&target_msgid, &channel, &nick, did.as_deref(), &emoji, ts));
+                let was_new = state.with_db(|db| db.store_reaction(&target_msgid, &channel, &nick, did.as_deref(), &emoji, ts));
+                if was_new == Some(false) {
+                    state.with_db(|db| db.remove_reaction(&target_msgid, &nick, &emoji));
+                }
             }
 
             // Deliver to local channel members


### PR DESCRIPTION
## Summary

- Reactions were add-only — clicking an existing reaction had no effect. Now sending the same `(msgid, nick, emoji)` reaction a second time removes it (toggle semantics).
- Server: `store_reaction` returns whether a row was inserted; on duplicate, `remove_reaction` deletes it instead. Applied to both local TAGMSG and S2S paths.
- Web app: `addReaction` in the store now toggles (removes nick if already present), and self-echoed TAGMSGs are skipped to prevent double-toggle.



## Test plan

- [x] Rust server compiles cleanly (`cargo check`)
- [x] All 130 lib unit tests pass (`cargo test --lib`)
- [x] Updated web store test to expect toggle-off behavior
- [ ] Manual: react to a message, click same reaction again — reaction disappears
- [ ] Manual: other users' reactions on the same message are unaffected
- [ ] Manual: reaction persists correctly across page reload (CHATHISTORY)

Made with [Cursor](https://cursor.com)