### PR TITLE
wumblr: MOTD + broker ALLOWED_ORIGINS for wumblr.com

### DIFF
--- a/freeq-auth-broker/src/main.rs
+++ b/freeq-auth-broker/src/main.rs
@@ -935,8 +935,12 @@ async fn auth_callback(
 
 const ALLOWED_ORIGINS: &[&str] = &[
     "https://irc.freeq.at",
+    "https://wumblr.com",
+    "https://api.wumblr.com",
+    "https://auth.wumblr.com",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
+    "http://127.0.0.1:8081",
 ];
 
 async fn session(

--- a/motd.txt
+++ b/motd.txt
@@ -1,10 +1,7 @@
-Welcome to freeq — IRC with AT Protocol identity.
+Welcome to wumblr — community-gated private groupchat on AT Protocol.
 
 Channels:
-  #freeq        Main channel — say hello!
-  #demo-follow  Bluesky follow-gated (must follow @freeq.at)
-  #demo-github  GitHub verification demo (auto-op with linked GitHub)
-  #demo-moderation  Moderator appointment demo
+  #wumblr-general  Main channel for the wumblr community — say hello!
 
 Sign in with your Bluesky handle to get a verified identity.
-Docs & source: https://github.com/chad/freeq
+Source: https://github.com/attpslabs/wumblr-freeq


### PR DESCRIPTION
- Replace freeq MOTD with wumblr welcome + #wumblr-general
- Extend broker ALLOWED_ORIGINS with wumblr.com, api.wumblr.com, auth.wumblr.com, and 127.0.0.1:8081 so wumblr web clients can call POST /session without being rejected by the CSRF origin check. Upstream entries kept for stock-freeq compatibility.