### PR TITLE
Clients address and key DMs by DID

### DIFF
--- a/freeq-app/src/components/AuditTimeline.tsx
+++ b/freeq-app/src/components/AuditTimeline.tsx
@@ -3,6 +3,7 @@
  * Fetches from GET /api/v1/channels/{name}/audit
  */
 import { useEffect, useState } from 'react';
+import { displayNameForKey } from '../lib/display-name';
 
 interface AuditEvent {
   timestamp: string;
@@ -74,7 +75,7 @@ export function AuditTimeline({ channel, onClose }: AuditTimelineProps) {
         <div className="flex items-center gap-2">
           <span className="text-lg">📋</span>
           <span className="font-semibold text-fg">Audit Timeline</span>
-          <span className="text-sm text-fg-dim">{channel}</span>
+          <span className="text-sm text-fg-dim">{displayNameForKey(channel)}</span>
         </div>
         <button onClick={onClose} className="text-fg-dim hover:text-fg text-lg">✕</button>
       </div>

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo, type KeyboardEvent, 
 import { useStore } from '../store';
 import { sendMessage, sendReply, sendEdit, sendMarkdown, joinChannel, partChannel, setTopic, setMode, kickUser, inviteUser, setAway, rawCommand, sendWhois } from '../irc/client';
 import { detectStepUpRequired, requestStepUp } from '../lib/oauth-step-up';
+import { displayNameForKey } from '../lib/display-name';
 import { EmojiPicker, EMOJI_DATA } from './EmojiPicker';
 import { SlashCommands, getCommandCount } from './SlashCommands';
 import { FormatToolbar } from './FormatToolbar';
@@ -787,8 +788,8 @@ export function ComposeBox() {
                 : activeChannel === 'server'
                   ? 'Type /help for commands...'
                   : ch?.isEncrypted
-                    ? `🔒 Message ${ch?.name || activeChannel} (encrypted)`
-                    : `Message ${ch?.name || activeChannel}`
+                    ? `🔒 Message ${displayNameForKey(ch?.name || activeChannel)} (encrypted)`
+                    : `Message ${displayNameForKey(ch?.name || activeChannel)}`
             }
             rows={1}
             className="flex-1 bg-transparent px-3 py-2.5 text-base text-fg outline-none placeholder:text-fg-dim resize-none min-h-[44px] max-h-[200px] leading-relaxed"

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -776,7 +776,7 @@ export function ComposeBox() {
           <div className="flex items-end">
           <textarea
             data-testid="compose-input"
-            aria-label={`Message ${activeChannel}`}
+            aria-label={`Message ${displayNameForKey(activeChannel)}`}
             ref={inputRef}
             value={text}
             onChange={(e) => { setText(e.target.value); onInput(); }}

--- a/freeq-app/src/components/FileDropOverlay.tsx
+++ b/freeq-app/src/components/FileDropOverlay.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useStore } from '../store';
+import { displayNameForKey } from '../lib/display-name';
 import { showToast } from './Toast';
 
 export function FileDropOverlay() {
@@ -67,7 +68,7 @@ export function FileDropOverlay() {
             <path d="M20 16.7V19a2 2 0 01-2 2H6a2 2 0 01-2-2v-2.3" />
           </svg>
           <div className="text-xl font-bold text-accent">Drop file to upload</div>
-          <div className="text-sm text-fg-dim mt-1">to {activeChannel}</div>
+          <div className="text-sm text-fg-dim mt-1">to {displayNameForKey(activeChannel)}</div>
         </div>
       </div>
     </div>

--- a/freeq-app/src/components/MemberList.tsx
+++ b/freeq-app/src/components/MemberList.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import { useStore, type Member } from '../store';
 import { fetchProfile, getCachedProfile, type ATProfile } from '../lib/profiles';
 import { UserPopover } from './UserPopover';
-import { sendWhois } from '../irc/client';
+import { sendWhois, getClient } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { parseAwayStatus } from '../lib/status';
+import { isDid, resolveIdentityName, findMemberByKey } from '../lib/identity';
 import * as e2ee from '../lib/e2ee';
 
 const NICK_COLORS = [
@@ -114,33 +115,34 @@ export function MemberList() {
   );
 }
 
-/** Determine online/away status by checking shared channel member lists (not the DM member map) */
-function usePresence(nick: string): { online: boolean; away: string | null } {
+/** Determine online/away status by checking shared channel member lists (not
+ *  the DM member map). `key` is the DM thread key — a nick or a DID. */
+function usePresence(key: string): { online: boolean; away: string | null } {
   const channels = useStore((s) => s.channels);
-  const nickLower = nick.toLowerCase();
-  for (const [name, ch] of channels) {
-    if (!name.startsWith('#')) continue; // skip DM buffers
-    const member = ch.members.get(nickLower);
-    if (member) {
-      return { online: true, away: member.away ?? null };
-    }
-  }
-  return { online: false, away: null };
+  const hit = findMemberByKey(channels, key, true);
+  return { online: !!hit, away: hit?.member.away ?? null };
 }
 
 /** Rich profile panel shown in the right sidebar for DMs */
 function DMProfilePanel({ nick, channel }: { nick: string; channel: { members: Map<string, any>; isEncrypted?: boolean } }) {
+  // `nick` is the DM thread key — a nick, or the peer's DID once the thread is
+  // DID-keyed. Resolve it to a real nick for the lookups that need one (WHOIS
+  // is a nick command; a DID target would just fail).
+  const channels = useStore((s) => s.channels);
+  const peerNick = isDid(nick)
+    ? (findMemberByKey(channels, nick)?.nick ?? getClient()?.getNickForDid(nick))
+    : nick;
   const whoisCache = useStore((s) => s.whoisCache);
-  const whois = whoisCache.get(nick.toLowerCase());
+  const whois = peerNick ? whoisCache.get(peerNick.toLowerCase()) : undefined;
   const partnerMember = channel.members.values().next().value;
-  const did = partnerMember?.did || whois?.did;
+  const did = isDid(nick) ? nick : (partnerMember?.did || whois?.did);
   const [profile, setProfile] = useState<ATProfile | null>(null);
   const [safetyNumber, setSafetyNumber] = useState<string | null>(null);
   const presence = usePresence(nick);
 
   useEffect(() => {
-    sendWhois(nick);
-  }, [nick]);
+    if (peerNick) sendWhois(peerNick);
+  }, [peerNick]);
 
   useEffect(() => {
     if (did) {
@@ -154,7 +156,13 @@ function DMProfilePanel({ nick, channel }: { nick: string; channel: { members: M
     }
   }, [did]);
 
-  const displayName = profile?.displayName || whois?.realname || nick;
+  // Never show a raw DID as the peer's name: prefer a real name, else the
+  // resolved nick, and only compact the DID when nothing resolves.
+  const label = resolveIdentityName(nick, {
+    nickForDid: () => peerNick,
+    nameForDid: () => profile?.handle || profile?.displayName,
+  });
+  const displayName = profile?.displayName || whois?.realname || label;
   const handle = profile?.handle || whois?.handle;
   const avatarUrl = profile?.avatar;
 
@@ -205,8 +213,8 @@ function DMProfilePanel({ nick, channel }: { nick: string; channel: { members: M
       <div className="pt-2 px-4 pb-4 text-center">
         {/* Display name */}
         <div className="font-semibold text-fg text-base">{displayName}</div>
-        {displayName !== nick && (
-          <div className="text-sm text-fg-muted">{nick}</div>
+        {displayName !== label && (
+          <div className="text-sm text-fg-muted">{label}</div>
         )}
 
         {/* AT Handle — linked to Bluesky (not for did:key users) */}

--- a/freeq-app/src/components/MemberList.tsx
+++ b/freeq-app/src/components/MemberList.tsx
@@ -163,7 +163,10 @@ function DMProfilePanel({ nick, channel }: { nick: string; channel: { members: M
     nickForDid: () => peerNick,
     nameForDid: () => profile?.handle || profile?.displayName,
   });
-  const displayName = profile?.displayName || whois?.realname || label;
+  // Same guard as UserPopover: a realname whose first token is a DID is the
+  // server's "did:… (via S2S federation)" placeholder, not a human name.
+  const saneRealname = whois?.realname && !isDid(whois.realname.split(' ')[0]) ? whois.realname : undefined;
+  const displayName = profile?.displayName || saneRealname || label;
   const handle = profile?.handle || whois?.handle;
   const avatarUrl = profile?.avatar;
 

--- a/freeq-app/src/components/MemberList.tsx
+++ b/freeq-app/src/components/MemberList.tsx
@@ -6,6 +6,7 @@ import { sendWhois, getClient } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { parseAwayStatus } from '../lib/status';
 import { isDid, resolveIdentityName, findMemberByKey } from '../lib/identity';
+import { displayNameForKey } from '../lib/display-name';
 import * as e2ee from '../lib/e2ee';
 
 const NICK_COLORS = [
@@ -411,7 +412,7 @@ function MemberItem({ member, onClick, inCall }: MemberItemProps) {
         <span className={`truncate text-[15px] ${
           member.away ? 'text-fg-dim' : 'text-fg-muted group-hover:text-fg'
         }`}>
-          {member.nick}
+          {displayNameForKey(member.nick)}
         </span>
 
         {member.actorClass === 'agent' && (

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useCallback, useState, useMemo, memo } from 'react';
 import { useStore, uniqueMemberCount, type Message, type PinnedMessage } from '../store';
 import { getNick, requestHistory, sendReaction, sendUnreact, joinChannel } from '../irc/client';
 import { fetchProfile, getCachedProfile, type ATProfile } from '../lib/profiles';
+import { isDid } from '../lib/identity';
+import { displayNameForKey } from '../lib/display-name';
 import { EmojiPicker } from './EmojiPicker';
 import { UserPopover } from './UserPopover';
 import { BlueskyEmbed } from './BlueskyEmbed';
@@ -419,7 +421,7 @@ function MessageContentImpl({ msg, channel, onNickClick }: {
     const color = msg.isSelf ? '#b18cff' : nickColor(msg.from);
     return (
       <div className="text-fg-muted italic text-[15px] mt-0.5">
-        <span style={{ color }} className="font-semibold not-italic">{'* '}{msg.from}</span>{' '}{msg.text}
+        <span style={{ color }} className="font-semibold not-italic">{'* '}{displayNameForKey(msg.from)}</span>{' '}{msg.text}
       </div>
     );
   }
@@ -710,9 +712,10 @@ function FullMessageImpl({ msg, channel, onNickClick }: MessageProps) {
           <button
             className="font-semibold text-[15px] hover:underline"
             style={{ color }}
+            title={isDid(msg.from) ? msg.from : undefined}
             onClick={(e) => onNickClick(msg.from, member?.did, origin, e)}
           >
-            {msg.from}
+            {displayNameForKey(msg.from)}
           </button>
           {member?.did && !isFederated && <VerifiedBadge />}
           {isFederated && <ViaBadge origin={origin!} />}
@@ -1438,7 +1441,7 @@ export function MessageList() {
             {shouldShowDateSep(messages, i) && <DateSeparator date={msg.timestamp} />}
             {msg.deleted ? (
               <div className="px-4 py-0.5 text-xs italic text-[var(--text-muted)] opacity-50">
-                Message from {msg.from} deleted
+                Message from {displayNameForKey(msg.from)} deleted
               </div>
             ) : msg.isSystem ? (
               <SystemMessage msg={msg} />

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -1389,9 +1389,11 @@ export function MessageList() {
           ) : (
             <>
               <div className="text-3xl mb-2">💬</div>
-              <div className="text-xl text-fg font-bold">Conversation with {activeChannel}</div>
+              <div className="text-xl text-fg font-bold" title={isDid(activeChannel) ? activeChannel : undefined}>
+                Conversation with {displayNameForKey(activeChannel)}
+              </div>
               <div className="text-sm mt-2 text-center max-w-xs leading-relaxed text-fg-dim">
-                Direct messages are private between you and <span className="text-fg-muted">{activeChannel}</span>.
+                Direct messages are private between you and <span className="text-fg-muted">{displayNameForKey(activeChannel)}</span>.
               </div>
             </>
           )}

--- a/freeq-app/src/components/QuickSwitcher.tsx
+++ b/freeq-app/src/components/QuickSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useStore } from '../store';
 import { joinChannel } from '../irc/client';
+import { displayNameForKey } from '../lib/display-name';
 
 interface QuickSwitcherProps {
   open: boolean;
@@ -18,10 +19,11 @@ export function QuickSwitcher({ open, onClose }: QuickSwitcherProps) {
   const results = useMemo(() => {
     const items: { type: 'channel' | 'action'; name: string; label: string }[] = [];
 
-    // Joined channels
+    // Joined channels. `name` stays the real key we switch to; `label` is the
+    // human form, so a DID-keyed DM lists as a name not a raw did:… string.
     for (const ch of channels.values()) {
       if (ch.isJoined) {
-        items.push({ type: 'channel', name: ch.name, label: ch.name });
+        items.push({ type: 'channel', name: ch.name, label: displayNameForKey(ch.name) });
       }
     }
 

--- a/freeq-app/src/components/SettingsPanel.tsx
+++ b/freeq-app/src/components/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '../store';
+import { displayNameForKey } from '../lib/display-name';
 import { requestPermission } from '../lib/notifications';
 import { getPreferences, setPreferences } from '../lib/db';
 import { useState, useEffect } from 'react';
@@ -220,10 +221,13 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 }
 
 function BlockedUserRow({ id, mono, onUnblock }: { id: string; mono?: boolean; onUnblock: () => void }) {
+  // A DID entry resolves to the peer's known name where possible; the full
+  // DID stays one hover away (title) so the entry is still exact.
+  const label = displayNameForKey(id);
   return (
     <div className="flex items-center justify-between text-sm gap-2">
-      <span className={`text-fg truncate ${mono ? 'font-mono text-xs' : ''}`} title={id}>
-        {id}
+      <span className={`text-fg truncate ${mono && label === id ? 'font-mono text-xs' : ''}`} title={id}>
+        {label}
       </span>
       <button onClick={onUnblock} className="text-xs text-danger hover:underline shrink-0">
         Unblock

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -87,11 +87,15 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
     })
     // Most-recent conversation first (standard messenger order). The old
     // alphabetical-by-key sort produced arbitrary placement once thread keys
-    // could be DIDs. Threads with no messages yet sort last.
+    // could be DIDs. Skip system messages — the time label and preview do,
+    // and a fresh system line (join/quit/notice) must not bump a stale
+    // thread to the top. Threads with no real messages sort last.
     .sort((a, b) => {
-      const last = (ch: { messages: { timestamp: string | number | Date }[] }) => {
-        const m = ch.messages[ch.messages.length - 1];
-        return m ? new Date(m.timestamp).getTime() : 0;
+      const last = (ch: { messages: { timestamp: string | number | Date; isSystem?: boolean }[] }) => {
+        for (let i = ch.messages.length - 1; i >= 0; i--) {
+          if (!ch.messages[i].isSystem) return new Date(ch.messages[i].timestamp).getTime();
+        }
+        return 0;
       };
       return last(b) - last(a);
     });

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useStore } from '../store';
-import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick, getClient } from '../irc/client';
+import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { MicIcon, MicOffIcon, CameraOnIcon, CameraOffIcon, PhoneOffIcon } from './CallPanel';
 import { fetchProfile, getCachedProfile } from '../lib/profiles';
 import { parseAwayStatus } from '../lib/status';
-import { isDid, resolveIdentityName, findMemberByKey } from '../lib/identity';
+import { isDid, findMemberByKey } from '../lib/identity';
+import { displayNameForKey } from '../lib/display-name';
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -313,10 +314,7 @@ function ChannelButton({ ch, isActive, onSelect, icon, showPreview }: {
 
   // A DID-keyed DM resolves to a human name (learned nick → AT profile →
   // compact DID). Channels and nick DMs pass through unchanged.
-  const label = resolveIdentityName(ch.name, {
-    nickForDid: (did) => getClient()?.getNickForDid(did),
-    nameForDid: (did) => getCachedProfile(did)?.handle || getCachedProfile(did)?.displayName,
-  }).replace(/^[#&]/, '');
+  const label = displayNameForKey(ch.name).replace(/^[#&]/, '');
 
   return (
     <div data-channel-key={ch.name.toLowerCase()}>
@@ -346,7 +344,7 @@ function ChannelButton({ ch, isActive, onSelect, icon, showPreview }: {
       )}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1">
-          <span className="truncate text-[15px]">{label}</span>
+          <span className="truncate text-[15px]" title={isDid(ch.name) ? ch.name : undefined}>{label}</span>
           {(ch.isEncrypted || (!ch.name.startsWith('#') && ch.members.values().next().value?.did)) && (
             <span className="text-[10px] text-success shrink-0" title="End-to-end encrypted">🔒</span>
           )}

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -85,7 +85,16 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
       }
       return true;
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    // Most-recent conversation first (standard messenger order). The old
+    // alphabetical-by-key sort produced arbitrary placement once thread keys
+    // could be DIDs. Threads with no messages yet sort last.
+    .sort((a, b) => {
+      const last = (ch: { messages: { timestamp: string | number | Date }[] }) => {
+        const m = ch.messages[ch.messages.length - 1];
+        return m ? new Date(m.timestamp).getTime() : 0;
+      };
+      return last(b) - last(a);
+    });
 
   const handleJoin = () => {
     const ch = joinInput.trim();

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { SpeakerIcon } from './SessionIndicator';
 import { MicIcon, MicOffIcon, CameraOnIcon, CameraOffIcon, PhoneOffIcon } from './CallPanel';
 import { fetchProfile, getCachedProfile } from '../lib/profiles';
 import { parseAwayStatus } from '../lib/status';
-import { resolveIdentityName } from '../lib/identity';
+import { isDid, resolveIdentityName, findMemberByKey } from '../lib/identity';
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -577,15 +577,9 @@ function DmAvatar({ nick }: { nick: string }) {
   const channels = useStore((s) => s.channels);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
 
-  // Find DID for this nick across all channel member lists
-  const did = (() => {
-    const lower = nick.toLowerCase();
-    for (const ch of channels.values()) {
-      const m = ch.members.get(lower);
-      if (m?.did) return m.did;
-    }
-    return null;
-  })();
+  // The thread key is either the peer's DID already, or a nick we resolve to
+  // one via the channel member lists.
+  const did = isDid(nick) ? nick : (findMemberByKey(channels, nick)?.member.did ?? null);
 
   useEffect(() => {
     if (!did) { setAvatarUrl(null); return; }
@@ -612,11 +606,8 @@ function DmAvatar({ nick }: { nick: string }) {
  *  in any shared channel. Muted + truncated so it never crowds the row. */
 function DmStatusText({ nick }: { nick: string }) {
   const status = useStore((s) => {
-    for (const ch of s.channels.values()) {
-      const m = ch.members.get(nick.toLowerCase());
-      if (m) return parseAwayStatus(m.away);
-    }
-    return null;
+    const hit = findMemberByKey(s.channels, nick);
+    return hit ? parseAwayStatus(hit.member.away) : null;
   });
   if (!status) return null;
   return (
@@ -626,22 +617,18 @@ function DmStatusText({ nick }: { nick: string }) {
   );
 }
 
-/** Shows a green/yellow online dot for a DM contact. */
+/** Shows a green/yellow online dot for a DM contact. `nick` is the thread key
+ *  — a nick or a DID. */
 function OnlineDot({ nick }: { nick: string }) {
   const channels = useStore((s) => s.channels);
-  // Check if this nick is online in any shared channel
-  for (const [, ch] of channels) {
-    const member = ch.members.get(nick.toLowerCase());
-    if (member) {
-      const isAway = member.away != null;
-      return (
-        <span className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-bg-secondary ${
-          isAway ? 'bg-warning' : 'bg-success'
-        }`} />
-      );
-    }
-  }
-  return null;
+  const hit = findMemberByKey(channels, nick, true);
+  if (!hit) return null;
+  const isAway = hit.member.away != null;
+  return (
+    <span className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-bg-secondary ${
+      isAway ? 'bg-warning' : 'bg-success'
+    }`} />
+  );
 }
 
 function formatSidebarTime(d: Date): string {

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useStore } from '../store';
-import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick } from '../irc/client';
+import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick, getClient } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { MicIcon, MicOffIcon, CameraOnIcon, CameraOffIcon, PhoneOffIcon } from './CallPanel';
 import { fetchProfile, getCachedProfile } from '../lib/profiles';
@@ -72,6 +72,13 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
       const key = ch.name;
       if (isDid(key) && blockedDids.includes(key)) return false;
       if (blockedNicks.includes(key.toLowerCase())) return false;
+      if (isDid(key)) {
+        // A block recorded against the nick (peer was offline at block time,
+        // so no DID was resolvable) must still hide the DID-keyed thread —
+        // bridge through the SDK's retained DID→nick binding.
+        const peerNick = getClient()?.getNickForDid(key)?.toLowerCase();
+        if (peerNick && blockedNicks.includes(peerNick)) return false;
+      }
       if (blockedDids.length > 0) {
         const m = findMemberByKey(channels, key)?.member;
         if (m?.did && blockedDids.includes(m.did)) return false;

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useStore } from '../store';
-import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick } from '../irc/client';
+import { joinChannel, partChannel, disconnect, startAvSession, endAvSession, leaveAvSession, getNick, getClient } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { MicIcon, MicOffIcon, CameraOnIcon, CameraOffIcon, PhoneOffIcon } from './CallPanel';
 import { fetchProfile, getCachedProfile } from '../lib/profiles';
 import { parseAwayStatus } from '../lib/status';
+import { resolveIdentityName } from '../lib/identity';
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -308,6 +309,13 @@ function ChannelButton({ ch, isActive, onSelect, icon, showPreview }: {
   const preview = lastMsg ? `${lastMsg.from}: ${lastMsg.text}` : null;
   const lastTime = lastMsg ? formatSidebarTime(new Date(lastMsg.timestamp)) : null;
 
+  // A DID-keyed DM resolves to a human name (learned nick → AT profile →
+  // compact DID). Channels and nick DMs pass through unchanged.
+  const label = resolveIdentityName(ch.name, {
+    nickForDid: (did) => getClient()?.getNickForDid(did),
+    nameForDid: (did) => getCachedProfile(did)?.handle || getCachedProfile(did)?.displayName,
+  }).replace(/^[#&]/, '');
+
   return (
     <div data-channel-key={ch.name.toLowerCase()}>
     <button
@@ -336,7 +344,7 @@ function ChannelButton({ ch, isActive, onSelect, icon, showPreview }: {
       )}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1">
-          <span className="truncate text-[15px]">{ch.name.replace(/^[#&]/, '')}</span>
+          <span className="truncate text-[15px]">{label}</span>
           {(ch.isEncrypted || (!ch.name.startsWith('#') && ch.members.values().next().value?.did)) && (
             <span className="text-[10px] text-success shrink-0" title="End-to-end encrypted">🔒</span>
           )}

--- a/freeq-app/src/components/Sidebar.tsx
+++ b/freeq-app/src/components/Sidebar.tsx
@@ -64,14 +64,16 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
     .filter((ch) => !ch.name.startsWith('#') && !ch.name.startsWith('&') && ch.name !== 'server')
     .filter((ch) => !hiddenDMs.has(ch.name.toLowerCase()))
     .filter((ch) => {
-      // Hide conversations with blocked users (nick first, then DID via shared channels)
-      const lower = ch.name.toLowerCase();
-      if (blockedNicks.includes(lower)) return false;
+      // Hide conversations with blocked users. The thread key is a nick or a
+      // DID: check a DID key against blocked DIDs directly, a nick against
+      // blocked nicks, and finally the member record (found by either form)
+      // for its DID — a DID-keyed thread must not resurface a blocked user.
+      const key = ch.name;
+      if (isDid(key) && blockedDids.includes(key)) return false;
+      if (blockedNicks.includes(key.toLowerCase())) return false;
       if (blockedDids.length > 0) {
-        for (const c of channels.values()) {
-          const m = c.members.get(lower);
-          if (m?.did && blockedDids.includes(m.did)) return false;
-        }
+        const m = findMemberByKey(channels, key)?.member;
+        if (m?.did && blockedDids.includes(m.did)) return false;
       }
       return true;
     })

--- a/freeq-app/src/components/TopBar.tsx
+++ b/freeq-app/src/components/TopBar.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import type { AvParticipant } from '../store';
 import { useStore, uniqueMemberCount } from '../store';
-import { setTopic as sendTopic, startAvSession } from '../irc/client';
+import { setTopic as sendTopic, startAvSession, getClient } from '../irc/client';
 import { SpeakerIcon } from './SessionIndicator';
 import { fetchProfile, type ATProfile } from '../lib/profiles';
+import { isDid, resolveIdentityName } from '../lib/identity';
 
 interface TopBarProps {
   onToggleSidebar?: () => void;
@@ -27,9 +28,12 @@ export function TopBar({ onToggleSidebar, onToggleMembers, sidebarOpen, membersO
   const isDM = activeChannel !== 'server' && !activeChannel.startsWith('#');
   const setChannelSettings = useStore((s) => s.setChannelSettingsOpen);
 
-  // For DMs, resolve partner profile
+  // For DMs, resolve partner profile. A DID-keyed DM (the thread name IS the
+  // peer's DID) is its own partner DID even before we have a member row.
   const partnerWhois = isDM ? whoisCache.get(activeChannel.toLowerCase()) : undefined;
-  const partnerDid = isDM ? (ch?.members.values().next().value?.did || partnerWhois?.did) : undefined;
+  const partnerDid = isDM
+    ? (isDid(activeChannel) ? activeChannel : (ch?.members.values().next().value?.did || partnerWhois?.did))
+    : undefined;
   const [partnerProfileState, setPartnerProfileState] = useState<{ did: string; profile: ATProfile | null } | null>(null);
   useEffect(() => {
     if (!isDM || !partnerDid) return;
@@ -40,6 +44,14 @@ export function TopBar({ onToggleSidebar, onToggleMembers, sidebarOpen, membersO
     return () => { cancelled = true; };
   }, [isDM, partnerDid]);
   const partnerProfile = partnerProfileState && partnerProfileState.did === partnerDid ? partnerProfileState.profile : null;
+
+  // DM title: a DID-keyed thread resolves to a human name — the nick the SDK
+  // learned for the DID, then the AT profile, then a compact DID as last
+  // resort. A nick-keyed DM renders unchanged.
+  const dmTitle = resolveIdentityName(activeChannel, {
+    nickForDid: (did) => getClient()?.getNickForDid(did),
+    nameForDid: () => partnerProfile?.handle || partnerProfile?.displayName,
+  });
 
   const startEdit = () => {
     setTopicDraft(topic);
@@ -86,7 +98,7 @@ export function TopBar({ onToggleSidebar, onToggleMembers, sidebarOpen, membersO
         {isChannel && <span className="text-accent text-base font-bold shrink-0">#</span>}
         {isDM && <span className="text-fg-dim text-base shrink-0">💬</span>}
         <span className="font-bold text-base text-fg truncate">
-          {isChannel ? (ch?.name || activeChannel).replace(/^#/, '') : isDM ? activeChannel : 'Server'}
+          {isChannel ? (ch?.name || activeChannel).replace(/^#/, '') : isDM ? dmTitle : 'Server'}
         </span>
         {ch?.isEncrypted && (
           <span className="text-success text-xs shrink-0" title="End-to-end encrypted channel">🔒</span>

--- a/freeq-app/src/components/TopBar.tsx
+++ b/freeq-app/src/components/TopBar.tsx
@@ -97,7 +97,7 @@ export function TopBar({ onToggleSidebar, onToggleMembers, sidebarOpen, membersO
       <div className="flex items-center gap-2 min-w-0 shrink">
         {isChannel && <span className="text-accent text-base font-bold shrink-0">#</span>}
         {isDM && <span className="text-fg-dim text-base shrink-0">💬</span>}
-        <span className="font-bold text-base text-fg truncate">
+        <span className="font-bold text-base text-fg truncate" title={isDM && isDid(activeChannel) ? activeChannel : undefined}>
           {isChannel ? (ch?.name || activeChannel).replace(/^#/, '') : isDM ? dmTitle : 'Server'}
         </span>
         {ch?.isEncrypted && (

--- a/freeq-app/src/components/UserPopover.tsx
+++ b/freeq-app/src/components/UserPopover.tsx
@@ -6,6 +6,7 @@ import { sendWhois, getNick } from '../irc/client';
 import { REPORT_REASONS, reportUser } from '../lib/safety';
 import { parseAwayStatus } from '../lib/status';
 import { isDid } from '../lib/identity';
+import { displayNameForKey } from '../lib/display-name';
 import { showToast } from './Toast';
 import * as e2ee from '../lib/e2ee';
 
@@ -282,7 +283,7 @@ export function UserPopover({ nick, did, origin, position, onClose }: UserPopove
     zIndex: 100,
   };
 
-  const displayName = profile?.displayName || whois?.realname || nick;
+  const displayName = profile?.displayName || whois?.realname || displayNameForKey(nick);
   const handle = profile?.handle || whois?.handle;
   const avatarUrl = profile?.avatar;
 

--- a/freeq-app/src/components/UserPopover.tsx
+++ b/freeq-app/src/components/UserPopover.tsx
@@ -5,6 +5,7 @@ import { useStore } from '../store';
 import { sendWhois, getNick } from '../irc/client';
 import { REPORT_REASONS, reportUser } from '../lib/safety';
 import { parseAwayStatus } from '../lib/status';
+import { isDid } from '../lib/identity';
 import { showToast } from './Toast';
 import * as e2ee from '../lib/e2ee';
 
@@ -264,8 +265,12 @@ export function UserPopover({ nick, did, origin, position, onClose }: UserPopove
   }, [effectiveDid, nick]);
 
   const startDM = () => {
-    addChannel(nick);
-    setActive(nick);
+    // Open the thread under the same canonical key the SDK sends/echoes
+    // under — the peer's DID when we know it, else the nick. Opening by nick
+    // while the echo keys by DID would split one person into two threads.
+    const key = effectiveDid && isDid(effectiveDid) ? effectiveDid : nick;
+    addChannel(key);
+    setActive(key);
     onClose();
   };
 

--- a/freeq-app/src/components/UserPopover.tsx
+++ b/freeq-app/src/components/UserPopover.tsx
@@ -283,7 +283,10 @@ export function UserPopover({ nick, did, origin, position, onClose }: UserPopove
     zIndex: 100,
   };
 
-  const displayName = profile?.displayName || whois?.realname || displayNameForKey(nick);
+  // A realname whose first token is a DID is not a human name — the server
+  // sends "did:key:… (via S2S federation)" for remote users it can't name.
+  const saneRealname = whois?.realname && !isDid(whois.realname.split(' ')[0]) ? whois.realname : undefined;
+  const displayName = profile?.displayName || saneRealname || displayNameForKey(nick);
   const handle = profile?.handle || whois?.handle;
   const avatarUrl = profile?.avatar;
 

--- a/freeq-app/src/lib/display-name.ts
+++ b/freeq-app/src/lib/display-name.ts
@@ -1,0 +1,22 @@
+/** Wired identity display — the standard resolution sources in one place.
+ *
+ * `resolveIdentityName` in `./identity` stays pure (and unit-tested); this is
+ * the app-wired convenience that plugs in the two sources every surface uses:
+ * the SDK's learned nick↔DID map, then the cached AT profile. Use it anywhere
+ * a conversation/thread key is shown to a human, so a DID-keyed DM never
+ * renders as a raw `did:plc:…` / `did:key:…` string.
+ */
+import { getClient } from '../irc/client';
+import { getCachedProfile } from './profiles';
+import { resolveIdentityName } from './identity';
+
+/** Human label for a thread key or identifier that may be a raw DID. */
+export function displayNameForKey(key: string): string {
+  return resolveIdentityName(key, {
+    nickForDid: (did) => getClient()?.getNickForDid(did),
+    nameForDid: (did) => {
+      const p = getCachedProfile(did);
+      return p?.handle || p?.displayName;
+    },
+  });
+}

--- a/freeq-app/src/lib/identity.test.ts
+++ b/freeq-app/src/lib/identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isDid, shortenDid, resolveIdentityName } from './identity';
+import { isDid, shortenDid, resolveIdentityName, findMemberByKey } from './identity';
 
 describe('isDid', () => {
   it('recognizes DIDs and rejects nicks / partials', () => {
@@ -42,5 +42,37 @@ describe('resolveIdentityName', () => {
 
   it('compacts when there are no sources at all', () => {
     expect(resolveIdentityName(did)).toBe('plc:k2n3…t5j7');
+  });
+});
+
+describe('findMemberByKey', () => {
+  const bot = { did: 'did:key:z6MkBot', away: null };
+  const carol = { did: undefined, away: 'lunch' };
+  const channels = new Map([
+    ['#dev', { members: new Map([['didtestbot', bot], ['carol', carol]]) }],
+    // A DM buffer keyed by the peer's DID, holding its own member record.
+    ['did:key:z6mkbot', { members: new Map([['didtestbot', bot]]) }],
+  ]);
+
+  it('finds a peer by DID — the case a nick-keyed lookup misses', () => {
+    expect(findMemberByKey(channels, 'did:key:z6MkBot')?.nick).toBe('didtestbot');
+  });
+
+  it('finds a peer by nick, case-insensitively', () => {
+    expect(findMemberByKey(channels, 'DidTestBot')?.nick).toBe('didtestbot');
+    expect(findMemberByKey(channels, 'carol')?.member.away).toBe('lunch');
+  });
+
+  it('returns null for an unknown peer', () => {
+    expect(findMemberByKey(channels, 'did:plc:nobody')).toBeNull();
+    expect(findMemberByKey(channels, 'nobody')).toBeNull();
+  });
+
+  it('channelsOnly ignores DM buffers so they cannot answer for themselves', () => {
+    const dmOnly = new Map([
+      ['did:key:z6mkbot', { members: new Map([['didtestbot', bot]]) }],
+    ]);
+    expect(findMemberByKey(dmOnly, 'did:key:z6MkBot', true)).toBeNull();
+    expect(findMemberByKey(dmOnly, 'did:key:z6MkBot', false)?.nick).toBe('didtestbot');
   });
 });

--- a/freeq-app/src/lib/identity.test.ts
+++ b/freeq-app/src/lib/identity.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { isDid, shortenDid, resolveIdentityName } from './identity';
+
+describe('isDid', () => {
+  it('recognizes DIDs and rejects nicks / partials', () => {
+    expect(isDid('did:plc:k2n3e2vsihf3farequ44t5j7')).toBe(true);
+    expect(isDid('did:key:z6MkabcDEF')).toBe(true);
+    expect(isDid('alice')).toBe(false);
+    expect(isDid('did:plc:')).toBe(false);
+  });
+});
+
+describe('shortenDid', () => {
+  it('compacts a long DID head+tail; passes nicks through', () => {
+    expect(shortenDid('did:plc:k2n3e2vsihf3farequ44t5j7')).toBe('plc:k2n3…t5j7');
+    expect(shortenDid('bob')).toBe('bob');
+  });
+});
+
+describe('resolveIdentityName', () => {
+  const did = 'did:plc:k2n3e2vsihf3farequ44t5j7';
+
+  it('returns a plain nick unchanged', () => {
+    expect(resolveIdentityName('alice')).toBe('alice');
+  });
+
+  it('resolves a DID via the nick map first', () => {
+    expect(resolveIdentityName(did, { nickForDid: () => 'alice' })).toBe('alice');
+  });
+
+  it('falls to the profile name when no nick is known', () => {
+    expect(
+      resolveIdentityName(did, { nickForDid: () => undefined, nameForDid: () => 'Alice R.' }),
+    ).toBe('Alice R.');
+  });
+
+  it('skips DID-valued sources and compacts as the last resort', () => {
+    expect(
+      resolveIdentityName(did, { nickForDid: () => 'did:plc:other', nameForDid: () => null }),
+    ).toBe('plc:k2n3…t5j7');
+  });
+
+  it('compacts when there are no sources at all', () => {
+    expect(resolveIdentityName(did)).toBe('plc:k2n3…t5j7');
+  });
+});

--- a/freeq-app/src/lib/identity.ts
+++ b/freeq-app/src/lib/identity.ts
@@ -1,0 +1,46 @@
+/** Identity display for DM thread keys and message authors.
+ *
+ * With DIDs as the load-bearing identity, a DM thread is keyed by the peer's
+ * DID (see the SDK's `address.ts`), so the buffer name reaching the UI can be
+ * a raw `did:plc:…` / `did:key:…` string. These helpers turn that into a human
+ * name, resolving against data the client already holds and falling back to a
+ * compact form only when nothing resolves. Display-only — the raw DID stays
+ * the identity the app operates on (DMs, blocks, reports).
+ */
+
+/** A syntactic DID: `did:<method>:<id>`. No network, no `id` validation. */
+export function isDid(s: string): boolean {
+  return /^did:[a-z0-9]+:.+/i.test(s);
+}
+
+/** Compact a DID for display: `did:plc:k2n3…t5j7`. Non-DIDs pass through. */
+export function shortenDid(s: string): string {
+  if (!isDid(s)) return s;
+  const [, method, ...idParts] = s.split(':');
+  const id = idParts.join(':');
+  if (id.length <= 12) return `${method}:${id}`;
+  return `${method}:${id.slice(0, 4)}…${id.slice(-4)}`;
+}
+
+/**
+ * Human name for a DM thread key or author identifier that may be a raw DID.
+ * A non-DID (an ordinary nick) is returned unchanged. A DID is resolved
+ * through the provided sources in order — the SDK's learned nick↔DID map, then
+ * a cached AT profile handle/display name — and only compacted with
+ * `shortenDid` when every source misses. Sources that themselves return a DID
+ * (or nothing) are skipped, so we never present one DID in place of another.
+ */
+export function resolveIdentityName(
+  id: string,
+  sources: {
+    nickForDid?: (did: string) => string | undefined | null;
+    nameForDid?: (did: string) => string | undefined | null;
+  } = {},
+): string {
+  if (!isDid(id)) return id;
+  for (const src of [sources.nickForDid, sources.nameForDid]) {
+    const v = src?.(id);
+    if (v && !isDid(v)) return v;
+  }
+  return shortenDid(id);
+}

--- a/freeq-app/src/lib/identity.ts
+++ b/freeq-app/src/lib/identity.ts
@@ -44,3 +44,41 @@ export function resolveIdentityName(
   }
   return shortenDid(id);
 }
+
+interface MemberLike {
+  did?: string;
+  away?: string | null;
+}
+interface ChannelLike {
+  members: Map<string, MemberLike>;
+}
+
+/**
+ * Locate a DM peer's member record across channels, given a thread key that
+ * may be a **nick or a DID**. Members carry both, so match on whichever form
+ * the key takes — a DID-keyed DM would otherwise find nothing in the
+ * nick-keyed member maps, reporting a peer who is plainly online as offline.
+ *
+ * `channelsOnly` restricts the search to real channels (`#…`), which presence
+ * needs so a DM buffer's own member map can't answer for itself.
+ */
+export function findMemberByKey(
+  channels: Map<string, ChannelLike>,
+  key: string,
+  channelsOnly = false,
+): { nick: string; member: MemberLike } | null {
+  const byDid = isDid(key);
+  const lower = key.toLowerCase();
+  for (const [name, ch] of channels) {
+    if (channelsOnly && !name.startsWith('#')) continue;
+    if (byDid) {
+      for (const [nick, member] of ch.members) {
+        if (member.did === key) return { nick, member };
+      }
+    } else {
+      const member = ch.members.get(lower);
+      if (member) return { nick: lower, member };
+    }
+  }
+  return null;
+}

--- a/freeq-sdk-js/src/address.test.ts
+++ b/freeq-sdk-js/src/address.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isDid, dmPeerKey } from './address.js';
+
+describe('isDid', () => {
+  it('recognizes DIDs and rejects nicks / partials', () => {
+    expect(isDid('did:plc:k2n3e2vsihf3farequ44t5j7')).toBe(true);
+    expect(isDid('did:key:z6MkabcDEF')).toBe(true);
+    expect(isDid('did:web:example.com')).toBe(true);
+    expect(isDid('alice')).toBe(false);
+    expect(isDid('did:')).toBe(false);
+    expect(isDid('did:plc:')).toBe(false);
+    expect(isDid('#did:plc:x')).toBe(false);
+  });
+});
+
+describe('dmPeerKey', () => {
+  // The one rule applied to a DM peer everywhere it is referenced (wire
+  // target + local thread key): DID when known, else the input unchanged.
+  const resolver = (nick: string): string | undefined =>
+    ({ bob: 'did:plc:bob', alice: 'did:plc:alice' })[nick.toLowerCase()];
+
+  it('passes a DID through unchanged (idempotent — DID in, same DID out)', () => {
+    expect(dmPeerKey('did:plc:bob', resolver)).toBe('did:plc:bob');
+    // Idempotent even when the DID also has a nick mapped to it.
+    expect(dmPeerKey(dmPeerKey('bob', resolver), resolver)).toBe('did:plc:bob');
+  });
+
+  it('resolves a known nick to its DID so nick and DID collapse to one key', () => {
+    expect(dmPeerKey('bob', resolver)).toBe('did:plc:bob');
+    expect(dmPeerKey('bob', resolver)).toBe(dmPeerKey('did:plc:bob', resolver));
+  });
+
+  it('leaves an unknown nick (guest / unresolved / remote) unchanged', () => {
+    expect(dmPeerKey('carol', resolver)).toBe('carol');
+  });
+
+  it('does not lowercase or otherwise mangle a nick it cannot resolve', () => {
+    expect(dmPeerKey('Carol', resolver)).toBe('Carol');
+  });
+});

--- a/freeq-sdk-js/src/address.ts
+++ b/freeq-sdk-js/src/address.ts
@@ -1,0 +1,34 @@
+// DM addressing: one rule for referencing a direct-message peer.
+//
+// A DM peer can be named two ways — a nick ("bob") or a DID
+// ("did:plc:bob"). To make a DID the load-bearing identity, the same rule
+// is applied everywhere a DM references a peer — the wire target we send to
+// AND the local buffer/thread key we file under:
+//
+//   DID when we know it, else the input unchanged.
+//
+// Because it is idempotent (DID in → same DID out) and maps a known nick to
+// the same DID, "bob" and "did:plc:bob" collapse to one conversation instead
+// of splitting into two. An unknown nick — a guest, or a remote user this
+// client hasn't learned a DID for — passes through untouched, so nick
+// addressing keeps working exactly as before.
+//
+// Channels are never routed through this (callers guard on `#`/`&` first).
+
+/** A syntactic DID: `did:<method>:<id>`. No network, no `id` validation. */
+export function isDid(s: string): boolean {
+  return /^did:[a-z0-9]+:.+/i.test(s);
+}
+
+/**
+ * Canonical key for a DM peer: its DID when known, else the input unchanged.
+ * `resolve` maps a nick to its DID (undefined if unknown); a peer that is
+ * already a DID is returned as-is without consulting it.
+ */
+export function dmPeerKey(
+  peer: string,
+  resolve: (nick: string) => string | undefined,
+): string {
+  if (isDid(peer)) return peer;
+  return resolve(peer) ?? peer;
+}

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -285,6 +285,27 @@ describe('messaging methods', () => {
     expect(client.getDidForNick('bob')).toBe('did:plc:bob');
   });
 
+  it('does not split a DM thread when the peer DID is learned mid-conversation', async () => {
+    // Regression for the bug live-testing caught: a DM keyed under the peer's
+    // bare nick, then re-keyed to their DID once a WHOIS resolved it — two
+    // threads for one person. With the account tag on the message, the DID is
+    // known from message one, and an interleaved WHOIS must not fork a second
+    // thread. All messages from the peer stay under a single DID key.
+    const { client, ws } = await makeRegistered();
+    const threads: string[] = [];
+    client.on('message', (channel) => threads.push(channel));
+
+    ws.recv('@account=did:plc:bob :bob!b@freeq/plc/xx PRIVMSG alice :one');
+    await flushAsync();
+    // A redundant WHOIS DID numeric arrives later (same binding) …
+    ws.recv(':srv 330 alice bob did:plc:bob :is logged in as');
+    // … and a second DM follows.
+    ws.recv('@account=did:plc:bob :bob!b@freeq/plc/xx PRIVMSG alice :two');
+    await flushAsync();
+
+    expect([...new Set(threads)]).toEqual(['did:plc:bob']);
+  });
+
   it('sendReply() sets +reply tag', async () => {
     const { client, ws } = await makeRegistered();
     client.sendReply('#foo', 'msg123', 'replying');

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -285,6 +285,45 @@ describe('messaging methods', () => {
     expect(client.getDidForNick('bob')).toBe('did:plc:bob');
   });
 
+  it('TARGETS with freeq.at/partner-did keys the conversation by the DID', async () => {
+    // The server's conversation list carries each DM partner's DID as a tag.
+    // The client must key the conversation by that DID — emit it as the
+    // target, fetch history by it (the reply batch then arrives DID-keyed),
+    // and learn the display binding so the DID renders as a name at once.
+    const { client, ws } = await makeRegistered();
+    const targets: string[] = [];
+    client.on('historyTarget', (t) => targets.push(t));
+    ws.recv(
+      '@time=2026-07-16T21:12:22.000Z;freeq.at/partner-did=did:key:z6MkBot :srv CHATHISTORY TARGETS didtestbot',
+    );
+    await flushAsync();
+    expect(targets).toEqual(['did:key:z6MkBot']);
+    const fetch = ws.sent.find((l) => l.startsWith('CHATHISTORY LATEST'));
+    expect(fetch).toContain('did:key:z6MkBot');
+    expect(client.getNickForDid('did:key:z6MkBot')).toBe('didtestbot');
+  });
+
+  it('the TARGETS envelope batch does not emit an empty historyBatch', async () => {
+    const { client, ws } = await makeRegistered();
+    const batches: string[] = [];
+    client.on('historyBatch', (channel) => batches.push(channel));
+    ws.recv(':srv BATCH +cht1 draft/chathistory-targets');
+    ws.recv('@batch=cht1;freeq.at/partner-did=did:plc:bob :srv CHATHISTORY TARGETS bob');
+    ws.recv(':srv BATCH -cht1');
+    await flushAsync();
+    expect(batches).toEqual([]); // no ('', []) noise for the envelope
+  });
+
+  it('TARGETS without the tag (old server) keeps nick behavior unchanged', async () => {
+    const { client, ws } = await makeRegistered();
+    const targets: string[] = [];
+    client.on('historyTarget', (t) => targets.push(t));
+    ws.recv(':srv CHATHISTORY TARGETS bob');
+    await flushAsync();
+    expect(targets).toEqual(['bob']);
+    expect(ws.sent.find((l) => l.startsWith('CHATHISTORY LATEST'))).toContain('bob');
+  });
+
   it('does not split a DM thread when the peer DID is learned mid-conversation', async () => {
     // Regression for the bug live-testing caught: a DM keyed under the peer's
     // bare nick, then re-keyed to their DID once a WHOIS resolved it — two

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -967,6 +967,21 @@ describe('read markers (draft/read-marker)', () => {
     expect(reqLine).toBeDefined();
     expect(reqLine).toContain('draft/read-marker');
   });
+
+  it('requests account-tag so incoming DMs carry the sender DID', async () => {
+    // Without account-tag the server never stamps the sender's DID onto a DM,
+    // so a first DM from a peer we share no channel with keys under the bare
+    // nick and later splits when the DID is learned. account-tag closes that.
+    const { FreeqClient } = await import('./client.js');
+    const client = new FreeqClient({ url: 'wss://test/irc', nick: 'caps', skipInitialBrokerRefresh: true });
+    client.connect();
+    await flushAsync();
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1]!;
+    ws.recv(':srv CAP * LS :message-tags server-time account-notify account-tag');
+    await flushAsync();
+    const reqLine = ws.sent.find((l) => l.startsWith('CAP REQ'));
+    expect(reqLine).toContain('account-tag');
+  });
 });
 
 describe('inbound: identity and MOTD', () => {

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -468,7 +468,14 @@ describe('identity resolution', () => {
     expect(client.getNickForDid('did:plc:carol')).toBe('carol');
   });
 
-  it('cache is cleared on QUIT', async () => {
+  it('QUIT forgets nick→DID (addressing) but keeps DID→nick (display)', async () => {
+    // The two directions carry different risk. A released nick can be
+    // recycled by someone else, so addressing must forget it. A DID is
+    // permanent and the reverse map is display-only, so keeping it lets an
+    // offline peer still render as a name rather than a raw did:… string —
+    // which is exactly when we need it (the "is offline" notice, a DM title
+    // for a peer who logged off). A rename overwrites it on the next
+    // JOIN/WHOIS, so it cannot drift silently.
     const { client, ws } = await makeRegistered();
     ws.recv(':srv 330 alice dave did:plc:dave :is authenticated as');
     await flushAsync();
@@ -476,7 +483,7 @@ describe('identity resolution', () => {
     ws.recv(':dave!user@host QUIT :goodbye');
     await flushAsync();
     expect(client.getDidForNick('dave')).toBeUndefined();
-    expect(client.getNickForDid('did:plc:dave')).toBeUndefined();
+    expect(client.getNickForDid('did:plc:dave')).toBe('dave');
   });
 });
 

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -231,6 +231,60 @@ describe('messaging methods', () => {
     expect(seen.length).toBe(1);
   });
 
+  // ── DID-addressed DMs ──────────────────────────────────────────────
+  // A DM to a peer whose DID we know goes out addressed to the DID, and the
+  // local thread is keyed by that DID — so the same conversation reaches the
+  // right identity on any server and never splits between nick and DID.
+
+  it('sendMessage() to a known-DID nick addresses the DID on the wire', async () => {
+    const { client, ws } = await makeRegistered();
+    client.nickToDid = (n) => (n.toLowerCase() === 'bob' ? 'did:plc:bob' : undefined);
+    client.sendMessage('bob', 'hi bob');
+    await flushAsync();
+    const line = ws.sent.find((l) => l.includes('PRIVMSG'));
+    expect(line).toMatch(/PRIVMSG did:plc:bob :hi bob/);
+  });
+
+  it('sendMessage() to an unknown nick addresses the nick unchanged', async () => {
+    const { client, ws } = await makeRegistered();
+    client.nickToDid = () => undefined; // guest / unresolved peer
+    client.sendMessage('carol', 'hi carol');
+    await flushAsync();
+    const line = ws.sent.find((l) => l.includes('PRIVMSG'));
+    expect(line).toMatch(/PRIVMSG carol :hi carol/);
+  });
+
+  it('sendMessage() addressed directly to a DID passes it through', async () => {
+    const { client, ws } = await makeRegistered();
+    client.sendMessage('did:plc:bob', 'hi by did');
+    await flushAsync();
+    const line = ws.sent.find((l) => l.includes('PRIVMSG'));
+    expect(line).toMatch(/PRIVMSG did:plc:bob :hi by did/);
+  });
+
+  it('local echo of a known-DID DM is keyed under the DID (one thread)', async () => {
+    const { client } = await makeRegistered();
+    client.nickToDid = (n) => (n.toLowerCase() === 'bob' ? 'did:plc:bob' : undefined);
+    const seen: string[] = [];
+    client.on('message', (channel) => seen.push(channel));
+    client.sendMessage('bob', 'hi');
+    expect(seen).toEqual(['did:plc:bob']);
+  });
+
+  it('an incoming DM keys under the sender DID learned from its account tag', async () => {
+    // We share no channel with bob, so no JOIN/WHOIS taught us his DID. His
+    // message's account tag must still key the thread under his DID — the
+    // same key our own sends to him use — so the conversation is one thread.
+    const { client, ws } = await makeRegistered();
+    const seen: string[] = [];
+    client.on('message', (channel) => seen.push(channel));
+    ws.recv('@account=did:plc:bob :bob!b@freeq/plc/xx PRIVMSG alice :hey there');
+    await flushAsync();
+    expect(seen).toEqual(['did:plc:bob']);
+    // And a later reply from us now resolves bob → same DID key.
+    expect(client.getDidForNick('bob')).toBe('did:plc:bob');
+  });
+
   it('sendReply() sets +reply tag', async () => {
     const { client, ws } = await makeRegistered();
     client.sendReply('#foo', 'msg123', 'replying');

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -1994,6 +1994,11 @@ export class FreeqClient extends EventEmitter {
               // emit a single `message` event (or push into a parent
               // batch if this was nested).
               await this.dispatchAssembledMultiline(batch);
+            } else if (batch.type === 'draft/chathistory-targets') {
+              // The TARGETS list envelope: its lines are CHATHISTORY
+              // TARGETS commands, each already handled individually, and it
+              // has no target of its own — emitting it as a historyBatch
+              // handed the app a meaningless ('', []) every login.
             } else {
               this.emit('historyBatch', batch.target, batch.messages);
             }
@@ -2005,14 +2010,30 @@ export class FreeqClient extends EventEmitter {
       case 'CHATHISTORY': {
         const sub = msg.params[0];
         if (sub === 'TARGETS' && msg.params[1]) {
-          const targetNick = msg.params[1];
+          const displayNick = msg.params[1];
           const timestamp = msg.params[2] || undefined;
+          // The server names the conversation partner's identity in the
+          // `freeq.at/partner-did` tag; the param is only a display nick
+          // (possibly historical — offline peers, renames). Key the
+          // conversation by the DID when present: emit it as the target and
+          // fetch history by it, so the reply batch (whose target echoes the
+          // request) is DID-keyed too — live messages and replay then agree
+          // on what a conversation is. Absent tag (older server) → nick
+          // behavior, unchanged.
+          const partnerDid = msg.tags['freeq.at/partner-did'];
+          const key = partnerDid && isDid(partnerDid) ? partnerDid : displayNick;
+          if (key !== displayNick) {
+            // Learn the display direction only (DID→nick): the nick may be
+            // historical, so binding it for addressing (nick→DID) could
+            // route a fresh nick owner's messages to the old identity.
+            this._didToNick.set(key, displayNick.toLowerCase());
+          }
           // Canonical event name (renamed from `dmTarget` — CHATHISTORY
           // TARGETS returns channels too, not just DMs).
-          this.emit('historyTarget', targetNick, timestamp);
+          this.emit('historyTarget', key, timestamp);
           // Deprecated alias — kept for one release for backwards compat.
-          this.emit('dmTarget', targetNick);
-          this.requestHistory({ target: targetNick, mode: 'latest' });
+          this.emit('dmTarget', key);
+          this.requestHistory({ target: key, mode: 'latest' });
         }
         break;
       }

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -2223,7 +2223,7 @@ export class FreeqClient extends EventEmitter {
       const wantedCaps: string[] = [];
       const caps = [
         'message-tags', 'server-time', 'batch', 'multi-prefix',
-        'echo-message', 'account-notify', 'extended-join', 'away-notify',
+        'echo-message', 'account-notify', 'account-tag', 'extended-join', 'away-notify',
         'draft/chathistory', 'draft/multiline', 'draft/read-marker',
       ];
       for (const c of caps) {

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -12,6 +12,7 @@ import { parse, prefixNick, format } from './parser.js';
 import { Transport } from './transport.js';
 import * as signing from './signing.js';
 import * as e2ee from './e2ee.js';
+import { dmPeerKey, isDid } from './address.js';
 import { prefetchProfiles } from './profiles.js';
 import type {
   IRCMessage, Message, Member, AvSession, AvParticipant,
@@ -312,6 +313,12 @@ export class FreeqClient extends EventEmitter {
   ): string | null {
     const isChannel = target.startsWith('#') || target.startsWith('&');
 
+    // Wire target + local buffer key for a DM: the peer's DID when known,
+    // else the nick unchanged. `target` stays the caller's input for E2EE
+    // peer resolution; `wireTarget` is what we address, sign over, and key
+    // the thread under. For a channel the two are identical.
+    const wireTarget = isChannel ? target : this.dmKey(target);
+
     // +E channels require the `+encrypted` tag on every PRIVMSG —
     // refuse rather than leak plaintext into a room the rest of the
     // members expect encrypted.
@@ -335,11 +342,11 @@ export class FreeqClient extends EventEmitter {
 
     const willEncrypt =
       e2ee.hasChannelKey(target) ||
-      (!isChannel && e2ee.isE2eeReady() && !!this.didForNick(target));
+      (!isChannel && e2ee.isE2eeReady() && !!this.remoteDidFor(target));
 
     // ── E2EE path ──
     if (willEncrypt) {
-      const remoteDid = !isChannel ? this.didForNick(target) : null;
+      const remoteDid = !isChannel ? this.remoteDidFor(target) : null;
       const encryptFn = isChannel
         ? () => e2ee.encryptChannel(target, text)
         : () => e2ee.encryptMessage(remoteDid!, text, this.serverOrigin);
@@ -347,7 +354,7 @@ export class FreeqClient extends EventEmitter {
       encryptFn().then((encrypted) => {
         if (!encrypted) {
           // Encryption failed — fall back to signed plaintext
-          this.sendLegacyPlaintext(target, text, extraOpenerTags);
+          this.sendLegacyPlaintext(wireTarget, text, extraOpenerTags);
           return;
         }
         this.cacheEchoPlaintext(encrypted, text);
@@ -357,7 +364,7 @@ export class FreeqClient extends EventEmitter {
             '+encrypted': '',
             ...extraOpenerTags,
           };
-          this.raw(format('PRIVMSG', [target, encrypted], tags));
+          this.raw(format('PRIVMSG', [wireTarget, encrypted], tags));
         } else {
           // Ciphertext too big → chunk across a multiline BATCH with
           // concat=true. Receiver concatenates fragments and decrypts once.
@@ -365,15 +372,15 @@ export class FreeqClient extends EventEmitter {
           if (chunks.length > this.multilineMaxLines) {
             this.emit(
               'systemMessage',
-              target,
+              wireTarget,
               `Message too large to send: ciphertext exceeds server multiline limit (${this.multilineMaxLines} lines).`,
             );
             return;
           }
-          this.emitMultilineBatch(target, chunks, extraOpenerTags, { '+encrypted': '' });
+          this.emitMultilineBatch(wireTarget, chunks, extraOpenerTags, { '+encrypted': '' });
         }
       });
-      this.maybeLocalEcho(target, text, willEncrypt);
+      this.maybeLocalEcho(wireTarget, text, willEncrypt);
       return null; // Async; can't return batch id meaningfully here
     }
 
@@ -400,12 +407,12 @@ export class FreeqClient extends EventEmitter {
         // text) and reads `+freeq.at/sig` from the opener tags. Per-batch
         // signing keeps each emitted message independently verifiable.
         const body = this.assembleMultiline(group);
-        signing.signMessage(target, body).then((sig) => {
+        signing.signMessage(wireTarget, body).then((sig) => {
           const openerTagsWithSig: Record<string, string> = { ...extraOpenerTags };
           if (sig) openerTagsWithSig['+freeq.at/sig'] = sig;
-          this.emitMultilineBatch(target, group, openerTagsWithSig);
+          this.emitMultilineBatch(wireTarget, group, openerTagsWithSig);
         });
-        this.maybeLocalEcho(target, body, willEncrypt);
+        this.maybeLocalEcho(wireTarget, body, willEncrypt);
       }
       // Async signing — batch id isn't synchronously available.
       return null;
@@ -413,8 +420,8 @@ export class FreeqClient extends EventEmitter {
 
     // Fits in one PRIVMSG (or no multiline cap) → single PRIVMSG. Legacy path
     // preserves \n escaping + +freeq.at/multiline for receivers that decode it.
-    this.sendLegacyPlaintext(target, text, extraOpenerTags);
-    this.maybeLocalEcho(target, text, willEncrypt);
+    this.sendLegacyPlaintext(wireTarget, text, extraOpenerTags);
+    this.maybeLocalEcho(wireTarget, text, willEncrypt);
     return null;
   }
 
@@ -904,6 +911,36 @@ export class FreeqClient extends EventEmitter {
     return this._nickToDid.get(targetNick.toLowerCase()) ?? this.nickToDid?.(targetNick);
   }
 
+  /**
+   * Canonical DM identity for a peer — its DID when known, else the peer
+   * unchanged (see `address.ts`). Used as BOTH the wire target we address and
+   * the local buffer key we file under, so "bob" and "did:plc:bob" are one
+   * conversation and a DID-addressed DM reaches the right identity on any
+   * server. A guest / unresolved nick passes through, so nick DMs are intact.
+   */
+  private dmKey(peer: string): string {
+    return dmPeerKey(peer, (n) => this.didForNick(n));
+  }
+
+  /** The recipient DID for a DM target that may be a nick or already a DID. */
+  private remoteDidFor(target: string): string | undefined {
+    return isDid(target) ? target : this.didForNick(target);
+  }
+
+  /**
+   * Learn a sender's nick↔DID binding from an inbound message's `account`
+   * tag. Without this, the first DM from a peer we share no channel with (so
+   * no JOIN/WHOIS taught us their DID) would key under the bare nick while
+   * our own sends key under the DID — splitting one conversation in two.
+   */
+  private rememberSenderDid(from: string, tags?: Record<string, string>): void {
+    const did = tags?.['+freeq.at/account'] ?? tags?.['account'];
+    if (!did || !isDid(did) || !from || from.startsWith('#') || from.startsWith('&')) return;
+    const lc = from.toLowerCase();
+    this._nickToDid.set(lc, did);
+    this._didToNick.set(did, lc);
+  }
+
   /** Resolve nick to DID — set by the app layer for E2EE support. */
   nickToDid: ((nick: string) => string | undefined) | null = null;
 
@@ -1054,7 +1091,11 @@ export class FreeqClient extends EventEmitter {
     const target = batch.target;
     const isChannel = target.startsWith('#') || target.startsWith('&');
     const isSelf = this.isSelfSender(from, openerTags);
-    const bufName = isChannel ? target : (isSelf ? target : from);
+    if (!isChannel && !isSelf) this.rememberSenderDid(from, openerTags);
+    // DM thread key = the peer's canonical DID when known (else the nick):
+    // our own echo is keyed by the wire target, an incoming DM by the sender,
+    // and both collapse to the same DID so a conversation is never split.
+    const bufName = isChannel ? target : this.dmKey(isSelf ? target : from);
 
     const wireText = this.assembleMultiline(lines);
 
@@ -1508,7 +1549,12 @@ export class FreeqClient extends EventEmitter {
         const isAction = text.startsWith('\x01ACTION ') && text.endsWith('\x01');
         const isChannel = target.startsWith('#') || target.startsWith('&');
         const isSelf = this.isSelfSender(from, msg.tags);
-        const bufName = isChannel ? target : (isSelf ? target : from);
+        if (!isChannel && !isSelf) this.rememberSenderDid(from, msg.tags);
+        // DM thread key = the peer's canonical DID when known (else the nick):
+        // our own echo is keyed by the wire target, an incoming DM by the
+        // sender, and both collapse to the same DID so a conversation is
+        // never split.
+        const bufName = isChannel ? target : this.dmKey(isSelf ? target : from);
 
         // If this PRIVMSG is a chunk of an open `draft/multiline` batch,
         // accumulate it raw and defer ALL processing (decryption,
@@ -1694,7 +1740,12 @@ export class FreeqClient extends EventEmitter {
         const target = msg.params[0];
         const isChannel = target.startsWith('#') || target.startsWith('&');
         const isSelf = this.isSelfSender(from, msg.tags);
-        const bufName = isChannel ? target : (isSelf ? target : from);
+        if (!isChannel && !isSelf) this.rememberSenderDid(from, msg.tags);
+        // DM thread key = the peer's canonical DID when known (else the nick):
+        // our own echo is keyed by the wire target, an incoming DM by the
+        // sender, and both collapse to the same DID so a conversation is
+        // never split.
+        const bufName = isChannel ? target : this.dmKey(isSelf ? target : from);
 
         const deleteOf = msg.tags['+draft/delete'];
         if (deleteOf) { this.emit('messageDeleted', bufName, deleteOf); break; }

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -1520,11 +1520,12 @@ export class FreeqClient extends EventEmitter {
         if (msg.prefix.includes('!spawn@freeq/spawn')) {
           this.emit('agentDespawned', { nick: from, reason: reason || undefined });
         }
-        // Forget any cached DID binding for this nick.
-        const lc = from.toLowerCase();
-        const did = this._nickToDid.get(lc);
-        this._nickToDid.delete(lc);
-        if (did) this._didToNick.delete(did);
+        // Forget the nick→DID binding: a released nick can be recycled by
+        // someone else, and addressing must never follow a stale one. Keep
+        // did→nick — a DID is permanent and that direction is display-only,
+        // so an offline peer still shows a name instead of a raw did:… string
+        // (a rename overwrites it on the next JOIN/WHOIS).
+        this._nickToDid.delete(from.toLowerCase());
         break;
       }
 

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -2025,9 +2025,15 @@ export class FreeqClient extends EventEmitter {
 
       // Error numerics
       case '401': {
-        const failNick = msg.params[1];
-        this.emit('systemMessage', failNick || 'server',
-          `${failNick} is offline — message saved, they'll see it next time they connect`);
+        const failTarget = msg.params[1];
+        // The target may be a DID (a DID-addressed DM); show a name rather
+        // than a raw did:… string. The buffer key stays the target itself,
+        // so the notice lands in that conversation.
+        const shown = failTarget && isDid(failTarget)
+          ? (this.getNickForDid(failTarget) ?? failTarget)
+          : failTarget;
+        this.emit('systemMessage', failTarget || 'server',
+          `${shown} is offline — message saved, they'll see it next time they connect`);
         break;
       }
       case '404':


### PR DESCRIPTION
# Clients address and key DMs by DID

Builds on #54, which made the server route `did:` message targets and persist
DMs under the participants' DIDs. This is the client half: the JS SDK and the
web app now *use* those rails, so a direct-message conversation is identified
by the other person's permanent DID rather than their per-server nickname —
while everything a human sees remains a name.

## What changes in practice

- **Sending:** a DM to a peer whose DID is known goes out as `PRIVMSG did:plc:x`
  (and the message signature covers that target). Unknown/guest peers keep
  plain nick addressing, unchanged.
- **One person, one thread.** The conversation is keyed by the peer's DID on
  both ends of the lifecycle: live messages and reloaded history agree, so a
  rename, a reconnect, or a page refresh can no longer split a conversation
  into a nick thread and a DID thread. The server's conversation list already
  carries each partner's DID (`freeq.at/partner-did` tag, merged in 40aab578);
  the SDK keys threads from it and fetches history by DID. Against a server
  that doesn't send the tag, the client falls back to nick keying — today's
  behavior, byte for byte.
- **Names everywhere, identity one hover away.** Every surface that shows a
  thread key or identifier resolves DIDs to a name (learned nick → cached
  AT profile → compact `plc:xxxx…yyyy` as last resort): titles, sidebar,
  quick switcher, composer placeholder, empty-thread hero, user cards,
  member rows, message authors, audit header, file-drop overlay, and the
  blocked-users list in Settings. Where a shortened form appears, the full
  DID is available via hover. User cards additionally reject DID-shaped
  WHOIS realnames (the server sends `did:… (via S2S federation)` for remote
  users it can't name; that server-side half is a separate follow-up).
- **Blocking works on DID-keyed threads**, including the corner where the
  peer was offline at block time (block recorded by nick, thread keyed by
  DID — bridged through the SDK's retained DID→nick binding).
- **DM list sorts by most-recent message** (the old alphabetical-by-key sort
  became arbitrary once keys can be DIDs), ignoring system lines.
- The SDK also now negotiates `account-tag`, so incoming DMs carry the
  sender's DID; without it, a first DM from a peer with no shared channel
  keyed by nick and later re-keyed — the split this PR exists to prevent.

## Compatibility / deploy

- **Old clients:** unaffected. The conversation-list tag is invisible to
  them; nick DMs behave exactly as before (unit- and browser-verified).
- **Servers:** no server changes in this PR; the one prerequisite commit
  (40aab578) is already on main. Deploy order note: build/deploy the server
  before or with the web client — a new client against a pre-40aab578 server
  degrades to nick-keyed threads (correct), but mixes DID-keyed live traffic
  with nick-keyed replay, which can show a conversation twice until the
  server catches up. No data loss; self-heals on the next server deploy.
- **Native apps:** untouched (Rust SDK unchanged); they keep today's
  behavior on every server and get their own pass later.

## Testing

- SDK: 212 unit tests, including regression guards for the two real bugs
  found while building this — the mid-conversation re-key split, and losing
  the DID→nick display binding on QUIT (offline peers degrading to raw DIDs).
- App: identity/display primitives unit-tested; full suite green apart from
  4 pre-existing AV-test failures that exist on main (unrelated, noted for
  transparency).
- Live verification against a running server: scripted wire test covering
  DID-addressed delivery to multiple devices, nick fallback, echo keying,
  and a full reload (fresh session reassembles one DID-keyed thread from
  TARGETS + history) — plus a manual browser pass covering the DM lifecycle,
  offline/blocking flows, and a cross-server DM round-trip (peer connected
  to the other production server, echo landing in the same thread, trust
  banner shown for the relayed identity).

## Next

The native clients (iOS / Android / macOS) are the follow-on: the same
addressing and rendering pass, with the thread-keying logic landing once in
the Rust SDK that all three share. Until then they keep today's behavior on
every server.
