### PR TITLE
Fix persistent login: /session race + stored brokerOrigin + StrictMode duplicate

### DIFF
--- a/freeq-app/src/components/ConnectScreen.tsx
+++ b/freeq-app/src/components/ConnectScreen.tsx
@@ -138,7 +138,12 @@ export function ConnectScreen() {
   });
   const [brokerOrigin] = useState(() => {
     const stored = localStorage.getItem(LS_BROKER_BASE);
-    if (stored) return stored;
+    // Discard a stored value that equals the web origin: that means an earlier
+    // session ran in single-server mode (no external broker). The broker
+    // session refresh effect below short-circuits when brokerOrigin equals
+    // webOrigin, so trusting that stored value would defeat persistent login
+    // for users who once ran without a broker and later moved to one.
+    if (stored && stored !== webOrigin) return stored;
     if (isTauri) return 'https://auth.freeq.at';
     const host = window.location.host;
     if (host === 'irc.freeq.at') return 'https://auth.freeq.at';

--- a/freeq-app/src/components/ConnectScreen.tsx
+++ b/freeq-app/src/components/ConnectScreen.tsx
@@ -48,6 +48,12 @@ let brokerAutoAttempts = 0;
 const MAX_BROKER_AUTO_ATTEMPTS = 3;
 // Synchronous guard: prevents broker effect from racing with OAuth result effect
 let oauthConnectInProgress = false;
+// Synchronous in-flight flag for the /session refresh effect. React 18
+// StrictMode double-invokes effects in dev, which would otherwise fire two
+// parallel /session calls per refresh. The broker serializes them safely
+// but the duplicate still costs a PDS round-trip and produces a visible
+// "Establishing session" flash when the second response lands.
+let sessionRefreshInFlight = false;
 
 type OAuthResultData = {
   did?: string;
@@ -228,6 +234,7 @@ export function ConnectScreen() {
     // Synchronous check: if OAuth result effect already called connect(), skip
     if (oauthConnectInProgress) return;
     if (brokerAutoAttempts >= MAX_BROKER_AUTO_ATTEMPTS) return;
+    if (sessionRefreshInFlight) return;
     const brokerToken = localStorage.getItem(LS_BROKER_TOKEN);
     if (!brokerToken) return;
     // If brokerOrigin is the same as webOrigin, there's no external broker —
@@ -238,6 +245,7 @@ export function ConnectScreen() {
     }
 
     brokerAutoAttempts++;
+    sessionRefreshInFlight = true;
     setAutoConnecting(true);
     // Use saved joined channels if available (reflects actual PART/JOIN state),
     // otherwise fall back to the saved channels from connect screen input.
@@ -290,6 +298,9 @@ export function ConnectScreen() {
         } else if (e?.name === 'AbortError') {
           setError('Authentication service unavailable. Try again or connect as guest.');
         }
+      })
+      .finally(() => {
+        sessionRefreshInFlight = false;
       });
   }, [registered, oauthPending, autoConnecting, brokerOrigin, server]);
 

--- a/freeq-auth-broker/src/main.rs
+++ b/freeq-auth-broker/src/main.rs
@@ -33,6 +33,12 @@ struct BrokerState {
     config: BrokerConfig,
     pending: Mutex<std::collections::HashMap<String, PendingAuth>>,
     db: Mutex<rusqlite::Connection>,
+    // Per-broker-token serialization for /session: AT Protocol refresh tokens
+    // are single-use, so concurrent /session calls for the same token cause
+    // one PDS rotation to succeed and the rest to fail with "replayed",
+    // eventually invalidating the stored token. This map gives each token
+    // its own mutex; concurrent callers queue and observe the rotated token.
+    session_locks: Mutex<std::collections::HashMap<String, Arc<Mutex<()>>>>,
 }
 
 #[derive(Clone)]
@@ -375,6 +381,7 @@ async fn main() {
         },
         pending: Mutex::new(std::collections::HashMap::new()),
         db: Mutex::new(db),
+        session_locks: Mutex::new(std::collections::HashMap::new()),
     });
 
     let app = Router::new()
@@ -952,14 +959,38 @@ async fn session(
         }
     }
 
+    tracing::info!(token_prefix = %req.broker_token.chars().take(8).collect::<String>(), "Session refresh request");
+
+    // Serialize concurrent /session calls for the same broker_token (see
+    // `session_locks` doc on BrokerState).
+    let lock = {
+        let mut map = state.session_locks.lock().await;
+        // Opportunistic GC: drop entries whose only reference is the map
+        // itself (strong_count == 1 means no active holder, no waiter). This
+        // keeps `session_locks` proportional to *concurrent* /session callers,
+        // not the cumulative set of broker_tokens the broker has ever served.
+        map.retain(|_, v| Arc::strong_count(v) > 1);
+        map.entry(req.broker_token.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _guard = lock.lock().await;
+
     let record = get_session(&state, &req.broker_token)
         .await
-        .ok_or((StatusCode::UNAUTHORIZED, "Invalid broker token".to_string()))?;
+        .ok_or_else(|| {
+            tracing::warn!(token_prefix = %req.broker_token.chars().take(8).collect::<String>(), "Session refresh: broker token not in DB");
+            (StatusCode::UNAUTHORIZED, "Invalid broker token".to_string())
+        })?;
 
     let (access_token, refresh_token, dpop_nonce, granted_scope) =
         refresh_access_token(&state.config, &record)
             .await
-            .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Refresh failed: {e}")))?;
+            .map_err(|e| {
+                tracing::warn!(error = %e, did = %record.did, "Session refresh: PDS refresh_access_token failed");
+                (StatusCode::BAD_GATEWAY, format!("Refresh failed: {e}"))
+            })?;
+    tracing::info!(did = %record.did, "Session refresh: PDS refresh succeeded");
 
     // Update stored refresh token + nonce (C-5: encrypt before storing)
     let now = chrono::Utc::now().timestamp();


### PR DESCRIPTION
Three small fixes for AT Protocol persistent-login. Each commit is self-contained; happy to split if easier to review.

> Draft because this is my first contribution against this repo and I'd love a sanity check before marking ready.

---

### 1. `fix(broker): serialize concurrent /session calls per broker_token`

AT Protocol refresh tokens are single-use: the PDS rotates the `refresh_token` on each `/token` call and immediately invalidates the previous one. The broker stores the rotated value, so serial `/session` callers each read the latest token and rotate again.

Concurrent `/session` calls for the same `broker_token` break this:

- Both callers read the same `refresh_token` R from the DB.
- Caller A wins at the PDS: gets new token R', broker stores R'.
- Caller B sends R: PDS replies `invalid_grant "Refresh token replayed"`. Broker returns 502 to B without touching the DB.

The web client retries `/session` once on 502, and React 18 StrictMode's effect double-invocation means each refresh fires the `/session` effect twice in parallel — kicking the race off again. After a few rounds the stored `refresh_token` has been rotated to a value the PDS has since invalidated, and every subsequent `/session` returns 502 forever — the session is bricked until full re-OAuth.

**Fix:** a per-`broker_token` `Mutex` in `BrokerState`. Concurrent callers for the same token queue on the same Mutex, so the second one sees R' (already rotated) instead of racing on R. Different `broker_token`s are independent, so `/session` concurrency across users is preserved. Bounded with an opportunistic GC pass (entries with `Arc::strong_count == 1` get dropped on the next `/session` call), so `session_locks` stays proportional to *concurrent* refresh callers rather than the cumulative set of tokens served.

Also adds `tracing::info!`/`warn!` on the `/session` path so this kind of failure is visible without source diving.

**Repro before patch:** open the web client, log in via AT Protocol, refresh the page twice. Second refresh shows the login screen; broker log shows `Refresh token replayed` followed by permanent `Invalid refresh token` until you re-OAuth.

### 2. `fix(web): ignore stored brokerOrigin equal to webOrigin`

`ConnectScreen` initialises `brokerOrigin` from `localStorage` unconditionally. The broker session-refresh effect, however, treats a `brokerOrigin` equal to `webOrigin` as "no external broker — server handles auth directly" and short-circuits without calling `/session`, silently dropping persistent login.

This strands any user whose previous session ran in single-server mode: even after the deployment grows a real broker, the stored value wins the precedence check and refresh never works again, forcing manual `localStorage` cleanup. Treat `stored === webOrigin` as absent so the broker-derivation rules below get a chance to run.

### 3. `fix(web): in-flight guard against parallel /session calls`

Belt-and-suspenders with #1. Once the broker handles concurrent callers correctly, the SPA itself still fires two `/session` calls per refresh (React 18 StrictMode double-invokes the effect in dev). Both now succeed thanks to the broker mutex, but each invokes `setSaslCredentials` + `connect()`, causing a visible "Establishing session" flash mid-load when the second response lands.

A module-level `sessionRefreshInFlight` flag — same pattern as the existing `oauthConnectInProgress` next to it — short-circuits the duplicate before the fetch. Reset in `.finally()` so failures don't permanently block future refreshes. The broker mutex remains the source-of-truth defence; this is just the SPA being a well-behaved caller.

---

## Test plan

- [x] Reproduced the `/session` race with React StrictMode + two quick refreshes; observed `Refresh token replayed` → permanent 502s in broker log.
- [x] With all three patches applied, completed AT Protocol OAuth end-to-end on a fresh local clone and refreshed the page 20+ times — single PDS round-trip per refresh, no login-screen fallback, no mid-load flash.
- [ ] Existing tests still pass (couldn't run the full suite locally — would appreciate CI confirmation).
- [ ] Broker `/session` behaviour unchanged when calls are serial (per-token mutex is uncontended in that case).
