### PR TITLE
Rust SDK + Android: DID-keyed DM conversations

### DIFF
--- a/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
@@ -3362,7 +3362,8 @@ data class IrcMessage (
     var `timestampMs`: kotlin.Long, 
     var `account`: kotlin.String?, 
     var `origin`: kotlin.String?, 
-    var `reactions`: List<ReactionTally>
+    var `reactions`: List<ReactionTally>, 
+    var `dmKey`: kotlin.String?
 ) {
     
     companion object
@@ -3390,6 +3391,7 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalString.read(buf),
             FfiConverterSequenceTypeReactionTally.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -3409,7 +3411,8 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterLong.allocationSize(value.`timestampMs`) +
             FfiConverterOptionalString.allocationSize(value.`account`) +
             FfiConverterOptionalString.allocationSize(value.`origin`) +
-            FfiConverterSequenceTypeReactionTally.allocationSize(value.`reactions`)
+            FfiConverterSequenceTypeReactionTally.allocationSize(value.`reactions`) +
+            FfiConverterOptionalString.allocationSize(value.`dmKey`)
     )
 
     override fun write(value: IrcMessage, buf: ByteBuffer) {
@@ -3429,6 +3432,7 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterOptionalString.write(value.`account`, buf)
             FfiConverterOptionalString.write(value.`origin`, buf)
             FfiConverterSequenceTypeReactionTally.write(value.`reactions`, buf)
+            FfiConverterOptionalString.write(value.`dmKey`, buf)
     }
 }
 
@@ -3569,7 +3573,8 @@ public object FfiConverterTypeTagEntry: FfiConverterRustBuffer<TagEntry> {
 data class TagMessage (
     var `from`: kotlin.String, 
     var `target`: kotlin.String, 
-    var `tags`: List<TagEntry>
+    var `tags`: List<TagEntry>, 
+    var `dmKey`: kotlin.String?
 ) {
     
     companion object
@@ -3584,19 +3589,22 @@ public object FfiConverterTypeTagMessage: FfiConverterRustBuffer<TagMessage> {
             FfiConverterString.read(buf),
             FfiConverterString.read(buf),
             FfiConverterSequenceTypeTagEntry.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
     override fun allocationSize(value: TagMessage) = (
             FfiConverterString.allocationSize(value.`from`) +
             FfiConverterString.allocationSize(value.`target`) +
-            FfiConverterSequenceTypeTagEntry.allocationSize(value.`tags`)
+            FfiConverterSequenceTypeTagEntry.allocationSize(value.`tags`) +
+            FfiConverterOptionalString.allocationSize(value.`dmKey`)
     )
 
     override fun write(value: TagMessage, buf: ByteBuffer) {
             FfiConverterString.write(value.`from`, buf)
             FfiConverterString.write(value.`target`, buf)
             FfiConverterSequenceTypeTagEntry.write(value.`tags`, buf)
+            FfiConverterOptionalString.write(value.`dmKey`, buf)
     }
 }
 
@@ -3613,12 +3621,14 @@ sealed class AvEvent {
     }
     
     data class ParticipantJoined(
-        val `nick`: kotlin.String) : AvEvent() {
+        val `nick`: kotlin.String, 
+        val `instance`: kotlin.String) : AvEvent() {
         companion object
     }
     
     data class ParticipantLeft(
-        val `nick`: kotlin.String) : AvEvent() {
+        val `nick`: kotlin.String, 
+        val `instance`: kotlin.String) : AvEvent() {
         companion object
     }
     
@@ -3704,8 +3714,10 @@ public object FfiConverterTypeAvEvent : FfiConverterRustBuffer<AvEvent>{
                 )
             3 -> AvEvent.ParticipantJoined(
                 FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
                 )
             4 -> AvEvent.ParticipantLeft(
+                FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
             5 -> AvEvent.AudioTrackStarted(
@@ -3772,6 +3784,7 @@ public object FfiConverterTypeAvEvent : FfiConverterRustBuffer<AvEvent>{
             (
                 4UL
                 + FfiConverterString.allocationSize(value.`nick`)
+                + FfiConverterString.allocationSize(value.`instance`)
             )
         }
         is AvEvent.ParticipantLeft -> {
@@ -3779,6 +3792,7 @@ public object FfiConverterTypeAvEvent : FfiConverterRustBuffer<AvEvent>{
             (
                 4UL
                 + FfiConverterString.allocationSize(value.`nick`)
+                + FfiConverterString.allocationSize(value.`instance`)
             )
         }
         is AvEvent.AudioTrackStarted -> {
@@ -3887,11 +3901,13 @@ public object FfiConverterTypeAvEvent : FfiConverterRustBuffer<AvEvent>{
             is AvEvent.ParticipantJoined -> {
                 buf.putInt(3)
                 FfiConverterString.write(value.`nick`, buf)
+                FfiConverterString.write(value.`instance`, buf)
                 Unit
             }
             is AvEvent.ParticipantLeft -> {
                 buf.putInt(4)
                 FfiConverterString.write(value.`nick`, buf)
+                FfiConverterString.write(value.`instance`, buf)
                 Unit
             }
             is AvEvent.AudioTrackStarted -> {
@@ -4133,7 +4149,14 @@ sealed class FreeqEvent {
     
     data class ChatHistoryTarget(
         val `nick`: kotlin.String, 
-        val `timestamp`: kotlin.String?) : FreeqEvent() {
+        val `timestamp`: kotlin.String?, 
+        val `partnerDid`: kotlin.String?) : FreeqEvent() {
+        companion object
+    }
+    
+    data class MemberDid(
+        val `nick`: kotlin.String, 
+        val `did`: kotlin.String) : FreeqEvent() {
         companion object
     }
     
@@ -4237,19 +4260,24 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
             18 -> FreeqEvent.ChatHistoryTarget(
                 FfiConverterString.read(buf),
                 FfiConverterOptionalString.read(buf),
+                FfiConverterOptionalString.read(buf),
                 )
-            19 -> FreeqEvent.ReadMarker(
+            19 -> FreeqEvent.MemberDid(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            20 -> FreeqEvent.ReadMarker(
                 FfiConverterString.read(buf),
                 FfiConverterOptionalString.read(buf),
                 )
-            20 -> FreeqEvent.WhoisReply(
+            21 -> FreeqEvent.WhoisReply(
                 FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            21 -> FreeqEvent.Notice(
+            22 -> FreeqEvent.Notice(
                 FfiConverterString.read(buf),
                 )
-            22 -> FreeqEvent.Disconnected(
+            23 -> FreeqEvent.Disconnected(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -4396,6 +4424,15 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
                 4UL
                 + FfiConverterString.allocationSize(value.`nick`)
                 + FfiConverterOptionalString.allocationSize(value.`timestamp`)
+                + FfiConverterOptionalString.allocationSize(value.`partnerDid`)
+            )
+        }
+        is FreeqEvent.MemberDid -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`nick`)
+                + FfiConverterString.allocationSize(value.`did`)
             )
         }
         is FreeqEvent.ReadMarker -> {
@@ -4535,27 +4572,34 @@ public object FfiConverterTypeFreeqEvent : FfiConverterRustBuffer<FreeqEvent>{
                 buf.putInt(18)
                 FfiConverterString.write(value.`nick`, buf)
                 FfiConverterOptionalString.write(value.`timestamp`, buf)
+                FfiConverterOptionalString.write(value.`partnerDid`, buf)
+                Unit
+            }
+            is FreeqEvent.MemberDid -> {
+                buf.putInt(19)
+                FfiConverterString.write(value.`nick`, buf)
+                FfiConverterString.write(value.`did`, buf)
                 Unit
             }
             is FreeqEvent.ReadMarker -> {
-                buf.putInt(19)
+                buf.putInt(20)
                 FfiConverterString.write(value.`target`, buf)
                 FfiConverterOptionalString.write(value.`timestamp`, buf)
                 Unit
             }
             is FreeqEvent.WhoisReply -> {
-                buf.putInt(20)
+                buf.putInt(21)
                 FfiConverterString.write(value.`nick`, buf)
                 FfiConverterString.write(value.`info`, buf)
                 Unit
             }
             is FreeqEvent.Notice -> {
-                buf.putInt(21)
+                buf.putInt(22)
                 FfiConverterString.write(value.`text`, buf)
                 Unit
             }
             is FreeqEvent.Disconnected -> {
-                buf.putInt(22)
+                buf.putInt(23)
                 FfiConverterString.write(value.`reason`, buf)
                 Unit
             }

--- a/freeq-android/freeq/src/main/java/com/freeq/model/DidDisplay.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/DidDisplay.kt
@@ -1,0 +1,88 @@
+package com.freeq.model
+
+/**
+ * DID display + DM-thread identity helpers (Android reference impl of the
+ * DID-keyed DM model; mirrors the web client's identity.ts).
+ *
+ * DM buffers are keyed by the SDK's `dm_key` — the peer's DID when known,
+ * else their nick — so one person is one thread. These helpers keep a raw
+ * `did:plc:…` / `did:key:…` key from ever being *rendered*: resolve to a
+ * human name where possible, compact the DID as a last resort.
+ */
+internal object DidDisplay {
+
+    /** A syntactic DID: `did:<method>:<id>`. No network, no id validation. */
+    fun isDid(s: String): Boolean =
+        Regex("^did:[a-z0-9]+:.+", RegexOption.IGNORE_CASE).matches(s)
+
+    /** Compact a DID for display: `did:plc:k2n3e2vsihf3farequ44t5j7` →
+     *  `plc:k2n3…t5j7`. Non-DIDs pass through unchanged. */
+    fun shorten(s: String): String {
+        if (!isDid(s)) return s
+        val parts = s.split(":", limit = 3)
+        val method = parts[1]
+        val id = parts[2]
+        return if (id.length <= 12) "$method:$id"
+        else "$method:${id.take(4)}…${id.takeLast(4)}"
+    }
+
+    /**
+     * Human name for a thread key or identifier that may be a raw DID:
+     * the display binding (DID→nick, from the conversation list / learned
+     * bindings), then a reverse scan of the nick→DID map, then the
+     * compacted DID. Plain nicks pass through unchanged.
+     */
+    fun displayName(
+        key: String,
+        didToNick: Map<String, String>,
+        nickToDid: Map<String, String>,
+    ): String {
+        if (!isDid(key)) return key
+        didToNick[key]?.let { return it }
+        nickToDid.entries.firstOrNull { it.value == key }?.let { return it.key }
+        return shorten(key)
+    }
+
+    /**
+     * Fold a nick-keyed DM buffer into the DID-keyed one after the peer's
+     * DID is learned (a cold first DM keys by nick until then — without the
+     * merge, one person becomes two threads). Messages dedupe by id and
+     * stay time-ordered via [ChannelState.appendIfNew]; unread counts carry
+     * over. Returns true when a merge happened (the caller repoints any
+     * active-thread state from `nick` to `did`).
+     */
+    fun mergeDmBuffers(
+        dmBuffers: MutableList<ChannelState>,
+        unreadCounts: MutableMap<String, Int>,
+        nick: String,
+        did: String,
+    ): Boolean {
+        if (!isDid(did) || nick.equals(did, ignoreCase = true)) return false
+        if (nick.startsWith("#") || nick.startsWith("&")) return false // never a channel
+        val nickIdx = dmBuffers.indexOfFirst { it.name.equals(nick, ignoreCase = true) }
+        if (nickIdx < 0) return false
+        val nickBuf = dmBuffers[nickIdx]
+
+        val didBuf = dmBuffers.firstOrNull { it.name == did }
+        if (didBuf != null) {
+            for (m in nickBuf.messages) didBuf.appendIfNew(m)
+            if (didBuf.lastActivityTime.value < nickBuf.lastActivityTime.value) {
+                didBuf.lastActivityTime.value = nickBuf.lastActivityTime.value
+            }
+            dmBuffers.removeAt(nickIdx)
+        } else {
+            // Only the nick thread exists → re-key it (rename-in-place,
+            // same shape as the nick-change rebuild).
+            val rekeyed = ChannelState(did)
+            for (m in nickBuf.messages) rekeyed.appendIfNew(m)
+            rekeyed.members.addAll(nickBuf.members)
+            rekeyed.lastActivityTime.value = nickBuf.lastActivityTime.value
+            dmBuffers.removeAt(nickIdx)
+            dmBuffers.add(rekeyed)
+        }
+        unreadCounts.remove(nickBuf.name)?.let { moved ->
+            unreadCounts[did] = (unreadCounts[did] ?: 0) + moved
+        }
+        return true
+    }
+}

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -185,6 +185,15 @@ class AppState(application: Application) : AndroidViewModel(application) {
     val blockedDids = mutableStateListOf<String>()
     val blockedNicks = mutableStateListOf<String>()
 
+    // DID → display nick, learned from the conversation list's partner-did
+    // tag and every nick↔DID binding. Display-grade: survives the peer going
+    // offline, so a DID-keyed thread keeps rendering as a name.
+    val didDisplayNames = mutableStateMapOf<String, String>()
+
+    /** Human label for a thread key that may be a raw DID (see DidDisplay). */
+    fun displayNameForKey(key: String): String =
+        DidDisplay.displayName(key, didDisplayNames, knownDids)
+
     // Nick → server-bound DID learned from message account-tags. Keyed by
     // lowercased nick. Backfills channel member entries (the FFI NAMES reply
     // carries no DID) so DID-gated UI has a real source.
@@ -794,6 +803,7 @@ class AppState(application: Application) : AndroidViewModel(application) {
      *  this is what makes DID-gated UI (verified badge, profile sheet) work. */
     fun recordUserDid(nick: String, did: String) {
         knownDids[nick.lowercase()] = did
+        didDisplayNames[did] = nick
         for (ch in channels) {
             val idx = ch.members.indexOfFirst { it.nick.equals(nick, ignoreCase = true) }
             if (idx >= 0 && ch.members[idx].did != did) {
@@ -904,7 +914,10 @@ class AppState(application: Application) : AndroidViewModel(application) {
         if (nick.value.equals(oldNick, ignoreCase = true)) {
             nick.value = newNick
         }
-        knownDids.remove(oldNick.lowercase())?.let { knownDids[newNick.lowercase()] = it }
+        knownDids.remove(oldNick.lowercase())?.let { did ->
+            knownDids[newNick.lowercase()] = did
+            didDisplayNames[did] = newNick
+        }
     }
 
     fun awayMessage(nick: String): String? {
@@ -1144,7 +1157,11 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                         )
                     }
                 } else {
-                    val bufferName = if (isSelf) ircMsg.target else ircMsg.fromNick
+                    // The SDK's canonical conversation key (peer DID when
+                    // known, else nick) — one person, one thread. Fallback
+                    // preserves behavior against an older SDK.
+                    val bufferName = ircMsg.dmKey
+                        ?: (if (isSelf) ircMsg.target else ircMsg.fromNick)
                     val dm = state.getOrCreateDM(bufferName)
                     dm.appendIfNew(msg)
                     if (!fromBlocked) state.incrementUnread(bufferName)
@@ -1304,7 +1321,7 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
 
                 // Typing indicators
                 tags["+typing"]?.let { typing ->
-                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value) ?: return@let
+                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value, event.msg.dmKey) ?: return@let
                     lookupBuffer(bufferName)?.let { ch ->
                         if (typing == "active") ch.typingUsers[from] = Date()
                         else if (typing == "done") ch.typingUsers.remove(from)
@@ -1313,7 +1330,7 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
 
                 // Message deletion (self-echo already applied optimistically by deleteMessage)
                 tags["+draft/delete"]?.let { deleteId ->
-                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value) ?: return@let
+                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value, event.msg.dmKey) ?: return@let
                     lookupBuffer(bufferName)?.applyDelete(deleteId)
                 }
 
@@ -1321,7 +1338,7 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 val emoji = tags["+react"]
                 val replyId = tags["+reply"]
                 if (emoji != null && replyId != null) {
-                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value)
+                    val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value, event.msg.dmKey)
                     if (bufferName != null) {
                         lookupBuffer(bufferName)?.applyReaction(replyId, emoji, from)
                     }
@@ -1358,7 +1375,25 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                 // its last-activity from the server-time tag so the chat
                 // list orders correctly on cold launch before per-DM
                 // history backfills (matches iOS 70c4ae3/6dff8b2).
-                state.getOrCreateDM(event.nick).seedActivityFromTarget(event.timestamp)
+                // Key by the conversation's stable identity when the server
+                // names it (freeq.at/partner-did); the display nick renders
+                // via displayNameForKey.
+                val key = event.partnerDid ?: event.nick
+                event.partnerDid?.let { state.didDisplayNames[it] = event.nick }
+                state.getOrCreateDM(key).seedActivityFromTarget(event.timestamp)
+            }
+
+            is FreeqEvent.MemberDid -> {
+                // A nick↔DID binding was learned (join/whois/account tag).
+                // Record it and fold any nick-keyed DM thread into the
+                // DID-keyed one — a cold first DM keys by nick until now.
+                state.recordUserDid(event.nick, event.did)
+                if (DidDisplay.mergeDmBuffers(
+                        state.dmBuffers, state.unreadCounts, event.nick, event.did
+                    ) && state.activeChannel.value.equals(event.nick, ignoreCase = true)
+                ) {
+                    state.activeChannel.value = event.did
+                }
             }
 
             is FreeqEvent.WhoisReply -> {

--- a/freeq-android/freeq/src/main/java/com/freeq/model/TagMsgRouter.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/TagMsgRouter.kt
@@ -22,8 +22,15 @@ internal object TagMsgRouter {
      *   TAGMSG is our own nick (the recipient), so the buffer is named
      *   after the sender (`from`).
      */
-    fun routeTo(target: String, from: String, selfNick: String): String? {
+    fun routeTo(
+        target: String,
+        from: String,
+        selfNick: String,
+        dmKey: String? = null,
+    ): String? {
         if (from.equals(selfNick, ignoreCase = true)) return null
-        return if (target.startsWith("#")) target else from
+        // DM buffers are keyed by the SDK's canonical conversation key (peer
+        // DID when known); fall back to the sender's nick for older SDKs.
+        return if (target.startsWith("#")) target else (dmKey ?: from)
     }
 }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/components/ComposeBar.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/components/ComposeBar.kt
@@ -176,7 +176,7 @@ fun ComposeBar(
                     val placeholder = when {
                         replyingTo != null -> "Reply..."
                         editingMessage != null -> "Edit message..."
-                        else -> "Message ${activeChannel ?: ""}"
+                        else -> "Message ${activeChannel?.let { appState.displayNameForKey(it) } ?: ""}"
                     }
                     Text(placeholder, fontSize = 15.sp)
                 },

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/navigation/MainScreen.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/navigation/MainScreen.kt
@@ -158,7 +158,12 @@ fun MainScreen(appState: AppState) {
                     channelName = channelName,
                     onBack = { navController.popBackStack() },
                     onNavigateToChat = { nick ->
-                        navController.navigate("chat/$nick")
+                        // Open DMs under their canonical key (peer DID when
+                        // known) so the thread the echo lands in is the one
+                        // on screen.
+                        val key = if (nick.startsWith("#")) nick
+                            else appState.didForNick(nick) ?: nick
+                        navController.navigate("chat/$key")
                     }
                 )
             }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatDetailScreen.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatDetailScreen.kt
@@ -33,6 +33,11 @@ fun ChatDetailScreen(
     // Don't cache channelState - it changes on reconnect when channels are recreated
     val channelState = appState.channels.firstOrNull { it.name.equals(channelName, ignoreCase = true) }
         ?: appState.dmBuffers.firstOrNull { it.name.equals(channelName, ignoreCase = true) }
+        // A nick-keyed DM can merge into its DID-keyed thread while open
+        // (the peer's first reply teaches the binding): follow it.
+        ?: appState.didForNick(channelName)?.let { did ->
+            appState.dmBuffers.firstOrNull { it.name == did }
+        }
 
     var showMembers by remember { mutableStateOf(false) }
     var showSearch by remember { mutableStateOf(false) }
@@ -73,7 +78,7 @@ fun ChatDetailScreen(
                         else Modifier
                     ) {
                         Text(
-                            channelName,
+                            if (isChannel) channelName else appState.displayNameForKey(channelName),
                             fontSize = 17.sp,
                             fontWeight = FontWeight.SemiBold
                         )
@@ -246,10 +251,11 @@ fun ChatDetailScreen(
                 origin = origin,
                 onDismiss = { profileTarget = null },
                 onNavigateToDM = { dmNick ->
-                    appState.getOrCreateDM(dmNick)
+                    val key = appState.didForNick(dmNick) ?: dmNick
+                    appState.getOrCreateDM(key)
                     showMembers = false
                     profileTarget = null
-                    onNavigateToChat?.invoke(dmNick)
+                    onNavigateToChat?.invoke(key)
                 }
             )
         }

--- a/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatsTab.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ui/screens/ChatsTab.kt
@@ -212,7 +212,8 @@ fun ChatsTab(
                                     ChatRow(
                                         conversation = conversation,
                                         unreadCount = appState.unreadCounts[conversation.name] ?: 0,
-                                        onClick = { onChannelClick(conversation.name) }
+                                        onClick = { onChannelClick(conversation.name) },
+                                        displayName = appState.displayNameForKey(conversation.name)
                                     )
                                 }
                             }
@@ -220,7 +221,8 @@ fun ChatsTab(
                             ChatRow(
                                 conversation = conversation,
                                 unreadCount = appState.unreadCounts[conversation.name] ?: 0,
-                                onClick = { onChannelClick(conversation.name) }
+                                onClick = { onChannelClick(conversation.name) },
+                                displayName = appState.displayNameForKey(conversation.name)
                             )
                         }
                         HorizontalDivider(
@@ -246,7 +248,8 @@ fun ChatsTab(
 private fun ChatRow(
     conversation: ChannelState,
     unreadCount: Int,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    displayName: String = conversation.name,
 ) {
     val isChannel = conversation.name.startsWith("#")
     val lastMessage = conversation.messages.lastOrNull { it.from.isNotEmpty() && !it.isDeleted }
@@ -278,7 +281,7 @@ private fun ChatRow(
                 )
             }
         } else {
-            UserAvatar(nick = conversation.name, size = 50.dp)
+            UserAvatar(nick = displayName, size = 50.dp)
         }
 
         // Content
@@ -289,7 +292,7 @@ private fun ChatRow(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = conversation.name,
+                    text = displayName,
                     fontSize = 16.sp,
                     fontWeight = if (unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
                     color = MaterialTheme.colorScheme.onBackground,

--- a/freeq-android/freeq/src/test/java/com/freeq/model/DidDisplayTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/DidDisplayTest.kt
@@ -1,0 +1,121 @@
+package com.freeq.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+
+/**
+ * Pure-JVM tests for the DID-keyed DM helpers (DidDisplay): identity
+ * syntax, display resolution, and the nick→DID thread merge. Mirrors the
+ * behavioral spec of the web client's identity.ts / store merge.
+ */
+class DidDisplayTest {
+
+    private var idCounter = 0
+    private fun msg(
+        id: String = "m-${idCounter++}",
+        from: String = "alice",
+        text: String = "hello",
+        timestamp: Date = Date(idCounter * 1000L),
+    ) = ChatMessage(
+        id = id,
+        from = from,
+        text = text,
+        isAction = false,
+        timestamp = timestamp,
+    )
+
+    // ── isDid / shorten ──
+
+    @Test
+    fun isDid_recognizes_dids_and_rejects_nicks() {
+        assertTrue(DidDisplay.isDid("did:plc:k2n3e2vsihf3farequ44t5j7"))
+        assertTrue(DidDisplay.isDid("did:key:z6MkabcDEF"))
+        assertFalse(DidDisplay.isDid("alice"))
+        assertFalse(DidDisplay.isDid("did:"))
+        assertFalse(DidDisplay.isDid("did:plc:"))
+        assertFalse(DidDisplay.isDid("#did:plc:x"))
+    }
+
+    @Test
+    fun shorten_compacts_long_dids_and_passes_nicks_through() {
+        assertEquals("plc:k2n3…t5j7", DidDisplay.shorten("did:plc:k2n3e2vsihf3farequ44t5j7"))
+        assertEquals("plc:short", DidDisplay.shorten("did:plc:short"))
+        assertEquals("bob", DidDisplay.shorten("bob"))
+    }
+
+    // ── displayName resolution chain ──
+
+    @Test
+    fun displayName_passes_plain_nicks_through() {
+        assertEquals("alice", DidDisplay.displayName("alice", emptyMap(), emptyMap()))
+    }
+
+    @Test
+    fun displayName_prefers_display_binding_then_reverse_then_shortens() {
+        val did = "did:plc:k2n3e2vsihf3farequ44t5j7"
+        assertEquals(
+            "zapnap",
+            DidDisplay.displayName(did, mapOf(did to "zapnap"), emptyMap())
+        )
+        assertEquals(
+            "zapnap",
+            DidDisplay.displayName(did, emptyMap(), mapOf("zapnap" to did))
+        )
+        assertEquals("plc:k2n3…t5j7", DidDisplay.displayName(did, emptyMap(), emptyMap()))
+    }
+
+    // ── mergeDmBuffers ──
+
+    private fun buffers(vararg names: String): MutableList<ChannelState> =
+        names.map { ChannelState(it) }.toMutableList()
+
+    @Test
+    fun merge_rekeys_a_lone_nick_thread_to_the_did() {
+        val bufs = buffers("zapnap")
+        bufs[0].appendIfNew(msg(text = "HELLO"))
+        val unread = mutableMapOf("zapnap" to 2)
+
+        assertTrue(DidDisplay.mergeDmBuffers(bufs, unread, "zapnap", "did:plc:zap"))
+        assertEquals(1, bufs.size)
+        assertEquals("did:plc:zap", bufs[0].name)
+        assertEquals("HELLO", bufs[0].messages.single().text)
+        assertEquals(2, unread["did:plc:zap"])
+        assertFalse(unread.containsKey("zapnap"))
+    }
+
+    @Test
+    fun merge_folds_nick_thread_into_existing_did_thread_ordered_and_deduped() {
+        val bufs = buffers("zapnap", "did:plc:zap")
+        val early = msg(text = "HELLO", timestamp = Date(1000))
+        val late = msg(text = "uhm hi", timestamp = Date(2000))
+        bufs[0].appendIfNew(early)
+        bufs[1].appendIfNew(late)
+        bufs[1].appendIfNew(early) // pre-existing copy → dedupe by id
+        val unread = mutableMapOf("zapnap" to 1, "did:plc:zap" to 1)
+
+        assertTrue(DidDisplay.mergeDmBuffers(bufs, unread, "zapnap", "did:plc:zap"))
+        assertEquals(1, bufs.size)
+        assertEquals(listOf("HELLO", "uhm hi"), bufs[0].messages.map { it.text })
+        assertEquals(2, unread["did:plc:zap"])
+    }
+
+    @Test
+    fun merge_is_a_noop_without_a_nick_thread_or_for_non_dids() {
+        val bufs = buffers("did:plc:zap")
+        assertFalse(DidDisplay.mergeDmBuffers(bufs, mutableMapOf(), "ghost", "did:plc:zap"))
+        assertFalse(DidDisplay.mergeDmBuffers(bufs, mutableMapOf(), "zapnap", "notadid"))
+        assertEquals(1, bufs.size)
+    }
+
+    @Test
+    fun merge_never_touches_channel_buffers() {
+        // A channel named like a nick must be untouched: merge only scans
+        // the DM buffer list handed to it — pass channels to prove no-op.
+        val bufs = buffers("#zapnap")
+        assertFalse(DidDisplay.mergeDmBuffers(bufs, mutableMapOf(), "#zapnap", "did:plc:zap"))
+        assertEquals("#zapnap", bufs[0].name)
+    }
+}

--- a/freeq-android/freeq/src/test/java/com/freeq/model/MessageMapperTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/MessageMapperTest.kt
@@ -53,6 +53,7 @@ class MessageMapperTest {
         account = account,
         origin = origin,
         reactions = reactions,
+        dmKey = null,
     )
 
     @Test fun preserves_basic_fields() {

--- a/freeq-bot-kit-js/examples/didtest-bot.ts
+++ b/freeq-bot-kit-js/examples/didtest-bot.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * didtest-bot — a throwaway did:key echo bot for exercising DID-addressed DMs.
+ *
+ * Mints a fresh did:key (a clean identity the server has never seen), joins a
+ * channel so you can click it in the member list, and echoes any DM back so a
+ * DM has two-way history under the canonical DID-pair key. Use it to check
+ * that a did:key peer renders as a name rather than a raw did:key:z6Mk… and
+ * that one peer is one thread.
+ *
+ *   npm --prefix freeq-sdk-js run build
+ *   npx tsx freeq-bot-kit-js/examples/didtest-bot.ts \
+ *     --owner did:plc:<your-did> --server wss://irc.zerosum.org/irc
+ */
+
+import { FreeqBot } from "../src/index.js";
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  options: {
+    server: { type: "string", default: "wss://irc.zerosum.org/irc" },
+    channel: { type: "string", default: "#didtest" },
+    nick: { type: "string", default: "didtestbot" },
+    // Fresh identity per run by default, so the server has no prior record.
+    name: { type: "string", default: `didtest-${Math.random().toString(36).slice(2, 8)}` },
+    owner: { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.owner) {
+  console.error(
+    "Usage: didtest-bot --owner did:plc:<your-did> [--server wss://…/irc] [--channel #didtest] [--nick didtestbot]",
+  );
+  process.exit(1);
+}
+
+const bot = await FreeqBot.create({
+  name: values.name!,
+  ownerDid: values.owner,
+  nick: values.nick!,
+  url: values.server!,
+  channels: [values.channel!],
+});
+
+bot.on("message", (channel, msg) => {
+  if (msg.isSelf) return;
+  const isDM = !channel.startsWith("#") && !channel.startsWith("&");
+  // Echo DMs; in-channel, only answer when addressed, to stay quiet.
+  if (isDM) {
+    console.error(`[didtest-bot] DM in thread "${channel}" from ${msg.from}: ${msg.text}`);
+    bot.client.sendMessage(channel, `echo: ${msg.text}`);
+  }
+});
+
+await bot.start();
+console.error(`[didtest-bot] up as ${bot.client.nick}`);
+console.error(`[didtest-bot] identity ${bot.identity.did}`);
+console.error(`[didtest-bot] in ${values.channel} on ${values.server}`);
+
+process.once("SIGINT", () => bot.stop("SIGINT").then(() => process.exit(0)));
+process.once("SIGTERM", () => bot.stop("SIGTERM").then(() => process.exit(0)));

--- a/freeq-bots/src/bin/context_bot.rs
+++ b/freeq-bots/src/bin/context_bot.rs
@@ -192,8 +192,7 @@ async fn run_once(args: &Args, llm: &LlmClient, ctx: &Arc<AgentContext>) -> Resu
                 from,
                 target,
                 text,
-                tags,
-            } if target == args.channel => {
+                tags, .. } if target == args.channel => {
                 // Record every message
                 let timestamp = tags
                     .get("time")

--- a/freeq-bots/src/bin/pi_bridge.rs
+++ b/freeq-bots/src/bin/pi_bridge.rs
@@ -201,8 +201,7 @@ async fn run_once(cfg: Config) -> anyhow::Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            } => {
+                tags, .. } => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-bots/src/main.rs
+++ b/freeq-bots/src/main.rs
@@ -184,8 +184,7 @@ async fn handle_event(
             from,
             target,
             text,
-            tags,
-        } => {
+            tags, .. } => {
             if tags.contains_key("batch") {
                 return Ok(());
             }

--- a/freeq-eliza/src/irc.rs
+++ b/freeq-eliza/src/irc.rs
@@ -810,8 +810,7 @@ pub async fn run(cfg: RunConfig) -> Result<()> {
             Event::TagMsg {
                 from: _,
                 target,
-                tags,
-            } => {
+                tags, .. } => {
                 let actor = tags.get("+freeq.at/av-actor").cloned().unwrap_or_default();
                 match classify_av_event(&target, &tags, &cfg.channels, &cfg.nick) {
                     AvAction::Start {

--- a/freeq-ios/freeq/Models/AppState.swift
+++ b/freeq-ios/freeq/Models/AppState.swift
@@ -2520,7 +2520,12 @@ final class SwiftEventHandler: @unchecked Sendable, EventHandler {
                 for msg in sorted { dm.appendIfNew(msg) }
             }
 
-        case .chatHistoryTarget(let nick, let timestamp):
+        case .memberDid:
+            // Emitted by the updated SDK when a nick<->DID binding is
+            // learned. Adopted in the iOS DID-DM pass; ignored until then.
+            break
+
+        case .chatHistoryTarget(let nick, let timestamp, _):
             // Server tells us "you have history with this peer"; create the
             // DM buffer and seed lastActivity from the server-provided
             // timestamp (`time` tag, ISO8601). Without this, every DM

--- a/freeq-macos/freeq-macos/Models/AppState.swift
+++ b/freeq-macos/freeq-macos/Models/AppState.swift
@@ -1644,7 +1644,12 @@ extension AppState {
             guard let batch = batches.removeValue(forKey: id) else { return }
             HistoryBatchRouting.apply(buffer: batch, channels: &channels, dmBuffers: &dmBuffers)
 
-        case .chatHistoryTarget(let targetNick, let timestamp):
+        case .memberDid:
+            // Emitted by the updated SDK when a nick<->DID binding is
+            // learned. Adopted in the macOS DID-DM pass; ignored until then.
+            break
+
+        case .chatHistoryTarget(let targetNick, let timestamp, _):
             if closedDMs.contains(targetNick.lowercased()) { return }
             let dm = getOrCreateDM(targetNick)
             profileCache.fetchProfileIfPossible(nick: targetNick)

--- a/freeq-sdk-ffi/src/freeq.udl
+++ b/freeq-sdk-ffi/src/freeq.udl
@@ -17,6 +17,7 @@ dictionary IrcMessage {
     string? account;
     string? origin;
     sequence<ReactionTally> reactions;
+    string? dm_key;
 };
 
 dictionary ReactionTally {
@@ -46,6 +47,7 @@ dictionary TagMessage {
     string from;
     string target;
     sequence<TagEntry> tags;
+    string? dm_key;
 };
 
 [Enum]
@@ -67,7 +69,8 @@ interface FreeqEvent {
     UserQuit(string nick, string reason);
     BatchStart(string id, string batch_type, string target);
     BatchEnd(string id);
-    ChatHistoryTarget(string nick, string? timestamp);
+    ChatHistoryTarget(string nick, string? timestamp, string? partner_did);
+    MemberDid(string nick, string did);
     // draft/read-marker (S1): reply to our mark/get, or another of our
     // devices advancing the marker. timestamp null = server reports none.
     ReadMarker(string target, string? timestamp);

--- a/freeq-sdk-ffi/src/lib.rs
+++ b/freeq-sdk-ffi/src/lib.rs
@@ -61,6 +61,10 @@ pub struct IrcMessage {
     /// server's `+freeq.at/reactions` tag (CHATHISTORY / JOIN replay).
     /// Live reactions still arrive as separate `TagMsg` events.
     pub reactions: Vec<ReactionTally>,
+    /// For a DM: the canonical conversation key — the peer's DID when known,
+    /// else their nick. `None` for channel messages. Key DM threads by this,
+    /// not by from/target (which flip with message direction).
+    pub dm_key: Option<String>,
 }
 
 pub struct ReactionTally {
@@ -105,6 +109,7 @@ pub struct TagMessage {
     pub from: String,
     pub target: String,
     pub tags: Vec<TagEntry>,
+    pub dm_key: Option<String>,
 }
 
 pub struct IrcMember {
@@ -188,6 +193,14 @@ pub enum FreeqEvent {
     ChatHistoryTarget {
         nick: String,
         timestamp: Option<String>,
+        /// The conversation's stable identity (`freeq.at/partner-did` tag).
+        partner_did: Option<String>,
+    },
+    /// A nick↔DID binding was learned; merge any nick-keyed DM thread for
+    /// `nick` into the DID-keyed one. Emitted only for new/changed bindings.
+    MemberDid {
+        nick: String,
+        did: String,
     },
     ReadMarker {
         target: String,
@@ -459,9 +472,10 @@ impl FreeqClient {
 fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
     use freeq_sdk::event::Event;
     Some(match event {
-        // Not in the UDL yet — exposed in the FFI-surface change alongside
-        // dm_key/partner_did; consumers get it once bindings regenerate.
-        Event::MemberDid { .. } => return None,
+        Event::MemberDid { nick, did } => FreeqEvent::MemberDid {
+            nick: nick.clone(),
+            did: did.clone(),
+        },
         Event::Connected => FreeqEvent::Connected,
         Event::Registered { nick } => FreeqEvent::Registered { nick: nick.clone() },
         Event::Authenticated { did } => FreeqEvent::Authenticated { did: did.clone() },
@@ -481,7 +495,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
             target,
             text,
             tags,
-            ..
+            dm_key,
         } => {
             let msgid = tags.get("msgid").cloned();
             let reply_to = tags.get("+reply").cloned();
@@ -525,10 +539,11 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
                     account: tags.get("account").cloned(),
                     origin: tags.get("+freeq.at/origin").cloned(),
                     reactions,
+                    dm_key: dm_key.clone(),
                 },
             }
         }
-        Event::TagMsg { from, target, tags, .. } => {
+        Event::TagMsg { from, target, tags, dm_key } => {
             let tag_entries = tags
                 .iter()
                 .map(|(k, v)| TagEntry {
@@ -541,6 +556,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
                     from: from.clone(),
                     target: target.clone(),
                     tags: tag_entries,
+                    dm_key: dm_key.clone(),
                 },
             }
         }
@@ -634,9 +650,10 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
             target: target.clone(),
         },
         Event::BatchEnd { id } => FreeqEvent::BatchEnd { id: id.clone() },
-        Event::ChatHistoryTarget { nick, timestamp, .. } => FreeqEvent::ChatHistoryTarget {
+        Event::ChatHistoryTarget { nick, timestamp, partner_did } => FreeqEvent::ChatHistoryTarget {
             nick: nick.clone(),
             timestamp: timestamp.clone(),
+            partner_did: partner_did.clone(),
         },
         Event::Disconnected { reason } => FreeqEvent::Disconnected {
             reason: reason.clone(),

--- a/freeq-sdk-ffi/src/lib.rs
+++ b/freeq-sdk-ffi/src/lib.rs
@@ -318,7 +318,9 @@ impl FreeqClient {
 
                 // Pump events
                 while let Some(event) = event_rx.recv().await {
-                    let ffi_event = convert_event(&event);
+                    let Some(ffi_event) = convert_event(&event) else {
+                        continue;
+                    };
                     if let FreeqEvent::Disconnected { .. } = &ffi_event {
                         *connected_store.lock().unwrap() = false;
                     }
@@ -451,9 +453,15 @@ impl FreeqClient {
 
 // ── Event conversion ──
 
-fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
+/// Convert an SDK event to its FFI form. `None` for events not yet exposed
+/// through the UDL (adding a variant requires regenerating the checked-in
+/// Kotlin/Swift bindings, which happens in the native build environments).
+fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
     use freeq_sdk::event::Event;
-    match event {
+    Some(match event {
+        // Not in the UDL yet — exposed in the FFI-surface change alongside
+        // dm_key/partner_did; consumers get it once bindings regenerate.
+        Event::MemberDid { .. } => return None,
         Event::Connected => FreeqEvent::Connected,
         Event::Registered { nick } => FreeqEvent::Registered { nick: nick.clone() },
         Event::Authenticated { did } => FreeqEvent::Authenticated { did: did.clone() },
@@ -473,6 +481,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
             target,
             text,
             tags,
+            ..
         } => {
             let msgid = tags.get("msgid").cloned();
             let reply_to = tags.get("+reply").cloned();
@@ -519,7 +528,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
                 },
             }
         }
-        Event::TagMsg { from, target, tags } => {
+        Event::TagMsg { from, target, tags, .. } => {
             let tag_entries = tags
                 .iter()
                 .map(|(k, v)| TagEntry {
@@ -625,7 +634,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
             target: target.clone(),
         },
         Event::BatchEnd { id } => FreeqEvent::BatchEnd { id: id.clone() },
-        Event::ChatHistoryTarget { nick, timestamp } => FreeqEvent::ChatHistoryTarget {
+        Event::ChatHistoryTarget { nick, timestamp, .. } => FreeqEvent::ChatHistoryTarget {
             nick: nick.clone(),
             timestamp: timestamp.clone(),
         },
@@ -646,7 +655,7 @@ fn convert_event(event: &freeq_sdk::event::Event) -> FreeqEvent {
         Event::RawLine(_) => FreeqEvent::Notice {
             text: String::new(),
         },
-    }
+    })
 }
 
 // ── E2EE Manager ───────────────────────────────────────────────────
@@ -2399,8 +2408,9 @@ mod tests {
             target: "#naptest".to_string(),
             text: "hi".to_string(),
             tags,
+            dm_key: None,
         };
-        let out = convert_event(&ev);
+        let out = convert_event(&ev).expect("exposed event");
         let FreeqEvent::Message { msg } = out else {
             panic!("expected Message variant");
         };
@@ -2424,8 +2434,9 @@ mod tests {
             target: "#x".to_string(),
             text: "no reactions here".to_string(),
             tags,
+            dm_key: None,
         };
-        let out = convert_event(&ev);
+        let out = convert_event(&ev).expect("exposed event");
         let FreeqEvent::Message { msg } = out else {
             panic!("expected Message variant");
         };

--- a/freeq-sdk/examples/demo_phase2.rs
+++ b/freeq-sdk/examples/demo_phase2.rs
@@ -59,8 +59,7 @@ async fn wait_owner(
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }
@@ -627,8 +626,7 @@ async fn main() -> Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-sdk/examples/demo_phase3.rs
+++ b/freeq-sdk/examples/demo_phase3.rs
@@ -58,8 +58,7 @@ async fn wait_owner(
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }
@@ -818,8 +817,7 @@ async fn main() -> Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-sdk/examples/demo_phase4.rs
+++ b/freeq-sdk/examples/demo_phase4.rs
@@ -56,8 +56,7 @@ async fn wait_owner(
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }
@@ -620,8 +619,7 @@ async fn main() -> Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-sdk/examples/pi_agent.rs
+++ b/freeq-sdk/examples/pi_agent.rs
@@ -301,8 +301,7 @@ async fn main() -> Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-sdk/examples/spawn_test.rs
+++ b/freeq-sdk/examples/spawn_test.rs
@@ -143,8 +143,7 @@ async fn main() -> Result<()> {
                 from,
                 target,
                 text,
-                tags,
-            })) => {
+                tags, .. })) => {
                 if tags.contains_key("batch") {
                     continue;
                 }

--- a/freeq-sdk/src/address.rs
+++ b/freeq-sdk/src/address.rs
@@ -1,0 +1,104 @@
+//! DM addressing: one rule for referencing a direct-message peer.
+//!
+//! A DM peer can be named two ways — a nick (`"bob"`) or a DID
+//! (`"did:plc:bob"`). To make a DID the load-bearing identity, the same rule
+//! is applied everywhere a DM references a peer — the wire target we send to
+//! AND the local buffer/thread key we file under:
+//!
+//! > DID when we know it, else the input unchanged.
+//!
+//! Because it is idempotent (DID in → same DID out) and maps a known nick to
+//! the same DID, `"bob"` and `"did:plc:bob"` collapse to one conversation
+//! instead of splitting into two. An unknown nick — a guest, or a remote user
+//! this client hasn't learned a DID for — passes through untouched, so nick
+//! addressing keeps working exactly as before.
+//!
+//! Channels are never routed through this (callers guard on `#`/`&` first).
+//!
+//! Twin of `freeq-sdk-js/src/address.ts`; the behaviours here mirror that
+//! module and its tests exactly.
+
+/// A syntactic DID: `did:<method>:<id>`. No network, no `id` validation.
+/// Mirrors the JS regex `/^did:[a-z0-9]+:.+/i`: `did:`, then a non-empty
+/// ASCII-alphanumeric method, then `:`, then a non-empty id.
+pub fn is_did(s: &str) -> bool {
+    let rest = match s.get(..4) {
+        Some(p) if p.eq_ignore_ascii_case("did:") => &s[4..],
+        _ => return false,
+    };
+    match rest.find(':') {
+        // method is everything before the colon: non-empty, all alphanumeric
+        Some(colon)
+            if colon > 0
+                && rest[..colon].bytes().all(|b| b.is_ascii_alphanumeric())
+                // id is everything after: non-empty
+                && colon + 1 < rest.len() =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Canonical key for a DM peer: its DID when known, else the input unchanged.
+///
+/// `resolve` maps a nick to its DID (`None` if unknown); a peer that is
+/// already a DID is returned as-is without consulting it.
+pub fn dm_peer_key<F>(peer: &str, resolve: F) -> String
+where
+    F: FnOnce(&str) -> Option<String>,
+{
+    if is_did(peer) {
+        return peer.to_string();
+    }
+    resolve(peer).unwrap_or_else(|| peer.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_did_recognizes_dids_and_rejects_nicks_and_partials() {
+        assert!(is_did("did:plc:k2n3e2vsihf3farequ44t5j7"));
+        assert!(is_did("did:key:z6MkabcDEF"));
+        assert!(is_did("did:web:example.com"));
+        assert!(!is_did("alice"));
+        assert!(!is_did("did:"));
+        assert!(!is_did("did:plc:"));
+        assert!(!is_did("#did:plc:x"));
+    }
+
+    /// The test resolver: nick → DID, case-insensitive, mirroring the JS test.
+    fn resolver(nick: &str) -> Option<String> {
+        match nick.to_lowercase().as_str() {
+            "bob" => Some("did:plc:bob".to_string()),
+            "alice" => Some("did:plc:alice".to_string()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn dm_peer_key_passes_a_did_through_unchanged() {
+        assert_eq!(dm_peer_key("did:plc:bob", resolver), "did:plc:bob");
+        // Idempotent even when the DID also has a nick mapped to it.
+        let once = dm_peer_key("bob", resolver);
+        assert_eq!(dm_peer_key(&once, resolver), "did:plc:bob");
+    }
+
+    #[test]
+    fn dm_peer_key_resolves_a_known_nick_so_nick_and_did_collapse() {
+        assert_eq!(dm_peer_key("bob", resolver), "did:plc:bob");
+        assert_eq!(dm_peer_key("bob", resolver), dm_peer_key("did:plc:bob", resolver));
+    }
+
+    #[test]
+    fn dm_peer_key_leaves_an_unknown_nick_unchanged() {
+        assert_eq!(dm_peer_key("carol", resolver), "carol");
+    }
+
+    #[test]
+    fn dm_peer_key_does_not_lowercase_or_mangle_an_unresolvable_nick() {
+        assert_eq!(dm_peer_key("Carol", resolver), "Carol");
+    }
+}

--- a/freeq-sdk/src/bot.rs
+++ b/freeq-sdk/src/bot.rs
@@ -317,6 +317,7 @@ impl Bot {
             target,
             text,
             tags,
+            ..
         } = event
         {
             // Ignore CHATHISTORY batches (avoid replaying history)

--- a/freeq-sdk/src/client.rs
+++ b/freeq-sdk/src/client.rs
@@ -257,15 +257,122 @@ pub(crate) struct CapsState {
 }
 pub(crate) type CapsAcked = Arc<parking_lot::Mutex<CapsState>>;
 
+/// Session-learned nick↔DID bindings, shared between the read loop (which
+/// learns them) and `ClientHandle` (which resolves send targets through
+/// them). The two directions deliberately have different lifetimes:
+///
+/// - `nick_to_did` is addressing-grade: cleared when the nick's owner quits,
+///   because a released nick can be recycled by someone else and routing
+///   must never follow a stale binding.
+/// - `did_to_nick` is display/keying-grade and retained: a DID is permanent,
+///   and a DM thread must keep its key (and name) after the peer goes
+///   offline. A rename overwrites it on the next join/whois/message.
+#[derive(Default)]
+pub(crate) struct DidMapsState {
+    /// lowercase nick → DID. Addressing-grade; cleared on QUIT.
+    nick_to_did: HashMap<String, String>,
+    /// DID → lowercase nick. Display/keying-grade; survives QUIT.
+    did_to_nick: HashMap<String, String>,
+}
+
+impl DidMapsState {
+    /// Learn an authoritative binding (extended-join, WHOIS 330, account
+    /// tag). Returns true when new/changed — the caller emits
+    /// [`Event::MemberDid`] exactly then.
+    fn learn(&mut self, nick: &str, did: &str) -> bool {
+        let lc = nick.to_lowercase();
+        let is_new = self.nick_to_did.get(&lc).map(|d| d.as_str()) != Some(did);
+        self.nick_to_did.insert(lc.clone(), did.to_string());
+        self.did_to_nick.insert(did.to_string(), lc);
+        is_new
+    }
+
+    /// Learn the display direction only (CHATHISTORY TARGETS): the display
+    /// nick may be historical, so it must not become an addressing binding.
+    fn learn_display(&mut self, did: &str, nick: &str) {
+        self.did_to_nick.insert(did.to_string(), nick.to_lowercase());
+    }
+
+    /// The peer's DID whose retained display nick is `nick`, if any.
+    fn reverse_did_for_nick(&self, nick: &str) -> Option<String> {
+        let lc = nick.to_lowercase();
+        self.did_to_nick
+            .iter()
+            .find(|(_, n)| **n == lc)
+            .map(|(d, _)| d.clone())
+    }
+
+    /// DM buffer/thread key: loose resolution (addressing map, then the
+    /// retained display binding) so an offline peer's thread keeps one key.
+    fn dm_key(&self, peer: &str) -> String {
+        crate::address::dm_peer_key(peer, |n| {
+            self.nick_to_did
+                .get(&n.to_lowercase())
+                .cloned()
+                .or_else(|| self.reverse_did_for_nick(n))
+        })
+    }
+
+    /// Wire target: strict resolution (addressing map only) — routing never
+    /// rides a display binding.
+    fn wire_target(&self, peer: &str) -> String {
+        crate::address::dm_peer_key(peer, |n| self.nick_to_did.get(&n.to_lowercase()).cloned())
+    }
+
+    /// A nick's owner quit: forget the addressing binding (the nick can be
+    /// recycled) but keep the display binding (the DID is permanent).
+    fn forget_nick(&mut self, nick: &str) {
+        self.nick_to_did.remove(&nick.to_lowercase());
+    }
+
+    /// A user renamed: move their addressing binding to the new nick and
+    /// refresh the display binding.
+    fn rename(&mut self, old_nick: &str, new_nick: &str) {
+        if let Some(did) = self.nick_to_did.remove(&old_nick.to_lowercase()) {
+            self.learn(new_nick, &did);
+        }
+    }
+}
+
+pub(crate) type DidMaps = Arc<parking_lot::Mutex<DidMapsState>>;
+
+/// Compute the DM key for an inbound/echoed message, or `None` for channels.
+/// The peer is the non-self end: our echo's peer is the target, an incoming
+/// message's peer is the sender.
+fn dm_key_for(
+    maps: &DidMaps,
+    own_nick: &str,
+    from: &str,
+    target: &str,
+) -> Option<String> {
+    if target.starts_with('#') || target.starts_with('&') {
+        return None;
+    }
+    let peer = if from.eq_ignore_ascii_case(own_nick) { target } else { from };
+    Some(maps.lock().dm_key(peer))
+}
+
 /// A handle to a running IRC client connection.
 #[derive(Clone)]
 pub struct ClientHandle {
     cmd_tx: mpsc::Sender<Command>,
     echo_registry: EchoRegistry,
     caps_acked: CapsAcked,
+    did_maps: DidMaps,
 }
 
 impl ClientHandle {
+    /// Resolve a DM send target to the peer's DID when addressing-grade
+    /// known (strict map only — never a display binding), else unchanged.
+    /// Channels pass through. The signature canonical covers the resolved
+    /// target, matching what the server verifies.
+    fn resolve_wire_target(&self, target: &str) -> String {
+        if target.starts_with('#') || target.starts_with('&') {
+            return target.to_string();
+        }
+        self.did_maps.lock().wire_target(target)
+    }
+
     pub async fn join(&self, channel: &str) -> Result<()> {
         self.cmd_tx.send(Command::Join(channel.to_string())).await?;
         Ok(())
@@ -282,6 +389,7 @@ impl ClientHandle {
     /// targeting old servers should pre-encode or call
     /// `send_multiline_chunks` with explicit chunks.
     pub async fn privmsg(&self, target: &str, text: &str) -> Result<()> {
+        let target = &self.resolve_wire_target(target);
         // Route through multiline when the text spans lines OR is long enough
         // that a single PRIVMSG would risk server-side truncation.
         let multiline_ready = (text.contains('\n') || text.len() > MULTILINE_PER_CHUNK_BYTES) && {
@@ -332,6 +440,7 @@ impl ClientHandle {
         chunks: Vec<MultilineChunk>,
         opener_tags: std::collections::HashMap<String, String>,
     ) -> Result<()> {
+        let target = &self.resolve_wire_target(target);
         self.cmd_tx
             .send(Command::SendMultiline {
                 target: target.to_string(),
@@ -425,6 +534,7 @@ impl ClientHandle {
         text: &str,
         tags: std::collections::HashMap<String, String>,
     ) -> Result<()> {
+        let target = &self.resolve_wire_target(target);
         let multiline_ready = (text.contains('\n') || text.len() > MULTILINE_PER_CHUNK_BYTES) && {
             let caps = self.caps_acked.lock();
             caps.acked.contains("draft/multiline") && caps.acked.contains("batch")
@@ -1248,15 +1358,18 @@ pub fn connect_with_stream(
     let (cmd_tx, cmd_rx) = mpsc::channel(256);
     let echo_registry: EchoRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
     let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+    let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
 
     let handle = ClientHandle {
         cmd_tx: cmd_tx.clone(),
         echo_registry: echo_registry.clone(),
         caps_acked: caps_acked.clone(),
+        did_maps: did_maps.clone(),
     };
 
     let echo_reg = echo_registry.clone();
     let caps_for_loop = caps_acked.clone();
+    let maps_for_loop = did_maps.clone();
     tokio::spawn(async move {
         let _ = event_tx.send(Event::Connected).await;
         let result = match conn {
@@ -1271,6 +1384,7 @@ pub fn connect_with_stream(
                     cmd_rx,
                     echo_reg,
                     caps_for_loop,
+                    maps_for_loop,
                 )
                 .await
             }
@@ -1285,6 +1399,7 @@ pub fn connect_with_stream(
                     cmd_rx,
                     echo_reg,
                     caps_for_loop,
+                    maps_for_loop,
                 )
                 .await
             }
@@ -1300,6 +1415,7 @@ pub fn connect_with_stream(
                     cmd_rx,
                     echo_reg,
                     caps_for_loop,
+                    maps_for_loop,
                 )
                 .await
             }
@@ -1315,6 +1431,7 @@ pub fn connect_with_stream(
                     cmd_rx,
                     echo_reg,
                     caps_for_loop,
+                    maps_for_loop,
                 )
                 .await
             }
@@ -1346,15 +1463,18 @@ pub fn connect(
     let (cmd_tx, cmd_rx) = mpsc::channel(256);
     let echo_registry: EchoRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
     let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+    let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
 
     let handle = ClientHandle {
         cmd_tx: cmd_tx.clone(),
         echo_registry: echo_registry.clone(),
         caps_acked: caps_acked.clone(),
+        did_maps: did_maps.clone(),
     };
 
     let echo_reg = echo_registry.clone();
     let caps_for_loop = caps_acked.clone();
+    let maps_for_loop = did_maps.clone();
     tokio::spawn(async move {
         if let Err(e) = run_client(
             config,
@@ -1363,6 +1483,7 @@ pub fn connect(
             cmd_rx,
             echo_reg,
             caps_for_loop,
+            maps_for_loop,
         )
         .await
         {
@@ -1384,6 +1505,7 @@ async fn run_client(
     cmd_rx: mpsc::Receiver<Command>,
     echo_registry: EchoRegistry,
     caps_acked: CapsAcked,
+    did_maps: DidMaps,
 ) -> Result<()> {
     let conn = establish_connection(&config).await?;
     let _ = event_tx.send(Event::Connected).await;
@@ -1399,6 +1521,7 @@ async fn run_client(
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await
         }
@@ -1413,6 +1536,7 @@ async fn run_client(
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await
         }
@@ -1428,6 +1552,7 @@ async fn run_client(
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await
         }
@@ -1443,6 +1568,7 @@ async fn run_client(
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await
         }
@@ -1678,6 +1804,7 @@ async fn run_irc<R, W>(
     mut cmd_rx: mpsc::Receiver<Command>,
     echo_registry: EchoRegistry,
     caps_acked: CapsAcked,
+    did_maps: DidMaps,
 ) -> Result<()>
 where
     R: tokio::io::AsyncBufRead + Unpin,
@@ -1695,6 +1822,9 @@ where
 
     let mut sasl_in_progress = false;
     let mut registered = false;
+    // Our own confirmed nick (001, self-NICK) — needed to tell which end of
+    // a DM is the peer when computing dm_key.
+    let mut own_nick = String::new();
     let mut nick_tries: u32 = 0;
     let mut web_token = config.web_token.clone();
     let mut authenticated_did: Option<String> = None;
@@ -1872,7 +2002,13 @@ where
                                     }
                                 } else if let Some(id) = ref_id.strip_prefix('-') {
                                     if let Some(batch) = multiline_batches.remove(id) {
-                                        dispatch_assembled_multiline(&event_tx, batch).await;
+                                        let dm_key = dm_key_for(
+                                            &did_maps,
+                                            &own_nick,
+                                            &batch.from,
+                                            &batch.target,
+                                        );
+                                        dispatch_assembled_multiline(&event_tx, batch, dm_key).await;
                                     } else {
                                         let _ = event_tx.send(Event::BatchEnd { id: id.to_string() }).await;
                                     }
@@ -1881,6 +2017,7 @@ where
                         }
                         "001" => {
                             let nick = msg.params.first().cloned().unwrap_or_default();
+                            own_nick = nick.clone();
                             let _ = event_tx.send(Event::Registered { nick }).await;
                             registered = true;
                             // Flush any commands that were queued before registration
@@ -1917,6 +2054,14 @@ where
                             let account = msg.params.get(1)
                                 .filter(|a| !a.is_empty() && a.as_str() != "*")
                                 .cloned();
+                            if let Some(did) = account.as_deref()
+                                && crate::address::is_did(did)
+                                && did_maps.lock().learn(&nick, did)
+                            {
+                                let _ = event_tx
+                                    .send(Event::MemberDid { nick: nick.clone(), did: did.to_string() })
+                                    .await;
+                            }
                             let _ = event_tx.send(Event::Joined { channel, nick, account }).await;
                         }
                         "PART" => {
@@ -1934,6 +2079,10 @@ where
                                 .to_string();
                             let new_nick = msg.params.first().cloned().unwrap_or_default();
                             if !old_nick.is_empty() && !new_nick.is_empty() {
+                                if old_nick.eq_ignore_ascii_case(&own_nick) {
+                                    own_nick = new_nick.clone();
+                                }
+                                did_maps.lock().rename(&old_nick, &new_nick);
                                 let _ = event_tx.send(Event::NickChanged { old_nick, new_nick }).await;
                             }
                         }
@@ -2078,6 +2227,16 @@ where
                             if msg.params.len() >= 3 {
                                 let nick = msg.params[1].clone();
                                 let account = &msg.params[2];
+                                if crate::address::is_did(account)
+                                    && did_maps.lock().learn(&nick, account)
+                                {
+                                    let _ = event_tx
+                                        .send(Event::MemberDid {
+                                            nick: nick.clone(),
+                                            did: account.clone(),
+                                        })
+                                        .await;
+                                }
                                 let label = msg.params.get(3).map(|s| s.as_str()).unwrap_or("is authenticated as");
                                 let info = format!("{nick} {label} {account}");
                                 let _ = event_tx.send(Event::WhoisReply { nick, info }).await;
@@ -2102,6 +2261,7 @@ where
                                 .unwrap_or("")
                                 .to_string();
                             let reason = msg.params.first().cloned().unwrap_or_default();
+                            did_maps.lock().forget_nick(&nick);
                             let _ = event_tx.send(Event::UserQuit { nick, reason }).await;
                         }
                         "PRIVMSG" | "NOTICE" => {
@@ -2161,7 +2321,27 @@ where
                                         let _ = tx.send(msgid.clone());
                                     }
 
-                                    let _ = event_tx.send(Event::Message { from, target, text, tags }).await;
+                                    // Learn the sender's DID from the account
+                                    // tag (a cold first DM would otherwise key
+                                    // by nick until too late) and announce a
+                                    // new binding so consumers can merge.
+                                    if !target.starts_with('#')
+                                        && !target.starts_with('&')
+                                        && !from.eq_ignore_ascii_case(&own_nick)
+                                        && let Some(did) = tags.get("account")
+                                        && crate::address::is_did(did)
+                                        && did_maps.lock().learn(&from, did)
+                                    {
+                                        let _ = event_tx
+                                            .send(Event::MemberDid {
+                                                nick: from.clone(),
+                                                did: did.clone(),
+                                            })
+                                            .await;
+                                    }
+                                    let dm_key =
+                                        dm_key_for(&did_maps, &own_nick, &from, &target);
+                                    let _ = event_tx.send(Event::Message { from, target, text, tags, dm_key }).await;
                                 }
                             }
                         }
@@ -2172,7 +2352,8 @@ where
                                     .unwrap_or("")
                                     .to_string();
                                 let target = msg.params[0].clone();
-                                let _ = event_tx.send(Event::TagMsg { from, target, tags: msg.tags.clone() }).await;
+                                let dm_key = dm_key_for(&did_maps, &own_nick, &from, &target);
+                                let _ = event_tx.send(Event::TagMsg { from, target, tags: msg.tags.clone(), dm_key }).await;
                             }
                         }
                         "CHATHISTORY" => {
@@ -2181,10 +2362,23 @@ where
                             if msg.params.first().map(|s| s.as_str()) == Some("TARGETS") {
                                 if let Some(nick) = msg.params.get(1) {
                                     let timestamp = msg.tags.get("time").cloned();
+                                    // The server names the conversation's
+                                    // stable identity in the partner-did tag;
+                                    // learn display-only (the nick may be
+                                    // historical — never addressing-grade).
+                                    let partner_did = msg
+                                        .tags
+                                        .get("freeq.at/partner-did")
+                                        .filter(|d| crate::address::is_did(d))
+                                        .cloned();
+                                    if let Some(ref did) = partner_did {
+                                        did_maps.lock().learn_display(did, nick);
+                                    }
                                     let _ = event_tx
                                         .send(Event::ChatHistoryTarget {
                                             nick: nick.clone(),
                                             timestamp,
+                                            partner_did,
                                         })
                                         .await;
                                 }
@@ -2264,6 +2458,7 @@ where
 async fn dispatch_assembled_multiline(
     event_tx: &mpsc::Sender<Event>,
     batch: InboundMultilineBatch,
+    dm_key: Option<String>,
 ) {
     let mut text = String::new();
     for (i, line) in batch.lines.iter().enumerate() {
@@ -2282,6 +2477,7 @@ async fn dispatch_assembled_multiline(
             target: batch.target,
             text,
             tags,
+            dm_key,
         })
         .await;
     // Nested-batch parent (e.g. multiline inside CHATHISTORY) is
@@ -2853,7 +3049,7 @@ mod multiline_tests {
             ],
             parent_batch_id: None,
         };
-        dispatch_assembled_multiline(&tx, batch).await;
+        dispatch_assembled_multiline(&tx, batch, None).await;
         match rx.recv().await.unwrap() {
             Event::Message {
                 from, target, text, ..
@@ -2889,7 +3085,7 @@ mod multiline_tests {
             ],
             parent_batch_id: None,
         };
-        dispatch_assembled_multiline(&tx, batch).await;
+        dispatch_assembled_multiline(&tx, batch, None).await;
         match rx.recv().await.unwrap() {
             Event::Message { text, .. } => assert_eq!(text, "alphabeta\ngamma"),
             other => panic!("expected Message, got {other:?}"),
@@ -2922,7 +3118,7 @@ mod multiline_tests {
             ],
             parent_batch_id: None,
         };
-        dispatch_assembled_multiline(&tx, batch).await;
+        dispatch_assembled_multiline(&tx, batch, None).await;
         match rx.recv().await.unwrap() {
             Event::Message { tags, .. } => {
                 assert_eq!(tags.get("msgid").map(String::as_str), Some("01XYZ"));
@@ -3164,6 +3360,7 @@ mod multiline_tests {
     async fn privmsg_auto_routes_to_multiline_when_cap_acked() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         caps_acked
             .lock()
             .acked
@@ -3173,6 +3370,7 @@ mod multiline_tests {
             cmd_tx,
             echo_registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             caps_acked,
+            did_maps,
         };
         handle.privmsg("#test", "alpha\nbeta\ngamma").await.unwrap();
         match cmd_rx.recv().await.unwrap() {
@@ -3201,11 +3399,13 @@ mod multiline_tests {
     async fn privmsg_falls_back_to_single_when_cap_not_acked() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         // No caps acked
         let handle = ClientHandle {
             cmd_tx,
             echo_registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             caps_acked,
+            did_maps,
         };
         handle.privmsg("#test", "a\nb").await.unwrap();
         match cmd_rx.recv().await.unwrap() {
@@ -3225,6 +3425,7 @@ mod multiline_tests {
     async fn send_tagged_auto_routes_to_multiline_with_opener_tags() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         caps_acked
             .lock()
             .acked
@@ -3234,6 +3435,7 @@ mod multiline_tests {
             cmd_tx,
             echo_registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             caps_acked,
+            did_maps,
         };
         let mut tags = std::collections::HashMap::new();
         tags.insert("+freeq.at/event".to_string(), "reveal".to_string());
@@ -3266,6 +3468,7 @@ mod multiline_tests {
     async fn privmsg_single_line_never_routes_to_multiline() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         caps_acked
             .lock()
             .acked
@@ -3275,6 +3478,7 @@ mod multiline_tests {
             cmd_tx,
             echo_registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             caps_acked,
+            did_maps,
         };
         handle.privmsg("#test", "hello world").await.unwrap();
         match cmd_rx.recv().await.unwrap() {
@@ -3301,6 +3505,7 @@ mod multiline_tests {
         let (_cmd_tx, cmd_rx) = mpsc::channel::<Command>(16);
         let echo_registry: EchoRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         let config = ConnectConfig {
             server_addr: "test".to_string(),
             nick: "tester".to_string(),
@@ -3323,6 +3528,7 @@ mod multiline_tests {
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await;
         });
@@ -3414,6 +3620,7 @@ mod multiline_tests {
         let (_cmd_tx, cmd_rx) = mpsc::channel::<Command>(16);
         let echo_registry: EchoRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         let config = ConnectConfig {
             server_addr: "test".to_string(),
             nick: "tester".to_string(),
@@ -3436,6 +3643,7 @@ mod multiline_tests {
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await;
         });
@@ -3590,6 +3798,7 @@ mod irc_loop_tests {
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>(64);
         let echo_registry: EchoRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let caps_acked: CapsAcked = Arc::new(parking_lot::Mutex::new(CapsState::default()));
+        let did_maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
         let config = test_config(nick);
 
         let (reader, writer) = tokio::io::split(client_side);
@@ -3603,6 +3812,7 @@ mod irc_loop_tests {
                 cmd_rx,
                 echo_registry,
                 caps_acked,
+                did_maps,
             )
             .await;
         });
@@ -4496,7 +4706,7 @@ mod irc_loop_tests {
 
         let got = tokio::time::timeout(tokio::time::Duration::from_millis(400), async {
             while let Some(ev) = events.recv().await {
-                if let Event::TagMsg { from, target, tags } = ev {
+                if let Event::TagMsg { from, target, tags, .. } = ev {
                     return Some((from, target, tags));
                 }
             }
@@ -4646,5 +4856,70 @@ mod irc_loop_tests {
             account.is_none(),
             "account `*` sentinel must be treated as unauthenticated (None)"
         );
+    }
+}
+
+#[cfg(test)]
+mod did_maps_tests {
+    use super::*;
+
+    const BOB: &str = "did:plc:bob";
+
+    #[test]
+    fn learn_reports_new_and_changed_bindings_only() {
+        let mut m = DidMapsState::default();
+        assert!(m.learn("Bob", BOB)); // new
+        assert!(!m.learn("bob", BOB)); // same (case-insensitive nick)
+        assert!(m.learn("bob", "did:plc:other")); // changed
+    }
+
+    #[test]
+    fn learn_display_never_creates_an_addressing_binding() {
+        let mut m = DidMapsState::default();
+        m.learn_display(BOB, "bob");
+        assert_eq!(m.wire_target("bob"), "bob"); // strict: unresolved
+        assert_eq!(m.dm_key("bob"), BOB); // loose: display reverse applies
+    }
+
+    #[test]
+    fn forget_nick_clears_addressing_but_keeps_display() {
+        let mut m = DidMapsState::default();
+        m.learn("bob", BOB);
+        m.forget_nick("bob");
+        assert_eq!(m.wire_target("bob"), "bob"); // routing must not follow
+        assert_eq!(m.dm_key("bob"), BOB); // thread key survives the quit
+        assert_eq!(m.did_to_nick.get(BOB).map(String::as_str), Some("bob"));
+    }
+
+    #[test]
+    fn rename_moves_the_binding() {
+        let mut m = DidMapsState::default();
+        m.learn("bob", BOB);
+        m.rename("bob", "bobby");
+        assert_eq!(m.wire_target("bobby"), BOB);
+        assert_eq!(m.wire_target("bob"), "bob");
+        assert_eq!(m.did_to_nick.get(BOB).map(String::as_str), Some("bobby"));
+    }
+
+    #[test]
+    fn keys_pass_dids_through_and_leave_guests_untouched() {
+        let m = DidMapsState::default();
+        assert_eq!(m.dm_key(BOB), BOB);
+        assert_eq!(m.dm_key("Guest7"), "Guest7"); // no mangling
+        assert_eq!(m.wire_target(BOB), BOB);
+    }
+
+    #[test]
+    fn dm_key_for_selects_the_peer_end_and_skips_channels() {
+        let maps: DidMaps = Arc::new(parking_lot::Mutex::new(DidMapsState::default()));
+        maps.lock().learn("bob", BOB);
+        // Channel → None.
+        assert_eq!(dm_key_for(&maps, "me", "bob", "#dev"), None);
+        // Incoming: peer is the sender.
+        assert_eq!(dm_key_for(&maps, "me", "bob", "me").as_deref(), Some(BOB));
+        // Echo of our own send: peer is the target.
+        assert_eq!(dm_key_for(&maps, "me", "me", "bob").as_deref(), Some(BOB));
+        // Guest peer stays nick-keyed.
+        assert_eq!(dm_key_for(&maps, "me", "guest9", "me").as_deref(), Some("guest9"));
     }
 }

--- a/freeq-sdk/src/event.rs
+++ b/freeq-sdk/src/event.rs
@@ -42,6 +42,13 @@ pub enum Event {
         text: String,
         /// IRCv3 message tags (empty if none).
         tags: std::collections::HashMap<String, String>,
+        /// For a DM: the canonical conversation key — the peer's DID when
+        /// known, else their nick (`address::dm_peer_key`). `None` for
+        /// channel messages. Direction-independent: our echo and the peer's
+        /// reply carry the same value, so one person is one thread. Assumes
+        /// one authenticated identity per client session (a multi-account
+        /// consumer must namespace its stores per account).
+        dm_key: Option<String>,
     },
 
     /// A TAGMSG (tags only, no body) — used for reactions, typing indicators, etc.
@@ -49,6 +56,9 @@ pub enum Event {
         from: String,
         target: String,
         tags: std::collections::HashMap<String, String>,
+        /// Same as [`Event::Message::dm_key`]: the DM conversation key,
+        /// `None` for channels.
+        dm_key: Option<String>,
     },
 
     /// BATCH start (e.g., chathistory)
@@ -69,6 +79,20 @@ pub enum Event {
     ChatHistoryTarget {
         nick: String,
         timestamp: Option<String>,
+        /// The partner's DID from the server's `freeq.at/partner-did` tag —
+        /// the conversation's stable identity (key threads by this, not the
+        /// display nick). `None` from servers that don't send the tag.
+        partner_did: Option<String>,
+    },
+
+    /// A nick↔DID binding was learned (extended-join, WHOIS, or a message's
+    /// account tag). Consumers should fold any nick-keyed DM thread for
+    /// `nick` into the DID-keyed one — a cold first DM keys by nick until
+    /// the peer's identity is learned here. Emitted only when the binding
+    /// is new or changed.
+    MemberDid {
+        nick: String,
+        did: String,
     },
 
     /// NAMES list for a channel (one 353 reply; may arrive in multiple parts).

--- a/freeq-sdk/src/lib.rs
+++ b/freeq-sdk/src/lib.rs
@@ -16,6 +16,7 @@
 //! - [`irc`] — IRC message parsing/formatting
 
 pub mod act;
+pub mod address;
 pub mod auth;
 pub mod av;
 pub mod bot;

--- a/freeq-server/tests/sdk_client.rs
+++ b/freeq-server/tests/sdk_client.rs
@@ -457,3 +457,262 @@ async fn nick_collision_gets_alternate() {
         );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════
+// DID-KEYED DMS (dm_key / MemberDid / partner_did)
+// ═══════════════════════════════════════════════════════════════
+
+const DID_A: &str = "did:plc:sdk_dm_alice";
+const DID_C: &str = "did:plc:sdk_dm_carol";
+
+async fn start_with_dids(
+    dids: &[(&str, &PrivateKey)],
+    with_db: bool,
+) -> (
+    std::net::SocketAddr,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+) {
+    let mut docs = HashMap::new();
+    for (did, key) in dids {
+        docs.insert(
+            did.to_string(),
+            did::make_test_did_document(did, &key.public_key_multibase()),
+        );
+    }
+    let db_path = if with_db {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let p = tmp.path().to_str().unwrap().to_string();
+        std::mem::forget(tmp);
+        Some(p)
+    } else {
+        None
+    };
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        server_name: "test-sdk-dm".to_string(),
+        challenge_timeout_secs: 60,
+        db_path,
+        ..Default::default()
+    };
+    freeq_server::server::Server::with_resolver(config, DidResolver::static_map(docs))
+        .start()
+        .await
+        .unwrap()
+}
+
+fn cfg(addr: std::net::SocketAddr, nick: &str) -> ConnectConfig {
+    ConnectConfig {
+        server_addr: addr.to_string(),
+        nick: nick.to_string(),
+        user: nick.to_string(),
+        realname: "t".to_string(),
+        ..Default::default()
+    }
+}
+
+fn signer_for(did: &str, key: PrivateKey) -> Arc<dyn ChallengeSigner> {
+    Arc::new(KeySigner::new(did.to_string(), key))
+}
+
+/// An incoming DM carries dm_key = the sender's DID (learned from the
+/// account tag), while `target` stays the raw wire value (our own nick);
+/// the binding is announced via MemberDid exactly once.
+#[tokio::test]
+async fn incoming_dm_keys_by_sender_did_and_announces_binding_once() {
+    let key = PrivateKey::generate_ed25519();
+    let (addr, _h) = start_with_dids(&[(DID_A, &key)], false).await;
+
+    let (ha, mut rxa) = client::connect(cfg(addr, "dmalice"), Some(signer_for(DID_A, key)));
+    wait(&mut rxa, |e| matches!(e, Event::Registered { .. }), "reg A").await;
+    let (_hb, mut rxb) = client::connect(cfg(addr, "dmguest"), None);
+    wait(&mut rxb, |e| matches!(e, Event::Registered { .. }), "reg B").await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    ha.privmsg("dmguest", "first").await.unwrap();
+    let m1 = wait(
+        &mut rxb,
+        |e| matches!(e, Event::Message { text, .. } if text == "first"),
+        "dm 1",
+    )
+    .await;
+    if let Event::Message { target, dm_key, .. } = m1 {
+        assert_eq!(target, "dmguest", "raw wire target preserved");
+        assert_eq!(dm_key.as_deref(), Some(DID_A), "keyed by the sender's DID");
+    }
+
+    ha.privmsg("dmguest", "second").await.unwrap();
+    wait(
+        &mut rxb,
+        |e| matches!(e, Event::Message { text, .. } if text == "second"),
+        "dm 2",
+    )
+    .await;
+    // Drain B's history: exactly one MemberDid for the peer.
+    let mut member_dids = 0;
+    while let Ok(Some(e)) =
+        tokio::time::timeout(Duration::from_millis(300), rxb.recv()).await
+    {
+        if matches!(&e, Event::MemberDid { did, .. } if did == DID_A) {
+            member_dids += 1;
+        }
+    }
+    // The two Message events already consumed above; the MemberDid arrived
+    // before the first of them — recv'd during the waits — so re-run the
+    // scenario with a fresh listener is overkill: assert via a third message
+    // that no NEW MemberDid is emitted.
+    ha.privmsg("dmguest", "third").await.unwrap();
+    let mut saw_third = false;
+    while let Ok(Some(e)) =
+        tokio::time::timeout(Duration::from_millis(500), rxb.recv()).await
+    {
+        match &e {
+            Event::MemberDid { did, .. } if did == DID_A => member_dids += 1,
+            Event::Message { text, .. } if text == "third" => {
+                saw_third = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_third, "third dm delivered");
+    assert_eq!(member_dids, 0, "no re-announcement for a known binding");
+}
+
+/// Channel messages never carry a dm_key.
+#[tokio::test]
+async fn channel_message_has_no_dm_key() {
+    let (addr, _h) = start().await;
+    let (h1, mut rx1) = client::connect(cfg(addr, "chan1"), None);
+    let (h2, mut rx2) = client::connect(cfg(addr, "chan2"), None);
+    wait(&mut rx1, |e| matches!(e, Event::Registered { .. }), "reg1").await;
+    wait(&mut rx2, |e| matches!(e, Event::Registered { .. }), "reg2").await;
+    h1.join("#dmkeytest").await.unwrap();
+    h2.join("#dmkeytest").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    h1.privmsg("#dmkeytest", "channel msg").await.unwrap();
+    let m = wait(
+        &mut rx2,
+        |e| matches!(e, Event::Message { text, .. } if text == "channel msg"),
+        "chan msg",
+    )
+    .await;
+    if let Event::Message { dm_key, .. } = m {
+        assert_eq!(dm_key, None);
+    }
+}
+
+/// After learning a peer's DID (extended-join), a nick-addressed send goes
+/// out DID-addressed: the recipient sees the DID as the wire target.
+#[tokio::test]
+async fn send_resolves_learned_did_target() {
+    let key = PrivateKey::generate_ed25519();
+    let (addr, _h) = start_with_dids(&[(DID_A, &key)], false).await;
+
+    let (hb, mut rxb) = client::connect(cfg(addr, "resolveb"), None);
+    wait(&mut rxb, |e| matches!(e, Event::Registered { .. }), "reg B").await;
+    hb.join("#resolve").await.unwrap();
+    wait(
+        &mut rxb,
+        |e| matches!(e, Event::Joined { channel, .. } if channel == "#resolve"),
+        "B joined",
+    )
+    .await;
+
+    let (ha, mut rxa) = client::connect(cfg(addr, "resolvea"), Some(signer_for(DID_A, key)));
+    wait(&mut rxa, |e| matches!(e, Event::Registered { .. }), "reg A").await;
+    ha.join("#resolve").await.unwrap();
+    // B sees A's extended-join with the account → learns + announces.
+    wait(
+        &mut rxb,
+        |e| matches!(e, Event::MemberDid { nick, did } if nick == "resolvea" && did == DID_A),
+        "B learned A's DID from the join",
+    )
+    .await;
+
+    hb.privmsg("resolvea", "hi by nick").await.unwrap();
+    let m = wait(
+        &mut rxa,
+        |e| matches!(e, Event::Message { text, .. } if text == "hi by nick"),
+        "A got the DM",
+    )
+    .await;
+    if let Event::Message { target, dm_key, .. } = m {
+        assert_eq!(target, DID_A, "wire target was resolved to the DID");
+        // For the recipient the peer is the (guest) sender.
+        assert_eq!(dm_key.as_deref(), Some("resolveb"));
+    }
+}
+
+/// CHATHISTORY TARGETS carries the partner's DID from the server tag.
+#[tokio::test]
+async fn chathistory_targets_carry_partner_did() {
+    let key_a = PrivateKey::generate_ed25519();
+    let key_c = PrivateKey::generate_ed25519();
+    let (addr, _h) = start_with_dids(&[(DID_A, &key_a), (DID_C, &key_c)], true).await;
+
+    // Both DID-authed so the DM persists; exchange one message.
+    let (ha, mut rxa) = client::connect(
+        cfg(addr, "hista"),
+        Some(signer_for(DID_A, PrivateKey::ed25519_from_bytes(&key_a.secret_bytes()).unwrap())),
+    );
+    wait(&mut rxa, |e| matches!(e, Event::Registered { .. }), "reg A").await;
+    let (_hc, mut rxc) = client::connect(
+        cfg(addr, "histc"),
+        Some(signer_for(DID_C, PrivateKey::ed25519_from_bytes(&key_c.secret_bytes()).unwrap())),
+    );
+    wait(&mut rxc, |e| matches!(e, Event::Registered { .. }), "reg C").await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    ha.privmsg("histc", "persist me").await.unwrap();
+    wait(
+        &mut rxc,
+        |e| matches!(e, Event::Message { text, .. } if text == "persist me"),
+        "C got it",
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // A reconnects fresh and asks for its conversation list.
+    let (ha2, mut rxa2) = client::connect(
+        cfg(addr, "hista2"),
+        Some(signer_for(DID_A, PrivateKey::ed25519_from_bytes(&key_a.secret_bytes()).unwrap())),
+    );
+    wait(&mut rxa2, |e| matches!(e, Event::Registered { .. }), "reg A2").await;
+    ha2.raw("CHATHISTORY TARGETS * * 50").await.unwrap();
+    let t = wait(
+        &mut rxa2,
+        |e| matches!(e, Event::ChatHistoryTarget { .. }),
+        "targets entry",
+    )
+    .await;
+    if let Event::ChatHistoryTarget { partner_did, .. } = t {
+        assert_eq!(
+            partner_did.as_deref(),
+            Some(DID_C),
+            "conversation list names the partner's DID"
+        );
+    }
+
+    // The TARGETS tag taught a DISPLAY binding only. Sending to the nick
+    // must keep the nick on the wire (display bindings are never
+    // addressing-grade) while the echo keys the thread by the DID — the
+    // strict/loose split, observed live. (The quit path exercises the same
+    // split but is gated behind the server's 30s reconnect-grace before it
+    // broadcasts QUIT; the forget-on-quit transition is unit-covered in
+    // client::did_maps_tests.)
+    ha2.privmsg("histc", "follow-up").await.unwrap();
+    let echo = wait(
+        &mut rxa2,
+        |e| matches!(e, Event::Message { text, .. } if text == "follow-up"),
+        "echo of the follow-up",
+    )
+    .await;
+    if let Event::Message { from, target, dm_key, .. } = echo {
+        assert_eq!(from, "hista2");
+        assert_eq!(target, "histc", "display binding must not become a wire target");
+        assert_eq!(
+            dm_key.as_deref(),
+            Some(DID_C),
+            "thread keys by the DID via the display binding"
+        );
+    }
+}

--- a/freeq-tui/src/main.rs
+++ b/freeq-tui/src/main.rs
@@ -869,6 +869,9 @@ fn process_p2p_event(app: &mut App, event: freeq_sdk::p2p::P2pEvent) {
 
 fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle) {
     match event {
+        // Nick<->DID binding learned. Adopted in the TUI's DID-DM pass;
+        // ignored until then (this keeps the build from breaking, no more).
+        Event::MemberDid { .. } => {}
         Event::Connected => {
             app.connection_state = "connected".to_string();
             app.status_msg(&format!(
@@ -921,8 +924,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
             from,
             target,
             text,
-            tags,
-        } => {
+            tags, .. } => {
             // Try E2EE decryption if we have a key for this channel
             let (text, was_encrypted) = {
                 let buf_key =
@@ -1166,7 +1168,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
         Event::BatchEnd { id } => {
             app.end_batch(&id);
         }
-        Event::TagMsg { from, target, tags } => {
+        Event::TagMsg { from, target, tags, .. } => {
             // Delete: mark the target line as deleted; don't display a new line.
             if let Some(deleted_msgid) = tags
                 .get("+draft/delete")
@@ -1451,7 +1453,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                 }
             }
         }
-        Event::ChatHistoryTarget { nick, timestamp } => {
+        Event::ChatHistoryTarget { nick, timestamp, .. } => {
             let ts_display = timestamp.as_deref().unwrap_or("?");
             app.buffer_mut("status")
                 .push_system(&format!("  DM: {nick}  (last: {ts_display})"));

--- a/freeq-windows-core/src/event.rs
+++ b/freeq-windows-core/src/event.rs
@@ -136,8 +136,7 @@ pub fn convert_event(event: &freeq_sdk::event::Event) -> DomainEvent {
             from,
             target,
             text,
-            tags,
-        } => {
+            tags, .. } => {
             let msgid = tags.get("msgid").cloned();
             let reply_to = tags.get("+reply").cloned();
             let edit_of = tags.get("+draft/edit").cloned();
@@ -167,7 +166,7 @@ pub fn convert_event(event: &freeq_sdk::event::Event) -> DomainEvent {
                 timestamp_ms: ts,
             })
         }
-        Event::TagMsg { from, target, tags } => DomainEvent::TagMsg(TagMsgData {
+        Event::TagMsg { from, target, tags, .. } => DomainEvent::TagMsg(TagMsgData {
             from: from.clone(),
             target: target.clone(),
             tags: tags.clone(),
@@ -265,7 +264,7 @@ pub fn convert_event(event: &freeq_sdk::event::Event) -> DomainEvent {
         Event::WhoisReply { nick, info } => DomainEvent::Notice {
             text: format!("WHOIS {nick}: {info}"),
         },
-        Event::ChatHistoryTarget { nick, timestamp } => DomainEvent::Notice {
+        Event::ChatHistoryTarget { nick, timestamp, .. } => DomainEvent::Notice {
             text: format!("DM: {nick} (last: {})", timestamp.as_deref().unwrap_or("?")),
         },
         Event::ReadMarker { target, timestamp } => DomainEvent::Notice {
@@ -275,6 +274,9 @@ pub fn convert_event(event: &freeq_sdk::event::Event) -> DomainEvent {
             ),
         },
         Event::RawLine(line) => DomainEvent::Notice { text: line.clone() },
+        // Nick<->DID binding learned. Not yet modeled as a DomainEvent —
+        // adopted in the Windows DID-DM pass; inert empty notice until then.
+        Event::MemberDid { .. } => DomainEvent::Notice { text: String::new() },
     }
 }
 
@@ -294,6 +296,7 @@ mod tests {
             target: "#test".to_string(),
             text: "hello world".to_string(),
             tags,
+            dm_key: None,
         };
 
         let domain = convert_event(&event);
@@ -314,6 +317,7 @@ mod tests {
             target: "#test".to_string(),
             text: "\x01ACTION waves\x01".to_string(),
             tags: HashMap::new(),
+            dm_key: None,
         };
 
         let domain = convert_event(&event);
@@ -379,6 +383,7 @@ mod tests {
             target: "#test".to_string(),
             text: "edited text".to_string(),
             tags,
+            dm_key: None,
         };
 
         let domain = convert_event(&event);


### PR DESCRIPTION
# Rust SDK + Android: DID-keyed DM conversations

## What changes

**Core SDK (`freeq-sdk`)** — additive; raw `from`/`target` are untouched
and existing consumers keep working unchanged:

- `address` module: `is_did` / `dm_peer_key` — "DID when known, else the
  input unchanged" (twin of the JS SDK's address.ts, same test vectors).
- The client keeps a session nick↔DID map with deliberately asymmetric
  lifetimes: nick→DID is addressing-grade and cleared when the owner quits
  (a released nick can be recycled — routing must never follow a stale
  binding); DID→nick is display/keying-grade and retained (a DID is
  permanent — a thread keeps its key and name when the peer goes offline).
  Populated from extended-join, WHOIS, inbound account tags, and the
  conversation list's `freeq.at/partner-did` tag (display-only — its nick
  can be historical).
- `Event::Message` / `Event::TagMsg` gain `dm_key`: the canonical
  conversation key (peer DID when known, else their nick; `None` for
  channels), computed from the non-self end so an echo and the peer's
  reply land in one thread. `Event::ChatHistoryTarget` gains
  `partner_did`. New `Event::MemberDid` announces a newly-learned binding
  so consumers can merge a nick-keyed thread from a cold first DM into
  the DID-keyed one.
- Sends (`privmsg` / multiline / `send_tagged`) resolve a DM target to
  the peer's DID when addressing-grade known; the signature canonical
  covers the resolved target, matching what the server verifies.

**FFI (`freeq-sdk-ffi`)**: `dm_key`, `partner_did`, and `MemberDid`
exposed through the UDL; Kotlin bindings regenerated (native libs build
locally via `build-rust.sh` as before).

**Android (`freeq-android`)** — the reference implementation:

- DM buffers key off `dm_key`; the conversation list keys off
  `partner_did`; `MemberDid` folds nick-keyed threads into DID-keyed ones
  (messages dedupe and stay ordered, unread carries, the active thread
  repoints).
- DM opens canonicalize to the DID at both navigation entry points, and
  the detail screen follows a mid-view re-key — on-device testing caught
  the first-contact flow ("Channel not found" after the peer's first
  reply re-keyed the open thread).
- `DidDisplay` resolves any key to a human name (display binding →
  reverse nick map → compacted DID) at chat rows, avatars, the DM title,
  and the composer placeholder — a raw `did:…` string never renders.

## Compatibility

- Entirely client-side; servers already provide everything consumed
  (`partner-did` tag, account tags, DID-target routing — all on main).
- Guests: `dm_peer_key` passes nicks through, so guest DMs stay
  nick-keyed and behave exactly as before, on every path.
- Old SDK consumers: new event fields are additive; anything ignoring
  them behaves identically to today. iOS/macOS keep current behavior
  until their own pass (Android is the template; their Swift bindings
  regenerate in their build environments). The mechanical Swift compile
  fixes for the regenerated bindings (ChatHistoryTarget arity, inert
  MemberDid arms) are included, so both apps build unchanged.

## Testing

- Rust: unit tests for the map semantics (learn/display/forget/rename,
  strict-vs-loose resolution, peer-end selection) and live-server tests
  driving a real client against a real server: incoming DMs keyed by the
  sender's DID with the raw wire target preserved, `MemberDid` announced
  exactly once, channels carry no `dm_key`, a nick-addressed send
  resolves to the DID wire target after extended-join learning, and the
  conversation list carries `partner_did` while its display binding keys
  threads without ever becoming a wire target. Suites: freeq-sdk 457,
  freeq-sdk-ffi 15, freeq-server 1071 — all green.
- Android: JVM unit tests for the identity helpers and the thread merge
  (113 green), plus a full on-device pass against a live server —
  first-contact DM, echo coherence, force-stop/cold-start conversation
  list, guest fallback, federated thread rendering.
