### PR TITLE
feat(macos): enable App Sandbox (Phase 1) with keychain fallback

### DIFF
--- a/freeq-macos/Package.swift
+++ b/freeq-macos/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
                 "ComposeHistory.swift",
                 "MessageTimeline.swift",
                 "BufferNavigation.swift",
+                "CommandRegistry.swift",
                 "Logger.swift",
                 "KeychainHelper.swift",
             ]

--- a/freeq-macos/SPIKE-MESSAGE-LIST.md
+++ b/freeq-macos/SPIKE-MESSAGE-LIST.md
@@ -1,0 +1,44 @@
+# Spike: Message-List Architecture (Phase 1 exit gate)
+
+**Question:** can the current `ScrollView` + `LazyVStack` + `ScrollViewReader`
+message list meet the plan's §7.5 budget (main-thread hitch time <1%) under
+demo-critical load?
+
+**Verdict: NO — rewrite required before Phase 2 (formatting), per plan §10.**
+
+## Method
+
+`FrameHitchMonitor` (120Hz main-thread heartbeat; a late beat = a stall the
+user feels) + DebugBridge harness (`#stress`, `#editstorm`, `#sweep`,
+`#hitch`). Run 2026-07-03 on the sandboxed Debug build, Mac Studio, 10,000
+synthetic messages in one channel (mixed lengths, multiline, inline
+markdown, reactions, 30 days of timestamps → date separators active).
+
+## Results
+
+| Scenario | Elapsed | Stalls >34ms | Worst | Hitch time |
+|---|---|---|---|---|
+| Idle, 10k loaded (baseline) | 15.0s | 0 | 0ms | **0.00%** |
+| Scroll sweep (251 scrollTo hops) | 105.9s | 630 | 198ms | **43.4%** |
+| Streaming-edit storm (30 edits/s, agent-output pattern) | 12.0s | 226 (every beat) | 59ms | **100%** |
+
+## Reading
+
+- Steady state is fine — the pain is *any* change to a large list.
+- `scrollTo` across a lazy list forces layout of everything in between;
+  jump-to-message and history navigation are unusable at depth.
+- The edit storm is the killer: every in-place mutation diffs the whole
+  10k-row ForEach, and at agent streaming rates (hero-demo beat 1) the main
+  thread saturates completely. Debug build inflates absolute numbers, but a
+  40–100× budget miss does not optimize away.
+
+## Decision
+
+Rewrite the message list on an AppKit-backed row-reuse container in Phase 2:
+- Evaluate in order: SwiftUI `List` (NSTableView-backed; cheapest migration,
+  granular row updates) → `NSTableView` + `NSHostingView` rows (full control:
+  bottom-anchoring, prepend-without-jump, per-row invalidation).
+- Keep: `MessageTimeline` (separator policy), row views (MessageRow etc.),
+  one-view-per-element rule, `.id`-based scroll targeting semantics.
+- The hitch harness above is the regression gate: same three scenarios must
+  come in under 1% hitch time (Release build) before the rewrite merges.

--- a/freeq-macos/Tests/FreeqMacosCoreTests/CommandRegistryTests.swift
+++ b/freeq-macos/Tests/FreeqMacosCoreTests/CommandRegistryTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import FreeqMacosCore
+
+final class CommandRegistryTests: XCTestCase {
+    // MARK: - Registry invariants
+
+    func testCommandIdsAreUnique() {
+        let ids = CommandRegistry.all.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "duplicate command ids")
+    }
+
+    func testShortcutLabelsAreUnique() {
+        let labels = CommandRegistry.all.compactMap(\.shortcutLabel)
+        XCTAssertEqual(labels.count, Set(labels).count, "two commands claim one shortcut")
+    }
+
+    func testEveryCommandHasCategory() {
+        XCTAssertFalse(CommandRegistry.all.contains { $0.category.isEmpty })
+    }
+
+    func testLookupById() {
+        XCTAssertEqual(CommandRegistry.command("call.leave")?.title, "Leave Call")
+        XCTAssertNil(CommandRegistry.command("nope"))
+    }
+
+    // MARK: - Matcher ranking
+
+    func testTitlePrefixOutranksWordBoundary() {
+        let ranked = CommandMatcher.rank(query: "to", in: CommandRegistry.all)
+        // "Toggle …" (title prefix) must come before anything matching
+        // "to" only at a later word boundary.
+        XCTAssertTrue(ranked.first?.title.lowercased().hasPrefix("to") ?? false)
+    }
+
+    func testWordBoundaryMatch() {
+        let ranked = CommandMatcher.rank(query: "mute", in: CommandRegistry.all)
+        XCTAssertTrue(ranked.contains { $0.id == "call.toggleMute" },
+                      "\"mute\" should match Toggle Mute at a word boundary")
+    }
+
+    func testKeywordMatch() {
+        let ranked = CommandMatcher.rank(query: "afk", in: CommandRegistry.all)
+        XCTAssertEqual(ranked.first?.id, "presence.toggleAway")
+    }
+
+    func testSubsequenceMatch() {
+        XCTAssertTrue(CommandMatcher.isSubsequence("lvc", of: "leave call"))
+        XCTAssertFalse(CommandMatcher.isSubsequence("xyz", of: "leave call"))
+        let ranked = CommandMatcher.rank(query: "lvcall", in: CommandRegistry.all)
+        XCTAssertTrue(ranked.contains { $0.id == "call.leave" })
+    }
+
+    func testEmptyQueryReturnsNothing() {
+        XCTAssertTrue(CommandMatcher.rank(query: "  ", in: CommandRegistry.all).isEmpty)
+    }
+
+    func testCaseInsensitive() {
+        let ranked = CommandMatcher.rank(query: "BOOKMARKS", in: CommandRegistry.all)
+        XCTAssertEqual(ranked.first?.id, "nav.bookmarks")
+    }
+
+    func testNoMatchReturnsEmpty() {
+        XCTAssertTrue(CommandMatcher.rank(query: "zzzzqqq", in: CommandRegistry.all).isEmpty)
+    }
+}

--- a/freeq-macos/Tests/FreeqMacosCoreTests/ValidationTests.swift
+++ b/freeq-macos/Tests/FreeqMacosCoreTests/ValidationTests.swift
@@ -628,3 +628,28 @@ final class ValidationTests: XCTestCase {
         XCTAssertEqual(matches.count, 2)
     }
 }
+
+// MARK: - Keychain legacy fallback (sandbox + ad-hoc signature)
+
+extension ValidationTests {
+    func testLegacyQueryOmitsDataProtection() {
+        let query = KeychainHelper.legacyQuery(key: "k")
+        XCTAssertNil(query[kSecUseDataProtectionKeychain as String],
+                     "legacy fallback must not request the data-protection keychain")
+        XCTAssertEqual(query[kSecAttrService as String] as? String, KeychainHelper.service)
+        XCTAssertEqual(query[kSecAttrAccount as String] as? String, "k")
+    }
+
+    func testLegacyLoadQueryAllowsInteraction() {
+        // The legacy path may show a one-time ACL prompt; blocking
+        // interaction there would fail loads instead of prompting.
+        let query = KeychainHelper.loadQuery(key: "k", dataProtection: false)
+        XCTAssertNil(query[kSecUseAuthenticationContext as String])
+        XCTAssertNil(query[kSecUseDataProtectionKeychain as String])
+    }
+
+    func testDataProtectionQueryUnchanged() {
+        let query = KeychainHelper.baseQuery(key: "k")
+        XCTAssertEqual(query[kSecUseDataProtectionKeychain as String] as? Bool, true)
+    }
+}

--- a/freeq-macos/freeq-macos.xcodeproj/project.pbxproj
+++ b/freeq-macos/freeq-macos.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02A3083762112F16B4DE3F31 /* CommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C14C09FE9CB53438535F9C /* CommandRegistry.swift */; };
 		035849CB7A13552E1686B4F8 /* CameraFrameRatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC9CABA22036B8DCCD1C135 /* CameraFrameRatePolicy.swift */; };
 		111A631DD747383DB85200BF /* DebugBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD56638DA817D921B8F261C /* DebugBridge.swift */; };
 		141F5EE2389E6C8A8801E692 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B144BCAA2F46CB480BF6E2CD /* Assets.xcassets */; };
@@ -38,6 +39,8 @@
 		9F958D5ED5FB22C5E40774A7 /* ChannelSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340BE5C80B24DD16B066ABC /* ChannelSettingsSheet.swift */; };
 		A115ABF32733643ACB3F34DF /* UserProfileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B151A6B667B7AC30647A4811 /* UserProfileSheet.swift */; };
 		A4F9C4AA63982ABFC87031B0 /* ComposeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D90D45494AECECE10448CB0E /* ComposeCommands.swift */; };
+		A9145BA4866695884EE7B4B9 /* FrameHitchMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D2221C3627158CF392EC73 /* FrameHitchMonitor.swift */; };
+		A94BB04F1EFEF742981293E0 /* CommandActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF97FF66F9ADAFA5CF386971 /* CommandActions.swift */; };
 		AA93A5BC96012105B5A999C2 /* ChannelE2eeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3846EF940D85D72154A72566 /* ChannelE2eeState.swift */; };
 		AF76EC565DC3FE7EB618879F /* AutocompletePopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B98D35F34492C2C6B3E504F /* AutocompletePopup.swift */; };
 		B0C4859CFAA8548B0B74CFD2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD71B67F52DD573EF6080AE /* SettingsView.swift */; };
@@ -106,6 +109,7 @@
 		AFDA007C5D2E0294D534B5A4 /* ComposeFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeFormatting.swift; sourceTree = "<group>"; };
 		B144BCAA2F46CB480BF6E2CD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B151A6B667B7AC30647A4811 /* UserProfileSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileSheet.swift; sourceTree = "<group>"; };
+		B7C14C09FE9CB53438535F9C /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
 		B840984A8780805615D0846A /* CallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallView.swift; sourceTree = "<group>"; };
 		BA939865F12BCD7A51A4E5D0 /* CallController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallController.swift; sourceTree = "<group>"; };
 		BD5D672B7A5F1D6E78162DE1 /* freeq.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = freeq.swift; sourceTree = "<group>"; };
@@ -119,10 +123,12 @@
 		DB0BA22F0AF547102314C733 /* CallAudioDevices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAudioDevices.swift; sourceTree = "<group>"; };
 		DB1B29BA8601FC220D46B705 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		DB6D944E494A3AE591F53C28 /* MediaViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViews.swift; sourceTree = "<group>"; };
+		DF97FF66F9ADAFA5CF386971 /* CommandActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandActions.swift; sourceTree = "<group>"; };
 		E71A46E52B4FC4C2F32D7F34 /* ServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		ECC9CABA22036B8DCCD1C135 /* CameraFrameRatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraFrameRatePolicy.swift; sourceTree = "<group>"; };
 		ED9F5A69D81B1BA80FC4782A /* ChannelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelState.swift; sourceTree = "<group>"; };
 		F0BFAA19CD6272B8B0EB81C7 /* CallLayoutPolicies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallLayoutPolicies.swift; sourceTree = "<group>"; };
+		F0D2221C3627158CF392EC73 /* FrameHitchMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameHitchMonitor.swift; sourceTree = "<group>"; };
 		F3D1930C0C5B69735D97DA9C /* ChannelCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCrypto.swift; sourceTree = "<group>"; };
 		F95B3DDDA0598080AE7E870C /* FormatToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatToolbar.swift; sourceTree = "<group>"; };
 		FDCB3DAE1E0BAC641DA22730 /* ComposeBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeBar.swift; sourceTree = "<group>"; };
@@ -218,6 +224,7 @@
 			children = (
 				20ABEF839D9D9D42C9D1BF08 /* App.swift */,
 				B144BCAA2F46CB480BF6E2CD /* Assets.xcassets */,
+				DF97FF66F9ADAFA5CF386971 /* CommandActions.swift */,
 				BF68A6E75172FAD9338D574F /* freeq-macos.entitlements */,
 				04D3AAFE430FB0DC2DA62F57 /* Theme.swift */,
 				1CFB5C09777E2612ABCDEDFB /* Auth */,
@@ -253,11 +260,13 @@
 				9E6BC4FEEBACC91D752966CC /* ChannelHydration.swift */,
 				ED9F5A69D81B1BA80FC4782A /* ChannelState.swift */,
 				DA3E838FFB8176761B9DAA50 /* ChatMessage.swift */,
+				B7C14C09FE9CB53438535F9C /* CommandRegistry.swift */,
 				D90D45494AECECE10448CB0E /* ComposeCommands.swift */,
 				AFDA007C5D2E0294D534B5A4 /* ComposeFormatting.swift */,
 				06360D5F1B334245B936F78F /* ComposeHistory.swift */,
 				0BD56638DA817D921B8F261C /* DebugBridge.swift */,
 				20B3BED9F9A6237942DD0971 /* E2eeManager.swift */,
+				F0D2221C3627158CF392EC73 /* FrameHitchMonitor.swift */,
 				6D0D657E5F637E5EFD232E19 /* KeychainHelper.swift */,
 				DB1B29BA8601FC220D46B705 /* Logger.swift */,
 				13C9D32F59D3998D69B16618 /* MediaDeviceSelection.swift */,
@@ -407,6 +416,8 @@
 				728190EB3B8C571044EBDE73 /* ChannelState.swift in Sources */,
 				95713207153A9DD7BAB5955A /* ChatMessage.swift in Sources */,
 				C724476B94820275BA16E55F /* ChatView.swift in Sources */,
+				A94BB04F1EFEF742981293E0 /* CommandActions.swift in Sources */,
+				02A3083762112F16B4DE3F31 /* CommandRegistry.swift in Sources */,
 				304585E2A3DCCB55DD8467D9 /* ComposeBar.swift in Sources */,
 				A4F9C4AA63982ABFC87031B0 /* ComposeCommands.swift in Sources */,
 				C480A25B440D0373E17082D8 /* ComposeFormatting.swift in Sources */,
@@ -417,6 +428,7 @@
 				E1AB7FC16F690AF9462DBBAC /* E2eeManager.swift in Sources */,
 				3ACCE0099E0E97EC7A321EDC /* FileUpload.swift in Sources */,
 				6DDB3CED329F29FC4C691EAD /* FormatToolbar.swift in Sources */,
+				A9145BA4866695884EE7B4B9 /* FrameHitchMonitor.swift in Sources */,
 				B8AB7DBFF62520564B9DDE52 /* JoinChannelSheet.swift in Sources */,
 				ECC92464E4422B5DCFDC770B /* KeychainHelper.swift in Sources */,
 				D520A6580822EF5314066E14 /* LinkPreview.swift in Sources */,

--- a/freeq-macos/freeq-macos/App.swift
+++ b/freeq-macos/freeq-macos/App.swift
@@ -29,26 +29,34 @@ enum AppearanceSetting: String, CaseIterable {
 @main
 struct FreeqApp: App {
     @State private var appState = AppState()
-    @State private var showQuickSwitcher = false
-    @State private var showBookmarks = false
-    @State private var showChannelList = false
     @State private var showOnboarding = !UserDefaults.standard.bool(forKey: "freeq.onboardingComplete")
     @AppStorage("freeq.appearance") private var appearanceRaw = "system"
 
+    /// Menu item projected from the Command registry — same title,
+    /// shortcut, availability, and handler the ⌘K palette uses.
+    private func commandButton(_ id: String) -> some View {
+        Button(CommandActions.title(id, appState)) {
+            CommandActions.run(id, appState)
+        }
+        .keyboardShortcut(CommandActions.keyboardShortcut(id))
+        .disabled(!CommandActions.isEnabled(id, appState))
+    }
+
     var body: some Scene {
         WindowGroup {
+            @Bindable var state = appState
             MainView()
                 .environment(appState)
                 .frame(minWidth: 700, minHeight: 400)
-                .sheet(isPresented: $showQuickSwitcher) {
+                .sheet(isPresented: $state.showQuickSwitcher) {
                     QuickSwitcher()
                         .environment(appState)
                 }
-                .sheet(isPresented: $showBookmarks) {
+                .sheet(isPresented: $state.showBookmarks) {
                     BookmarksPanel()
                         .environment(appState)
                 }
-                .sheet(isPresented: $showChannelList) {
+                .sheet(isPresented: $state.showChannelList) {
                     ChannelListBrowser()
                         .environment(appState)
                 }
@@ -72,61 +80,27 @@ struct FreeqApp: App {
                 }
         }
         .commands {
+            // All menu content projects from the Command registry
+            // (CommandRegistry + CommandActions) — the ⌘K palette shows the
+            // same commands, so the two can never drift.
             CommandGroup(after: .sidebar) {
-                Button("Toggle Detail Panel") {
-                    appState.showDetailPanel.toggle()
-                }
-                .keyboardShortcut("d", modifiers: [.command, .shift])
+                commandButton("view.toggleDetail")
 
                 Divider()
 
                 // Slack-compatible channel navigation muscle memory.
-                Button("Previous Channel") {
-                    appState.switchToAdjacentChannel(.previous)
-                }
-                .keyboardShortcut(.upArrow, modifiers: .option)
-
-                Button("Next Channel") {
-                    appState.switchToAdjacentChannel(.next)
-                }
-                .keyboardShortcut(.downArrow, modifiers: .option)
-
-                Button("Previous Unread Channel") {
-                    appState.switchToAdjacentChannel(.previous, unreadOnly: true)
-                }
-                .keyboardShortcut(.upArrow, modifiers: [.option, .shift])
-
-                Button("Next Unread Channel") {
-                    appState.switchToAdjacentChannel(.next, unreadOnly: true)
-                }
-                .keyboardShortcut(.downArrow, modifiers: [.option, .shift])
+                commandButton("nav.prevChannel")
+                commandButton("nav.nextChannel")
+                commandButton("nav.prevUnread")
+                commandButton("nav.nextUnread")
             }
 
             CommandGroup(replacing: .newItem) {
-                Button("Quick Switcher") {
-                    showQuickSwitcher = true
-                }
-                .keyboardShortcut("k", modifiers: .command)
-
-                Button("Search Messages") {
-                    appState.showSearch.toggle()
-                }
-                .keyboardShortcut("f", modifiers: .command)
-
-                Button("Bookmarks") {
-                    showBookmarks = true
-                }
-                .keyboardShortcut("b", modifiers: [.command, .shift])
-
-                Button("Browse Channels") {
-                    showChannelList = true
-                }
-                .keyboardShortcut("l", modifiers: [.command, .shift])
-
-                Button("Join Channel…") {
-                    appState.showJoinSheet = true
-                }
-                .keyboardShortcut("j", modifiers: .command)
+                commandButton("nav.quickSwitcher")
+                commandButton("nav.search")
+                commandButton("nav.bookmarks")
+                commandButton("nav.browseChannels")
+                commandButton("nav.joinChannel")
 
                 Divider()
 
@@ -138,39 +112,26 @@ struct FreeqApp: App {
                 }
             }
 
-            // In-call controls (Zoom's muscle memory: ⇧⌘M / ⇧⌘V / ⇧⌘S).
-            CommandMenu("Call") {
-                Button(appState.isMuted ? "Unmute" : "Mute") {
-                    appState.toggleMute()
-                }
-                .keyboardShortcut("m", modifiers: [.command, .shift])
-                .disabled(!appState.isInCall)
-
-                Button(appState.isCameraOn ? "Stop Camera" : "Start Camera") {
-                    appState.toggleCamera()
-                }
-                .keyboardShortcut("v", modifiers: [.command, .shift])
-                .disabled(!appState.isInCall)
-
-                Button(appState.isScreenSharing ? "Stop Sharing Screen" : "Share Screen") {
-                    appState.toggleScreenShare()
-                }
-                .keyboardShortcut("s", modifiers: [.command, .shift])
-                .disabled(!appState.isInCall)
+            CommandMenu("Channel") {
+                commandButton("channel.toggleFavorite")
+                commandButton("channel.toggleMute")
+                commandButton("channel.leave")
 
                 Divider()
 
-                Button(appState.isCallExpanded ? "Collapse Call" : "Expand Call") {
-                    appState.isCallExpanded.toggle()
-                }
-                .keyboardShortcut("e", modifiers: [.command, .shift])
-                .disabled(!appState.isInCall)
+                commandButton("presence.toggleAway")
+            }
 
-                Button("Leave Call") {
-                    appState.leaveCall()
-                }
-                .keyboardShortcut("h", modifiers: [.command, .shift])
-                .disabled(!appState.isInCall)
+            // In-call controls (Zoom's muscle memory: ⇧⌘M / ⇧⌘V / ⇧⌘S).
+            CommandMenu("Call") {
+                commandButton("call.toggleMute")
+                commandButton("call.toggleCamera")
+                commandButton("call.toggleScreen")
+
+                Divider()
+
+                commandButton("call.toggleExpand")
+                commandButton("call.leave")
             }
 
             CommandGroup(replacing: .help) {

--- a/freeq-macos/freeq-macos/CommandActions.swift
+++ b/freeq-macos/freeq-macos/CommandActions.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// App-layer half of the Command registry: key bindings, availability, and
+/// execution against AppState. The menu bar and the ⌘K palette both call
+/// through here, so an action can never exist in one and not the other.
+@MainActor
+enum CommandActions {
+    static func keyboardShortcut(_ id: String) -> KeyboardShortcut? {
+        switch id {
+        case "nav.quickSwitcher": return .init("k", modifiers: .command)
+        case "nav.search": return .init("f", modifiers: .command)
+        case "nav.bookmarks": return .init("b", modifiers: [.command, .shift])
+        case "nav.browseChannels": return .init("l", modifiers: [.command, .shift])
+        case "nav.joinChannel": return .init("j", modifiers: .command)
+        case "nav.prevChannel": return .init(.upArrow, modifiers: .option)
+        case "nav.nextChannel": return .init(.downArrow, modifiers: .option)
+        case "nav.prevUnread": return .init(.upArrow, modifiers: [.option, .shift])
+        case "nav.nextUnread": return .init(.downArrow, modifiers: [.option, .shift])
+        case "view.toggleDetail": return .init("d", modifiers: [.command, .shift])
+        case "call.toggleMute": return .init("m", modifiers: [.command, .shift])
+        case "call.toggleCamera": return .init("v", modifiers: [.command, .shift])
+        case "call.toggleScreen": return .init("s", modifiers: [.command, .shift])
+        case "call.toggleExpand": return .init("e", modifiers: [.command, .shift])
+        case "call.leave": return .init("h", modifiers: [.command, .shift])
+        default: return nil
+        }
+    }
+
+    static func isEnabled(_ id: String, _ app: AppState) -> Bool {
+        switch id {
+        case let cmd where cmd.hasPrefix("call."):
+            return app.isInCall
+        case "channel.toggleFavorite", "channel.toggleMute", "channel.leave":
+            return app.activeChannel?.hasPrefix("#") == true
+        case "presence.toggleAway":
+            return app.connectionState == .registered
+        default:
+            return true
+        }
+    }
+
+    /// Dynamic titles where state matters ("Mute" vs "Unmute").
+    static func title(_ id: String, _ app: AppState) -> String {
+        switch id {
+        case "call.toggleMute": return app.isMuted ? "Unmute" : "Mute"
+        case "call.toggleCamera": return app.isCameraOn ? "Stop Camera" : "Start Camera"
+        case "call.toggleScreen": return app.isScreenSharing ? "Stop Sharing Screen" : "Share Screen"
+        case "call.toggleExpand": return app.isCallExpanded ? "Collapse Call" : "Expand Call"
+        case "presence.toggleAway": return app.selfAwayReason == nil ? "Set Away" : "Remove Away"
+        case "channel.toggleFavorite":
+            guard let ch = app.activeChannel else { return "Favorite Channel" }
+            return app.favorites.contains(ch.lowercased()) ? "Unfavorite \(ch)" : "Favorite \(ch)"
+        case "channel.toggleMute":
+            guard let ch = app.activeChannel else { return "Mute Channel" }
+            return app.mutedChannels.contains(ch.lowercased()) ? "Unmute \(ch)" : "Mute \(ch)"
+        case "channel.leave":
+            return app.activeChannel.map { "Leave \($0)" } ?? "Leave Channel"
+        default:
+            return CommandRegistry.command(id)?.title ?? id
+        }
+    }
+
+    static func run(_ id: String, _ app: AppState) {
+        switch id {
+        case "nav.quickSwitcher": app.showQuickSwitcher = true
+        case "nav.search": app.showSearch.toggle()
+        case "nav.bookmarks": app.showBookmarks = true
+        case "nav.browseChannels": app.showChannelList = true
+        case "nav.joinChannel": app.showJoinSheet = true
+        case "nav.prevChannel": app.switchToAdjacentChannel(.previous)
+        case "nav.nextChannel": app.switchToAdjacentChannel(.next)
+        case "nav.prevUnread": app.switchToAdjacentChannel(.previous, unreadOnly: true)
+        case "nav.nextUnread": app.switchToAdjacentChannel(.next, unreadOnly: true)
+        case "view.toggleDetail": app.showDetailPanel.toggle()
+        case "call.toggleMute": app.toggleMute()
+        case "call.toggleCamera": app.toggleCamera()
+        case "call.toggleScreen": app.toggleScreenShare()
+        case "call.toggleExpand": app.isCallExpanded.toggle()
+        case "call.leave": app.leaveCall()
+        case "presence.toggleAway": app.setAway(app.selfAwayReason == nil ? "AFK" : nil)
+        case "channel.toggleFavorite": app.activeChannel.map { app.toggleFavorite($0) }
+        case "channel.toggleMute": app.activeChannel.map { app.toggleMuted($0) }
+        case "channel.leave": app.activeChannel.map { app.partChannel($0) }
+        default: break
+        }
+    }
+}

--- a/freeq-macos/freeq-macos/Models/CommandRegistry.swift
+++ b/freeq-macos/freeq-macos/Models/CommandRegistry.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// One user-facing action. The registry is the single source of truth that
+/// the menu bar, the ⌘K palette, tooltips, and (later) App Intents all
+/// project from — four hand-synced action lists would drift; one registry
+/// cannot. Pure data: execution and key bindings live in the app layer
+/// (CommandActions), keeping this SwiftPM-testable.
+struct AppCommand: Identifiable, Equatable, Hashable {
+    let id: String
+    let title: String
+    let category: String
+    /// Display form, e.g. "⌥⇧↓" — the actual KeyboardShortcut lives with
+    /// the action map in the app layer.
+    let shortcutLabel: String?
+    /// Extra match terms for the palette ("dm", "mute", …).
+    let keywords: [String]
+
+    init(_ id: String, _ title: String, category: String,
+         shortcut: String? = nil, keywords: [String] = []) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.shortcutLabel = shortcut
+        self.keywords = keywords
+    }
+}
+
+enum CommandRegistry {
+    static let navigation = "Navigation"
+    static let view = "View"
+    static let call = "Call"
+    static let presence = "Presence"
+    static let channel = "Channel"
+
+    static let all: [AppCommand] = [
+        // Navigation
+        AppCommand("nav.quickSwitcher", "Quick Switcher", category: navigation,
+                   shortcut: "⌘K", keywords: ["palette", "jump", "switch"]),
+        AppCommand("nav.search", "Search Messages", category: navigation,
+                   shortcut: "⌘F", keywords: ["find"]),
+        AppCommand("nav.bookmarks", "Bookmarks", category: navigation,
+                   shortcut: "⇧⌘B", keywords: ["saved"]),
+        AppCommand("nav.browseChannels", "Browse Channels", category: navigation,
+                   shortcut: "⇧⌘L", keywords: ["list", "discover"]),
+        AppCommand("nav.joinChannel", "Join Channel…", category: navigation,
+                   shortcut: "⌘J", keywords: ["add"]),
+        AppCommand("nav.prevChannel", "Previous Channel", category: navigation,
+                   shortcut: "⌥↑", keywords: ["up"]),
+        AppCommand("nav.nextChannel", "Next Channel", category: navigation,
+                   shortcut: "⌥↓", keywords: ["down"]),
+        AppCommand("nav.prevUnread", "Previous Unread Channel", category: navigation,
+                   shortcut: "⌥⇧↑", keywords: ["unread"]),
+        AppCommand("nav.nextUnread", "Next Unread Channel", category: navigation,
+                   shortcut: "⌥⇧↓", keywords: ["unread"]),
+
+        // View
+        AppCommand("view.toggleDetail", "Toggle Detail Panel", category: view,
+                   shortcut: "⇧⌘D", keywords: ["members", "inspector", "sidebar"]),
+
+        // Call
+        AppCommand("call.toggleMute", "Toggle Mute", category: call,
+                   shortcut: "⇧⌘M", keywords: ["microphone", "unmute"]),
+        AppCommand("call.toggleCamera", "Toggle Camera", category: call,
+                   shortcut: "⇧⌘V", keywords: ["video"]),
+        AppCommand("call.toggleScreen", "Share Screen", category: call,
+                   shortcut: "⇧⌘S", keywords: ["screenshare", "present"]),
+        AppCommand("call.toggleExpand", "Expand Call", category: call,
+                   shortcut: "⇧⌘E", keywords: ["grid", "collapse"]),
+        AppCommand("call.leave", "Leave Call", category: call,
+                   shortcut: "⇧⌘H", keywords: ["hangup", "end"]),
+
+        // Presence
+        AppCommand("presence.toggleAway", "Toggle Away", category: presence,
+                   keywords: ["afk", "status", "back"]),
+
+        // Channel (acts on the active buffer)
+        AppCommand("channel.toggleFavorite", "Toggle Favorite for Channel", category: channel,
+                   keywords: ["star", "pin"]),
+        AppCommand("channel.toggleMute", "Toggle Mute for Channel", category: channel,
+                   keywords: ["silence", "notifications"]),
+        AppCommand("channel.leave", "Leave Channel", category: channel,
+                   keywords: ["part", "close"]),
+    ]
+
+    static func command(_ id: String) -> AppCommand? {
+        all.first { $0.id == id }
+    }
+
+    static func category(_ name: String) -> [AppCommand] {
+        all.filter { $0.category == name }
+    }
+}
+
+/// Fuzzy matcher for the palette. Ranking: title prefix > word-boundary
+/// prefix > keyword prefix > subsequence. Ties keep registry order.
+enum CommandMatcher {
+    static func rank(query: String, in commands: [AppCommand]) -> [AppCommand] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return [] }
+        return commands
+            .compactMap { cmd -> (AppCommand, Int)? in
+                guard let s = score(query: q, command: cmd) else { return nil }
+                return (cmd, s)
+            }
+            .enumerated()
+            .sorted { a, b in
+                a.element.1 != b.element.1
+                    ? a.element.1 > b.element.1
+                    : a.offset < b.offset
+            }
+            .map { $0.element.0 }
+    }
+
+    static func score(query q: String, command: AppCommand) -> Int? {
+        let title = command.title.lowercased()
+        if title.hasPrefix(q) { return 100 }
+        // Word-boundary prefix ("mute" matches "Toggle Mute").
+        let words = title.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        if words.contains(where: { $0.hasPrefix(q) }) { return 80 }
+        if command.keywords.contains(where: { $0.lowercased().hasPrefix(q) }) { return 60 }
+        if isSubsequence(q, of: title) { return 30 }
+        return nil
+    }
+
+    /// Every character of `needle` appears in order within `haystack`.
+    static func isSubsequence(_ needle: String, of haystack: String) -> Bool {
+        var it = needle.startIndex
+        for ch in haystack {
+            if it == needle.endIndex { return true }
+            if ch == needle[it] { it = needle.index(after: it) }
+        }
+        return it == needle.endIndex
+    }
+}

--- a/freeq-macos/freeq-macos/Models/DebugBridge.swift
+++ b/freeq-macos/freeq-macos/Models/DebugBridge.swift
@@ -134,6 +134,65 @@ final class DebugBridge {
         case "storepath":
             let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
             NSLog("[debug-bridge] cachesDir=\(caches.path)")
+        // ── Message-list spike harness ──
+        case "stress":
+            // Inject N synthetic messages into the active channel: mixed
+            // lengths, multiline, inline code, reactions, timestamps
+            // spanning 30 days (exercises date separators + grouping).
+            guard let ch = app.activeChannelState else { return }
+            let n = Int(arg) ?? 1000
+            let nicks = ["alice", "bob", "carol", "dave", "erin"]
+            let now = Date()
+            let start = now.addingTimeInterval(-30 * 86_400)
+            let bodies = [
+                "short one",
+                "a somewhat longer message that wraps across a couple of lines when the window is narrow enough to matter",
+                "line one\nline two\nline three",
+                "with `inline code` and **bold** and _italics_ mixed in",
+                String(repeating: "stress ", count: 60),
+            ]
+            for i in 0..<n {
+                let ts = start.addingTimeInterval(Double(i) / Double(n) * 30 * 86_400)
+                var msg = ChatMessage(
+                    id: String(format: "stress-%06d", i),
+                    from: nicks[i % nicks.count],
+                    text: "#\(i) " + bodies[i % bodies.count],
+                    isAction: false, timestamp: ts, replyTo: nil)
+                if i % 7 == 0 { msg.reactions = ["👍": ["alice", "bob"], "🎉": ["carol"]] }
+                ch.appendIfNew(msg)
+            }
+            NSLog("[debug-bridge] stress injected \(n), channel now \(ch.messages.count)")
+        case "editstorm":
+            // Streaming-edit simulation: rapid text mutations on the last
+            // message, 30/s (the agent-output pattern).
+            guard let ch = app.activeChannelState,
+                  let last = ch.messages.last(where: { !$0.from.isEmpty }) else { return }
+            let count = Int(arg) ?? 100
+            Task { @MainActor in
+                for i in 0..<count {
+                    ch.applyEdit(originalId: last.id, newId: nil,
+                                 newText: "streaming chunk \(i): " + String(repeating: "token ", count: i % 40))
+                    try? await Task.sleep(nanoseconds: 33_000_000)
+                }
+                NSLog("[debug-bridge] editstorm done (\(count) edits)")
+            }
+        case "sweep":
+            // Scroll the full list via the scroll-to-message path,
+            // top → bottom, one hop per 400ms.
+            guard let ch = app.activeChannelState else { return }
+            let ids = ch.messages.enumerated()
+                .filter { $0.offset % 40 == 0 }
+                .map { $0.element.id }
+            Task { @MainActor in
+                for id in ids {
+                    app.scrollToMessageId = id
+                    try? await Task.sleep(nanoseconds: 400_000_000)
+                }
+                NSLog("[debug-bridge] sweep done (\(ids.count) hops)")
+            }
+        case "hitch":
+            if arg == "start" { FrameHitchMonitor.shared.start() }
+            else { FrameHitchMonitor.shared.stop() }
         case "dumpmsgs":
             if let ch = app.activeChannelState {
                 for (i, m) in ch.messages.enumerated() {

--- a/freeq-macos/freeq-macos/Models/DebugBridge.swift
+++ b/freeq-macos/freeq-macos/Models/DebugBridge.swift
@@ -122,6 +122,18 @@ final class DebugBridge {
             // Fire the composer's own submit (records input history etc.),
             // unlike plain-text lines which go straight to submitInput.
             ComposeNSTextView.activeInstance?.submitAction?()
+        case "keychain":
+            // Sandbox smoke test: the data-protection keychain with an
+            // ad-hoc signature must keep working after sandboxing, or
+            // session restore silently breaks. Logs a PASS/FAIL verdict.
+            let key = "sandbox-probe"
+            let saved = KeychainHelper.save(key: key, value: "ok-\(ProcessInfo.processInfo.processIdentifier)")
+            let loaded = KeychainHelper.load(key: key)
+            KeychainHelper.delete(key: key)
+            NSLog("[debug-bridge] keychain probe: save=\(saved) load=\(loaded ?? "nil") verdict=\(saved && loaded != nil ? "PASS" : "FAIL")")
+        case "storepath":
+            let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            NSLog("[debug-bridge] cachesDir=\(caches.path)")
         case "dumpmsgs":
             if let ch = app.activeChannelState {
                 for (i, m) in ch.messages.enumerated() {

--- a/freeq-macos/freeq-macos/Models/FrameHitchMonitor.swift
+++ b/freeq-macos/freeq-macos/Models/FrameHitchMonitor.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Main-thread stall monitor for the message-list architecture spike.
+///
+/// A 120Hz heartbeat timer on the main runloop: when layout/render work
+/// stalls the main thread, the beat fires late, and the lateness is the
+/// stall duration a user would feel as a hitch. (CVDisplayLink would be
+/// wrong here — it ticks on the display's clock even while the app hangs.)
+final class FrameHitchMonitor {
+    static let shared = FrameHitchMonitor()
+
+    private var timer: Timer?
+    private var lastBeat: CFAbsoluteTime = 0
+    private var samples = 0
+    private var stalls: [Double] = []
+    private var startedAt: CFAbsoluteTime = 0
+
+    /// Intervals above this are counted as user-visible hitches
+    /// (2+ dropped frames at 60Hz).
+    private let hitchThreshold = 0.034
+
+    func start() {
+        stop(report: false)
+        samples = 0
+        stalls = []
+        startedAt = CFAbsoluteTimeGetCurrent()
+        lastBeat = startedAt
+        let t = Timer(timeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            let now = CFAbsoluteTimeGetCurrent()
+            let interval = now - self.lastBeat
+            self.lastBeat = now
+            self.samples += 1
+            if interval > self.hitchThreshold {
+                self.stalls.append(interval)
+            }
+        }
+        t.tolerance = 0
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+        NSLog("[hitch] monitoring started")
+    }
+
+    func stop(report: Bool = true) {
+        timer?.invalidate()
+        timer = nil
+        guard report, samples > 0 else { return }
+        let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
+        let worst = (stalls.max() ?? 0) * 1000
+        let totalStall = stalls.reduce(0, +) * 1000
+        let hitchRatio = elapsed > 0 ? (stalls.reduce(0, +) / elapsed) * 100 : 0
+        NSLog(String(
+            format: "[hitch] SUMMARY elapsed=%.1fs beats=%d stalls>34ms=%d worst=%.0fms totalStall=%.0fms hitchTime=%.2f%%",
+            elapsed, samples, stalls.count, worst, totalStall, hitchRatio))
+    }
+}

--- a/freeq-macos/freeq-macos/Models/KeychainHelper.swift
+++ b/freeq-macos/freeq-macos/Models/KeychainHelper.swift
@@ -3,19 +3,36 @@ import LocalAuthentication
 import Security
 
 /// Simple Keychain wrapper for storing sensitive strings.
+///
+/// Storage strategy: prefer the modern data-protection keychain (no repeated
+/// ACL prompts for rebuilt dev-signed apps). Under App Sandbox with an
+/// ad-hoc signature, that keychain is unavailable — SecItem* returns
+/// errSecMissingEntitlement (-34018) because there is no application
+/// identifier — so every operation falls back to the legacy file-based
+/// keychain, which works sandboxed without a team identity. Properly signed
+/// builds (Developer ID / MAS) never hit the fallback.
 enum KeychainHelper {
     static let service = "at.freeq.macos"
 
-    static func baseQuery(key: String) -> [String: Any] {
-        [
+    static func baseQuery(key: String, dataProtection: Bool = true) -> [String: Any] {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
+        ]
+        if dataProtection {
             // Use the modern data-protection keychain instead of the
             // legacy macOS keychain ACL path. The legacy path prompts
             // repeatedly for rebuilt/dev-signed apps.
-            kSecUseDataProtectionKeychain as String: true,
-        ]
+            query[kSecUseDataProtectionKeychain as String] = true
+        }
+        return query
+    }
+
+    /// Legacy fallback query — no data-protection flag, and interaction is
+    /// allowed (the legacy path may show a one-time ACL prompt).
+    static func legacyQuery(key: String) -> [String: Any] {
+        baseQuery(key: key, dataProtection: false)
     }
 
     static func noninteractiveContext() -> LAContext {
@@ -24,11 +41,13 @@ enum KeychainHelper {
         return context
     }
 
-    static func loadQuery(key: String) -> [String: Any] {
-        var query = baseQuery(key: key)
+    static func loadQuery(key: String, dataProtection: Bool = true) -> [String: Any] {
+        var query = baseQuery(key: key, dataProtection: dataProtection)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
-        query[kSecUseAuthenticationContext as String] = noninteractiveContext()
+        if dataProtection {
+            query[kSecUseAuthenticationContext as String] = noninteractiveContext()
+        }
         return query
     }
 
@@ -39,16 +58,28 @@ enum KeychainHelper {
     @discardableResult
     static func save(key: String, value: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
-        let query = baseQuery(key: key)
+        if save(key: key, data: data, dataProtection: true) { return true }
+        Log.auth.warning("KeychainHelper: data-protection save failed (status=\(lastStatus, privacy: .public)) — trying legacy keychain for key=\(key, privacy: .public)")
+        return save(key: key, data: data, dataProtection: false)
+    }
+
+    /// Status of the most recent low-level operation (for fallback routing).
+    private nonisolated(unsafe) static var lastStatus: OSStatus = errSecSuccess
+
+    private static func save(key: String, data: Data, dataProtection: Bool) -> Bool {
+        let query = baseQuery(key: key, dataProtection: dataProtection)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        lastStatus = updateStatus
         if updateStatus == errSecSuccess { return true }
         guard updateStatus == errSecItemNotFound else {
-            Log.auth.error("KeychainHelper.update failed key=\(key, privacy: .public) status=\(updateStatus, privacy: .public)")
+            if updateStatus != errSecMissingEntitlement {
+                Log.auth.error("KeychainHelper.update failed key=\(key, privacy: .public) status=\(updateStatus, privacy: .public)")
+            }
             return false
         }
 
@@ -57,23 +88,40 @@ enum KeychainHelper {
             add[attributeKey] = value
         }
         let status = SecItemAdd(add as CFDictionary, nil)
+        lastStatus = status
         if status != errSecSuccess {
-            Log.auth.error("KeychainHelper.save failed key=\(key, privacy: .public) status=\(status, privacy: .public)")
+            if status != errSecMissingEntitlement {
+                Log.auth.error("KeychainHelper.save failed key=\(key, privacy: .public) status=\(status, privacy: .public)")
+            }
             return false
         }
         return true
     }
 
     static func load(key: String) -> String? {
-        let query = loadQuery(key: key)
+        // Try both stores: the item may live in either depending on the
+        // signing/sandbox mode that wrote it, and SecItemCopyMatching does
+        // not reliably surface errSecMissingEntitlement (an unavailable
+        // data-protection store can read as item-not-found). A miss in the
+        // legacy store is harmless — our own items carry our ACL, so no
+        // prompt fires for them.
+        if let value = load(key: key, dataProtection: true) { return value }
+        return load(key: key, dataProtection: false)
+    }
+
+    private static func load(key: String, dataProtection: Bool) -> String? {
+        let query = loadQuery(key: key, dataProtection: dataProtection)
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
+        lastStatus = status
         guard status == errSecSuccess, let data = result as? Data else { return nil }
         return String(data: data, encoding: .utf8)
     }
 
     static func delete(key: String) {
-        let query = baseQuery(key: key)
-        SecItemDelete(query as CFDictionary)
+        // Best-effort in both stores — an item may exist in either after a
+        // signing-mode change.
+        SecItemDelete(baseQuery(key: key, dataProtection: true) as CFDictionary)
+        SecItemDelete(legacyQuery(key: key) as CFDictionary)
     }
 }

--- a/freeq-macos/freeq-macos/Views/QuickSwitcher.swift
+++ b/freeq-macos/freeq-macos/Views/QuickSwitcher.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
-/// ⌘K Quick Switcher — fuzzy search channels and DMs.
+/// ⌘K palette — fuzzy search across channels, DMs, and every registered
+/// command (the same set the menu bar shows, projected from
+/// CommandRegistry/CommandActions).
 struct QuickSwitcher: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
@@ -8,11 +10,29 @@ struct QuickSwitcher: View {
     @FocusState private var isFocused: Bool
     @State private var selectedIndex: Int = 0
 
-    private var results: [ChannelState] {
+    private enum Item: Identifiable {
+        case buffer(ChannelState)
+        case command(AppCommand)
+
+        var id: String {
+            switch self {
+            case .buffer(let ch): return "b:\(ch.name)"
+            case .command(let cmd): return "c:\(cmd.id)"
+            }
+        }
+    }
+
+    private var results: [Item] {
         let all = appState.allBuffers
-        if query.isEmpty { return all }
+        if query.isEmpty {
+            return all.map(Item.buffer)
+        }
         let q = query.lowercased()
-        return all.filter { $0.name.lowercased().contains(q) }
+        let buffers = all.filter { $0.name.lowercased().contains(q) }.map(Item.buffer)
+        let commands = CommandMatcher.rank(query: query, in: CommandRegistry.all)
+            .filter { CommandActions.isEnabled($0.id, appState) }
+            .map(Item.command)
+        return buffers + commands
     }
 
     var body: some View {
@@ -21,7 +41,7 @@ struct QuickSwitcher: View {
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
-                TextField("Switch to channel or DM…", text: $query)
+                TextField("Switch to channel — or type a command…", text: $query)
                     .textFieldStyle(.plain)
                     .font(.title3)
                     .focused($isFocused)
@@ -35,37 +55,14 @@ struct QuickSwitcher: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(results.enumerated()), id: \.element.id) { index, item in
-                        HStack(spacing: 10) {
-                            if item.isChannel {
-                                Image(systemName: "number")
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 20)
-                            } else {
-                                Circle()
-                                    .fill(appState.isNickOnline(item.name) ? .green : Color.secondary.opacity(0.3))
-                                    .frame(width: 10, height: 10)
-                                    .frame(width: 20)
+                        row(for: item)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(index == selectedIndex ? Color.accentColor.opacity(0.15) : .clear)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                activate(item)
                             }
-                            Text(item.name)
-                                .lineLimit(1)
-                            Spacer()
-                            if let unread = appState.unreadCounts[item.name.lowercased()], unread > 0 {
-                                Text("\(unread)")
-                                    .font(.caption2.weight(.bold))
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(Capsule().fill(.red))
-                            }
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(index == selectedIndex ? Color.accentColor.opacity(0.15) : .clear)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            appState.activeChannel = item.name
-                            dismiss()
-                        }
                     }
                 }
             }
@@ -93,9 +90,65 @@ struct QuickSwitcher: View {
         }
     }
 
+    @ViewBuilder
+    private func row(for item: Item) -> some View {
+        switch item {
+        case .buffer(let ch):
+            HStack(spacing: 10) {
+                if ch.isChannel {
+                    Image(systemName: "number")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20)
+                } else {
+                    Circle()
+                        .fill(appState.isNickOnline(ch.name) ? .green : Color.secondary.opacity(0.3))
+                        .frame(width: 10, height: 10)
+                        .frame(width: 20)
+                }
+                Text(ch.name)
+                    .lineLimit(1)
+                Spacer()
+                if let unread = appState.unreadCounts[ch.name.lowercased()], unread > 0 {
+                    Text("\(unread)")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(.red))
+                }
+            }
+        case .command(let cmd):
+            HStack(spacing: 10) {
+                Image(systemName: "command")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20)
+                Text(CommandActions.title(cmd.id, appState))
+                    .lineLimit(1)
+                Text(cmd.category)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                if let shortcut = cmd.shortcutLabel {
+                    Text(shortcut)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func activate(_ item: Item) {
+        switch item {
+        case .buffer(let ch):
+            appState.activeChannel = ch.name
+        case .command(let cmd):
+            CommandActions.run(cmd.id, appState)
+        }
+        dismiss()
+    }
+
     private func select() {
         guard selectedIndex < results.count else { return }
-        appState.activeChannel = results[selectedIndex].name
-        dismiss()
+        activate(results[selectedIndex])
     }
 }

--- a/freeq-macos/freeq-macos/freeq-macos.entitlements
+++ b/freeq-macos/freeq-macos/freeq-macos.entitlements
@@ -3,8 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>

--- a/freeq-macos/project.yml
+++ b/freeq-macos/project.yml
@@ -71,5 +71,14 @@ targets:
     entitlements:
       path: freeq-macos/freeq-macos.entitlements
       properties:
-        com.apple.security.app-sandbox: false
+        # Phase 1: sandbox ON (ADA/MAS prerequisite; late sandboxing would
+        # invalidate everything tested before it).
+        com.apple.security.app-sandbox: true
         com.apple.security.network.client: true
+        # iroh P2P listens for inbound peer connections.
+        com.apple.security.network.server: true
+        # AV calls + voice messages.
+        com.apple.security.device.camera: true
+        com.apple.security.device.audio-input: true
+        # Uploads via open panel / drag-drop; image "Save" via save panel.
+        com.apple.security.files.user-selected.read-write: true


### PR DESCRIPTION
Phase 1 of the App-of-the-Year plan: sandbox on, first (per §7.1 — late sandboxing invalidates everything tested before it).

## What
- **Entitlements**: `app-sandbox` on + `network.server` (iroh listener), `device.camera`, `device.audio-input`, `files.user-selected.read-write`
- **Keychain fallback**: under sandbox with an ad-hoc signature, the data-protection keychain returns `errSecMissingEntitlement` — session restore would silently break. Loads/saves now fall back to the legacy file-based keychain (loads try both stores). Signed builds never hit the fallback.
- **Store**: SQLite cache lands in the container automatically; deliberately no migration (server-recoverable, and a migration manifest would move files out from under running unsandboxed builds).
- **DebugBridge**: `#keychain` / `#storepath` sandbox probes.

## Verified live (sandboxed guest instance against irc.freeq.at)
- TLS connect, channel join, message send ✅
- SQLite store created inside `~/Library/Containers/at.freeq.macos/` ✅
- Keychain probe PASS via fallback (was FAIL before the fallback) ✅
- 199 SwiftPM tests green

## Known behavior changes for dev (ad-hoc) builds
- First sandboxed launch: message cache cold-starts once (refetched from server)
- Existing session token was written to the data-protection store by the unsandboxed build; the sandboxed ad-hoc build reads both stores, but if the data-protection store is entirely unavailable you'll sign in once
- Test-bridge command file must live inside the container (`~/Library/Containers/at.freeq.macos/Data/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcR5aCgXyQPGv9jsJyHXLS