### PR TITLE
[codex] Add animated sidebar toggles

### DIFF
--- a/freeq-app/src/App.tsx
+++ b/freeq-app/src/App.tsx
@@ -28,6 +28,32 @@ import { BookmarksPanel } from './components/BookmarksPanel';
 import { MotdBanner } from './components/MotdBanner';
 import { CallPanel } from './components/CallPanel';
 
+const SIDEBAR_OPEN_KEY = 'freeq-sidebar-open';
+const MEMBERS_OPEN_KEY = 'freeq-members-open';
+
+function getStoredBoolean(key: string, fallback: boolean) {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const value = window.localStorage.getItem(key);
+    return value === null ? fallback : value === 'true';
+  } catch {
+    return fallback;
+  }
+}
+
+function setStoredBoolean(key: string, value: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down embeds.
+  }
+}
+
+function isDesktopViewport() {
+  return typeof window === 'undefined' || window.innerWidth >= 768;
+}
+
 export default function App() {
   const registered = useStore((s) => s.registered);
   const wasRegistered = useStore((s) => s.wasRegistered);
@@ -46,13 +72,25 @@ export default function App() {
   const [quickSwitcher, setQuickSwitcher] = useState(false);
   const [settings, setSettings] = useState(false);
   const [shortcuts, setShortcuts] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [membersOpen, setMembersOpen] = useState(() => window.innerWidth >= 768);
+  const [sidebarOpen, setSidebarOpen] = useState(() => getStoredBoolean(SIDEBAR_OPEN_KEY, true));
+  const [membersOpen, setMembersOpen] = useState(() => getStoredBoolean(MEMBERS_OPEN_KEY, isDesktopViewport()));
   const threadMsgId = useStore((s) => s.threadMsgId);
   const threadChannel = useStore((s) => s.threadChannel);
   const channels = useStore((s) => s.channels);
   const activeChannel = useStore((s) => s.activeChannel);
   const setActive = useStore((s) => s.setActiveChannel);
+  const hasRightSidebar = activeChannel !== 'server';
+  const isProfileSidebar = hasRightSidebar && !activeChannel.startsWith('#');
+  const rightSidebarWidth = isProfileSidebar ? 'w-64' : 'w-52';
+  const rightSidebarDesktopWidth = isProfileSidebar ? 'md:w-64' : 'md:w-52';
+
+  useEffect(() => {
+    setStoredBoolean(SIDEBAR_OPEN_KEY, sidebarOpen);
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    setStoredBoolean(MEMBERS_OPEN_KEY, membersOpen);
+  }, [membersOpen]);
 
   // Swipe gesture to open/close sidebar on mobile
   const touchStart = useRef<{ x: number; y: number } | null>(null);
@@ -206,38 +244,42 @@ export default function App() {
       <ReconnectBanner />
       <GuestUpgradeBanner />
       <div className="flex flex-1 min-h-0">
-        {/* Mobile sidebar overlay */}
-        {sidebarOpen && (
-          <div
-            className="fixed inset-0 bg-black/40 z-30 md:hidden"
-            onClick={() => setSidebarOpen(false)}
-          />
-        )}
-        <div className={`${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        } fixed inset-y-0 left-0 md:relative md:inset-auto md:h-full md:translate-x-0 z-30 transition-transform duration-200`}>
+        <div
+          className={`app-sidebar-backdrop fixed inset-0 bg-black/40 z-20 md:hidden ${
+            sidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+          onClick={() => setSidebarOpen(false)}
+        />
+        <div className={`app-sidebar-shell fixed inset-y-0 left-0 z-30 w-64 md:relative md:inset-auto md:h-full ${
+          sidebarOpen ? 'translate-x-0 md:w-64' : '-translate-x-full md:w-0 md:translate-x-0 pointer-events-none'
+        }`}>
           <Sidebar onOpenSettings={() => setSettings(true)} />
         </div>
 
         <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
           <MotdBanner />
           <TopBar
-            onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
-            onToggleMembers={() => setMembersOpen(!membersOpen)}
+            onToggleSidebar={() => setSidebarOpen((open) => !open)}
+            onToggleMembers={() => setMembersOpen((open) => !open)}
+            sidebarOpen={sidebarOpen}
             membersOpen={membersOpen}
           />
           <CallPanel />
           <MessageList />
           <ComposeBox />
         </main>
-        {/* Member list — inline on desktop, overlay on mobile */}
-        {membersOpen && (
+        {/* Member/profile list — inline on desktop, overlay on mobile */}
+        {hasRightSidebar && (
           <>
             <div
-              className="fixed inset-0 bg-black/40 z-30 md:hidden"
+              className={`app-sidebar-backdrop fixed inset-0 bg-black/40 z-20 md:hidden ${
+                membersOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+              }`}
               onClick={() => setMembersOpen(false)}
             />
-            <div className="fixed right-0 top-0 bottom-0 z-30 md:relative md:z-auto">
+            <div className={`app-sidebar-shell fixed right-0 top-0 bottom-0 z-30 ${rightSidebarWidth} md:relative md:inset-auto md:z-auto md:h-full ${
+              membersOpen ? `translate-x-0 ${rightSidebarDesktopWidth}` : 'translate-x-full md:w-0 md:translate-x-0 pointer-events-none'
+            }`}>
               <MemberList />
             </div>
           </>

--- a/freeq-app/src/components/TopBar.tsx
+++ b/freeq-app/src/components/TopBar.tsx
@@ -8,10 +8,11 @@ import { fetchProfile, type ATProfile } from '../lib/profiles';
 interface TopBarProps {
   onToggleSidebar?: () => void;
   onToggleMembers?: () => void;
+  sidebarOpen?: boolean;
   membersOpen?: boolean;
 }
 
-export function TopBar({ onToggleSidebar, onToggleMembers, membersOpen }: TopBarProps) {
+export function TopBar({ onToggleSidebar, onToggleMembers, sidebarOpen, membersOpen }: TopBarProps) {
   const activeChannel = useStore((s) => s.activeChannel);
   const channels = useStore((s) => s.channels);
   const connectionState = useStore((s) => s.connectionState);
@@ -29,14 +30,16 @@ export function TopBar({ onToggleSidebar, onToggleMembers, membersOpen }: TopBar
   // For DMs, resolve partner profile
   const partnerWhois = isDM ? whoisCache.get(activeChannel.toLowerCase()) : undefined;
   const partnerDid = isDM ? (ch?.members.values().next().value?.did || partnerWhois?.did) : undefined;
-  const [partnerProfile, setPartnerProfile] = useState<ATProfile | null>(null);
+  const [partnerProfileState, setPartnerProfileState] = useState<{ did: string; profile: ATProfile | null } | null>(null);
   useEffect(() => {
-    if (isDM && partnerDid) {
-      fetchProfile(partnerDid).then((p) => p && setPartnerProfile(p));
-    } else {
-      setPartnerProfile(null);
-    }
+    if (!isDM || !partnerDid) return;
+    let cancelled = false;
+    fetchProfile(partnerDid).then((profile) => {
+      if (!cancelled) setPartnerProfileState({ did: partnerDid, profile });
+    });
+    return () => { cancelled = true; };
   }, [isDM, partnerDid]);
+  const partnerProfile = partnerProfileState && partnerProfileState.did === partnerDid ? partnerProfileState.profile : null;
 
   const startEdit = () => {
     setTopicDraft(topic);
@@ -51,13 +54,20 @@ export function TopBar({ onToggleSidebar, onToggleMembers, membersOpen }: TopBar
   return (
     <>
     <header className="h-14 bg-bg-secondary border-b border-border flex items-center gap-3 px-4 shrink-0">
-      {/* Mobile menu button */}
+      {/* Sidebar toggle */}
       <button
         onClick={onToggleSidebar}
-        className="md:hidden text-fg-dim hover:text-fg-muted p-1 -ml-1 mr-1"
+        className={`text-fg-dim hover:text-fg-muted p-1.5 -ml-1 rounded-lg hover:bg-bg-tertiary shrink-0 transition-colors ${
+          sidebarOpen ? 'text-fg-muted' : 'text-fg-dim'
+        }`}
+        title={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+        aria-label={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+        aria-pressed={sidebarOpen}
       >
-        <svg className="w-5 h-5" viewBox="0 0 16 16" fill="currentColor">
-          <path fillRule="evenodd" d="M2.5 12a.5.5 0 01.5-.5h10a.5.5 0 010 1H3a.5.5 0 01-.5-.5zm0-4a.5.5 0 01.5-.5h10a.5.5 0 010 1H3a.5.5 0 01-.5-.5zm0-4a.5.5 0 01.5-.5h10a.5.5 0 010 1H3a.5.5 0 01-.5-.5z"/>
+        <svg className="w-5 h-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="4" width="14" height="12" rx="2" />
+          <path d="M8 4v12" />
+          <path d={sidebarOpen ? 'M12.5 8l-2 2 2 2' : 'M10.5 8l2 2-2 2'} />
         </svg>
       </button>
 
@@ -175,11 +185,13 @@ export function TopBar({ onToggleSidebar, onToggleMembers, membersOpen }: TopBar
             membersOpen ? 'text-fg-muted' : 'text-fg-dim'
           }`}
           title={membersOpen ? 'Hide members' : 'Show members'}
+          aria-label={membersOpen ? 'Hide members sidebar' : 'Show members sidebar'}
+          aria-pressed={membersOpen}
         >
           <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 8a3 3 0 100-6 3 3 0 000 6zM2 14s-1 0-1-1 1-4 7-4 7 3 7 4-1 1-1 1H2z"/>
           </svg>
-          {memberCount > 0 && <span>{memberCount}</span>}
+          {memberCount > 0 && <span className="hidden sm:inline tabular-nums">{memberCount}</span>}
         </button>
       )}
 
@@ -191,6 +203,8 @@ export function TopBar({ onToggleSidebar, onToggleMembers, membersOpen }: TopBar
             membersOpen ? 'text-fg-muted' : 'text-fg-dim'
           }`}
           title={membersOpen ? 'Hide profile' : 'Show profile'}
+          aria-label={membersOpen ? 'Hide profile sidebar' : 'Show profile sidebar'}
+          aria-pressed={membersOpen}
         >
           <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 8a3 3 0 100-6 3 3 0 000 6zM2 14s-1 0-1-1 1-4 7-4 7 3 7 4-1 1-1 1H2z"/>

--- a/freeq-app/src/index.css
+++ b/freeq-app/src/index.css
@@ -91,6 +91,23 @@ body {
 /* Remove transition from scroll */
 [class*="overflow"] { transition: none; }
 
+.app-sidebar-shell {
+  overflow: hidden;
+  transition: width 200ms ease, transform 200ms ease;
+  will-change: width, transform;
+}
+
+.app-sidebar-backdrop {
+  transition: opacity 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-sidebar-shell,
+  .app-sidebar-backdrop {
+    transition-duration: 1ms;
+  }
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/57daaeb3-8d4d-482f-9e5f-00b4db3093c4


- Add compact top-bar controls for opening and closing the left channel sidebar and right member/profile sidebar.
- Persist both sidebar states in `localStorage` so the layout survives reloads.
- Animate sidebar width/transform changes and mobile backdrop fades, with reduced-motion handling.

## Impact
This frees horizontal space in the web client while keeping the existing sidebar and member/profile workflows available on desktop and mobile.

## Validation
- `npx eslint src/App.tsx src/components/TopBar.tsx`
- `npm run build`

Note: full `npm run lint` still has pre-existing unrelated lint failures across tests and other components.