### PR TITLE
One identity per message, unchanged by edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,29 @@ freeq-auth-broker/ OAuth broker for AT Protocol
 freeq-site/      Marketing site (freeq.at)
 ```
 
+## Database migrations
+
+The server's SQLite database has two change mechanisms, and which one you
+use depends on what you're changing:
+
+- **Schema shape** (new tables, new columns): add an idempotent
+  `CREATE TABLE IF NOT EXISTS` / `ALTER TABLE` to the statement list in
+  `Db::init()` (`freeq-server/src/db.rs`). These replay on every boot and
+  converge any database to the current shape.
+- **One-time data changes** (backfills, rewrites, anything that moves rows):
+  add an entry to `migration_ladder()` in the same file. The ladder is
+  `rusqlite_migration`, tracked in SQLite's `PRAGMA user_version` — the
+  integer version slot SQLite reserves for the application. Migrations are
+  numbered by list position, run in order, and each commits atomically with
+  its version stamp, so they run exactly once per database and don't need to
+  be idempotent. The ladder is **append-only**: never insert, reorder, or
+  renumber entries — databases in the wild are stamped with the versions
+  they've passed.
+
+Slot 1 of the ladder is an empty placeholder deliberately reserved for
+moving the `init()` schema statements into the ladder (see the comment on
+`migration_ladder()`). Don't put anything else there.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
+ "rusqlite_migration",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -7165,6 +7166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite_migration"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ffe0efe8568c769d1e39c67ea2a093134afaac9bb4559246a2ee7a4d686044"
+dependencies = [
+ "log",
+ "rusqlite",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8465,7 +8476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/ffi/freeq.kt
@@ -3302,6 +3302,54 @@ public object FfiConverterTypeChannelTopic: FfiConverterRustBuffer<ChannelTopic>
 
 
 
+data class CoordinationEvent (
+    var `eventType`: kotlin.String, 
+    var `taskId`: kotlin.String?, 
+    var `phase`: kotlin.String?, 
+    var `evidenceType`: kotlin.String?, 
+    var `reference`: kotlin.String?, 
+    var `payload`: kotlin.String?
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeCoordinationEvent: FfiConverterRustBuffer<CoordinationEvent> {
+    override fun read(buf: ByteBuffer): CoordinationEvent {
+        return CoordinationEvent(
+            FfiConverterString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: CoordinationEvent) = (
+            FfiConverterString.allocationSize(value.`eventType`) +
+            FfiConverterOptionalString.allocationSize(value.`taskId`) +
+            FfiConverterOptionalString.allocationSize(value.`phase`) +
+            FfiConverterOptionalString.allocationSize(value.`evidenceType`) +
+            FfiConverterOptionalString.allocationSize(value.`reference`) +
+            FfiConverterOptionalString.allocationSize(value.`payload`)
+    )
+
+    override fun write(value: CoordinationEvent, buf: ByteBuffer) {
+            FfiConverterString.write(value.`eventType`, buf)
+            FfiConverterOptionalString.write(value.`taskId`, buf)
+            FfiConverterOptionalString.write(value.`phase`, buf)
+            FfiConverterOptionalString.write(value.`evidenceType`, buf)
+            FfiConverterOptionalString.write(value.`reference`, buf)
+            FfiConverterOptionalString.write(value.`payload`, buf)
+    }
+}
+
+
+
 data class IrcMember (
     var `nick`: kotlin.String, 
     var `isOp`: kotlin.Boolean, 
@@ -3363,7 +3411,9 @@ data class IrcMessage (
     var `account`: kotlin.String?, 
     var `origin`: kotlin.String?, 
     var `reactions`: List<ReactionTally>, 
-    var `dmKey`: kotlin.String?
+    var `edited`: kotlin.Boolean, 
+    var `dmKey`: kotlin.String?, 
+    var `coordination`: CoordinationEvent?
 ) {
     
     companion object
@@ -3391,7 +3441,9 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalString.read(buf),
             FfiConverterSequenceTypeReactionTally.read(buf),
+            FfiConverterBoolean.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalTypeCoordinationEvent.read(buf),
         )
     }
 
@@ -3412,7 +3464,9 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterOptionalString.allocationSize(value.`account`) +
             FfiConverterOptionalString.allocationSize(value.`origin`) +
             FfiConverterSequenceTypeReactionTally.allocationSize(value.`reactions`) +
-            FfiConverterOptionalString.allocationSize(value.`dmKey`)
+            FfiConverterBoolean.allocationSize(value.`edited`) +
+            FfiConverterOptionalString.allocationSize(value.`dmKey`) +
+            FfiConverterOptionalTypeCoordinationEvent.allocationSize(value.`coordination`)
     )
 
     override fun write(value: IrcMessage, buf: ByteBuffer) {
@@ -3432,7 +3486,9 @@ public object FfiConverterTypeIrcMessage: FfiConverterRustBuffer<IrcMessage> {
             FfiConverterOptionalString.write(value.`account`, buf)
             FfiConverterOptionalString.write(value.`origin`, buf)
             FfiConverterSequenceTypeReactionTally.write(value.`reactions`, buf)
+            FfiConverterBoolean.write(value.`edited`, buf)
             FfiConverterOptionalString.write(value.`dmKey`, buf)
+            FfiConverterOptionalTypeCoordinationEvent.write(value.`coordination`, buf)
     }
 }
 
@@ -4930,6 +4986,38 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
         } else {
             buf.put(1)
             FfiConverterString.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeCoordinationEvent: FfiConverterRustBuffer<CoordinationEvent?> {
+    override fun read(buf: ByteBuffer): CoordinationEvent? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeCoordinationEvent.read(buf)
+    }
+
+    override fun allocationSize(value: CoordinationEvent?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeCoordinationEvent.allocationSize(value)
+        }
+    }
+
+    override fun write(value: CoordinationEvent?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeCoordinationEvent.write(value, buf)
         }
     }
 }

--- a/freeq-android/freeq/src/main/java/com/freeq/model/MessageMapper.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/MessageMapper.kt
@@ -29,6 +29,10 @@ internal object MessageMapper {
             isAction = ircMsg.isAction,
             timestamp = Date(ircMsg.timestampMs),
             replyTo = ircMsg.replyTo,
+            // Covers both signals: a live edit (`editOf`) and one the server
+            // already collapsed into join replay, which carries no
+            // `+draft/edit` and would otherwise read as the original.
+            isEdited = ircMsg.edited,
             isSigned = ircMsg.isSigned,
             origin = ircMsg.origin,
             reactions = reactions,

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -128,29 +128,44 @@ class ChannelState(val name: String) {
         messages[idx] = messages[idx].copy(isDeleted = true, text = "")
     }
 
-    fun applyReaction(msgId: String, emoji: String, from: String): Boolean {
-        val idx = findMessage(msgId) ?: return true
+    /// Add `from` to this emoji's reactors. Idempotent: `+react` is an
+    /// explicit op, not a toggle, so a re-delivered or duplicated one is a
+    /// no-op rather than a removal.
+    fun addReaction(msgId: String, emoji: String, from: String) {
+        mutateReactions(msgId, emoji) { nicks -> nicks.add(from) }
+    }
+
+    /// Remove `from` from this emoji's reactors — what `+freeq.at/unreact`
+    /// means. Dropping the emoji entirely once nobody is left on it.
+    fun removeReaction(msgId: String, emoji: String, from: String) {
+        mutateReactions(msgId, emoji) { nicks -> nicks.remove(from) }
+    }
+
+    /// True when `from` has already reacted with `emoji` — lets the send path
+    /// decide which explicit op to transmit without inferring it from a
+    /// mutation's return value.
+    fun hasReaction(msgId: String, emoji: String, from: String): Boolean {
+        val idx = findMessage(msgId) ?: return false
+        return messages[idx].reactions[emoji]?.contains(from) == true
+    }
+
+    private fun mutateReactions(
+        msgId: String,
+        emoji: String,
+        change: (MutableSet<String>) -> Unit,
+    ) {
+        val idx = findMessage(msgId) ?: return
         val msg = messages[idx]
         // Build entirely new collections — mutating in place causes old.equals(new)
         // to be true on the data class, so LazyColumn skips recomposition.
         val newReactions = mutableMapOf<String, MutableSet<String>>()
-        var added = true
         for ((e, nicks) in msg.reactions) {
-            if (e == emoji) {
-                val newNicks = nicks.toMutableSet()
-                if (from in newNicks) { newNicks.remove(from); added = false }
-                else { newNicks.add(from); added = true }
-                if (newNicks.isNotEmpty()) newReactions[e] = newNicks
-            } else {
-                newReactions[e] = nicks.toMutableSet()
-            }
+            if (e != emoji) newReactions[e] = nicks.toMutableSet()
         }
-        if (emoji !in msg.reactions) {
-            newReactions[emoji] = mutableSetOf(from)
-            added = true
-        }
+        val target = msg.reactions[emoji]?.toMutableSet() ?: mutableSetOf()
+        change(target)
+        if (target.isNotEmpty()) newReactions[emoji] = target
         messages[idx] = msg.copy(reactions = newReactions)
-        return added
     }
 }
 
@@ -674,13 +689,20 @@ class AppState(application: Application) : AndroidViewModel(application) {
         } catch (_: Exception) {}
     }
 
+    /// Toggle our own reaction: which explicit op to send is decided from the
+    /// current state, then applied locally and transmitted. Removing used to
+    /// update the screen and send nothing at all, so an un-react never left
+    /// the device — the reaction stayed for everyone else.
     fun sendReaction(target: String, msgId: String, emoji: String) {
         val ch = channels.firstOrNull { it.name.equals(target, ignoreCase = true) }
             ?: dmBuffers.firstOrNull { it.name.equals(target, ignoreCase = true) }
-        val added = ch?.applyReaction(msgId, emoji, nick.value) ?: true
-        if (added) {
-            sendRaw("@+react=$emoji;+reply=$msgId TAGMSG $target")
+        val alreadyReacted = ch?.hasReaction(msgId, emoji, nick.value) ?: false
+        if (alreadyReacted) {
+            ch?.removeReaction(msgId, emoji, nick.value)
+        } else {
+            ch?.addReaction(msgId, emoji, nick.value)
         }
+        sendRaw(ReactionOp.line(target, msgId, emoji, alreadyReacted))
     }
 
     fun deleteMessage(target: String, msgId: String) {
@@ -1373,14 +1395,19 @@ class AndroidEventHandler(private val state: AppState) : EventHandler {
                     lookupBuffer(bufferName)?.applyDelete(deleteId)
                 }
 
-                // Reactions (self-echo already applied optimistically by sendReaction)
-                val emoji = tags["+react"]
+                // Reactions (self-echo already applied optimistically by
+                // sendReaction). Explicit ops, never a toggle: a re-delivered
+                // `+react` must be a no-op, and an unreact must remove —
+                // unreact wasn't handled here at all, so a reaction someone
+                // took back stayed on screen until a history refetch.
                 val replyId = tags["+reply"]
-                if (emoji != null && replyId != null) {
+                val addEmoji = tags["+react"]
+                val removeEmoji = tags["+freeq.at/unreact"]
+                if (replyId != null && (addEmoji != null || removeEmoji != null)) {
                     val bufferName = TagMsgRouter.routeTo(target, from, state.nick.value, event.msg.dmKey)
-                    if (bufferName != null) {
-                        lookupBuffer(bufferName)?.applyReaction(replyId, emoji, from)
-                    }
+                    val buf = if (bufferName != null) lookupBuffer(bufferName) else null
+                    if (addEmoji != null) buf?.addReaction(replyId, addEmoji, from)
+                    if (removeEmoji != null) buf?.removeReaction(replyId, removeEmoji, from)
                 }
             }
 

--- a/freeq-android/freeq/src/main/java/com/freeq/model/ReactionOp.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/ReactionOp.kt
@@ -1,0 +1,27 @@
+package com.freeq.model
+
+/**
+ * The wire line for reacting or un-reacting to a message.
+ *
+ * A reaction is two explicit operations, not one toggle: `+react` adds the
+ * sender to an emoji's reactors and `+freeq.at/unreact` removes them. Only the
+ * *sender's* intent is a toggle — which of the two to send is decided here from
+ * whether they've already reacted — and receivers apply whichever op arrives,
+ * so a re-delivered `+react` is a no-op rather than an accidental removal.
+ *
+ * Pure so the outbound line is assertable without an `AppState`; the dispatch
+ * site owns the local optimistic apply. (Removing used to update the screen and
+ * send nothing at all, so an un-react never left the device.)
+ *
+ * `msgId` needs no resolution: the server has sent root ids on reaction fan-out
+ * since it began keying by them, and this client has never re-keyed a message
+ * on edit, so the id held here is already the one the server files under.
+ */
+internal object ReactionOp {
+    fun line(target: String, msgId: String, emoji: String, alreadyReacted: Boolean): String =
+        if (alreadyReacted) {
+            "@+freeq.at/unreact=$emoji;+reply=$msgId TAGMSG $target"
+        } else {
+            "@+react=$emoji;+reply=$msgId TAGMSG $target"
+        }
+}

--- a/freeq-android/freeq/src/test/java/com/freeq/model/ChannelStateTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/ChannelStateTest.kt
@@ -121,35 +121,64 @@ class ChannelStateTest {
         assertFalse(ch.messages[0].isDeleted)
     }
 
-    // ── applyReaction ──
+    // ── reactions ──
+    //
+    // Two explicit ops, never a toggle. The sender's intent toggles (see
+    // ReactionOpTest); what arrives on the wire is an add or a remove, and
+    // applying one twice must not undo it.
 
-    @Test fun applyReaction_adds_first_reaction() {
+    @Test fun addReaction_adds_first_reaction() {
         val ch = ChannelState("#test")
         ch.appendIfNew(msg(id = "a"))
-        val added = ch.applyReaction("a", "👍", "alice")
-        assertTrue(added)
-        assertEquals(setOf("alice"), ch.messages[0].reactions["👍"])
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        assertEquals(setOf("alice"), ch.messages[0].reactions["\uD83D\uDC4D"])
     }
 
-    @Test fun applyReaction_toggles_off_when_same_user_reacts_again() {
+    @Test fun addReaction_is_idempotent_on_redelivery() {
+        // A duplicated or re-delivered `+react` used to toggle the reaction
+        // back off, silently removing something nobody took back.
         val ch = ChannelState("#test")
         ch.appendIfNew(msg(id = "a"))
-        ch.applyReaction("a", "👍", "alice")
-        val secondAdd = ch.applyReaction("a", "👍", "alice")
-        assertFalse("toggling off must report `added=false`", secondAdd)
-        assertNull(ch.messages[0].reactions["👍"])
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        assertEquals(setOf("alice"), ch.messages[0].reactions["\uD83D\uDC4D"])
     }
 
-    @Test fun applyReaction_keeps_other_users_reactions_when_one_toggles_off() {
+    @Test fun removeReaction_drops_the_emoji_when_nobody_is_left() {
         val ch = ChannelState("#test")
         ch.appendIfNew(msg(id = "a"))
-        ch.applyReaction("a", "👍", "alice")
-        ch.applyReaction("a", "👍", "bob")
-        ch.applyReaction("a", "👍", "alice") // alice toggles off
-        assertEquals(setOf("bob"), ch.messages[0].reactions["👍"])
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        ch.removeReaction("a", "\uD83D\uDC4D", "alice")
+        assertNull(ch.messages[0].reactions["\uD83D\uDC4D"])
     }
 
-    @Test fun applyReaction_replaces_message_object_so_compose_recomposes() {
+    @Test fun removeReaction_keeps_other_users_on_the_same_emoji() {
+        val ch = ChannelState("#test")
+        ch.appendIfNew(msg(id = "a"))
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        ch.addReaction("a", "\uD83D\uDC4D", "bob")
+        ch.removeReaction("a", "\uD83D\uDC4D", "alice")
+        assertEquals(setOf("bob"), ch.messages[0].reactions["\uD83D\uDC4D"])
+    }
+
+    @Test fun removeReaction_for_someone_who_never_reacted_is_a_noop() {
+        val ch = ChannelState("#test")
+        ch.appendIfNew(msg(id = "a"))
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        ch.removeReaction("a", "\uD83D\uDC4D", "bob")
+        assertEquals(setOf("alice"), ch.messages[0].reactions["\uD83D\uDC4D"])
+    }
+
+    @Test fun hasReaction_reports_whether_this_user_already_reacted() {
+        val ch = ChannelState("#test")
+        ch.appendIfNew(msg(id = "a"))
+        assertFalse(ch.hasReaction("a", "\uD83D\uDC4D", "alice"))
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
+        assertTrue(ch.hasReaction("a", "\uD83D\uDC4D", "alice"))
+        assertFalse(ch.hasReaction("a", "\uD83D\uDC4D", "bob"))
+    }
+
+    @Test fun addReaction_replaces_message_object_so_compose_recomposes() {
         // A LazyColumn reading via mutableStateListOf only recomposes when
         // the element identity changes (data class .equals would otherwise
         // make pre-/post- look identical to Compose). Verify the message
@@ -157,19 +186,20 @@ class ChannelStateTest {
         val ch = ChannelState("#test")
         ch.appendIfNew(msg(id = "a"))
         val before = ch.messages[0]
-        ch.applyReaction("a", "👍", "alice")
+        ch.addReaction("a", "\uD83D\uDC4D", "alice")
         val after = ch.messages[0]
-        assertNotNull(after.reactions["👍"])
+        assertNotNull(after.reactions["\uD83D\uDC4D"])
         // Different instance — the helper builds a new map.
         assertFalse(before === after)
     }
 
-    @Test fun applyReaction_returns_true_for_unknown_message() {
-        // Existing behavior: unknown msg id returns true (no-op,
-        // documented in the helper). Documenting it here so future
-        // changes go through a deliberate decision.
+    @Test fun reactions_on_an_unknown_message_are_a_noop() {
+        // Reacting to something this buffer doesn't hold must not create it.
         val ch = ChannelState("#test")
-        assertTrue(ch.applyReaction("missing", "👍", "alice"))
+        ch.addReaction("missing", "\uD83D\uDC4D", "alice")
+        ch.removeReaction("missing", "\uD83D\uDC4D", "alice")
+        assertTrue(ch.messages.isEmpty())
+        assertFalse(ch.hasReaction("missing", "\uD83D\uDC4D", "alice"))
     }
 
     // ── findMessage ──

--- a/freeq-android/freeq/src/test/java/com/freeq/model/MessageMapperTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/MessageMapperTest.kt
@@ -36,6 +36,7 @@ class MessageMapperTest {
         account: String? = null,
         origin: String? = null,
         reactions: List<ReactionTally> = emptyList(),
+        edited: Boolean = false,
     ) = IrcMessage(
         fromNick = fromNick,
         target = target,
@@ -53,7 +54,9 @@ class MessageMapperTest {
         account = account,
         origin = origin,
         reactions = reactions,
+        edited = edited,
         dmKey = null,
+        coordination = null,
     )
 
     @Test fun preserves_basic_fields() {
@@ -110,6 +113,15 @@ class MessageMapperTest {
         assertTrue(out.reactions.isEmpty())
         assertFalse(out.isEdited)
         assertFalse(out.isDeleted)
+    }
+
+    @Test fun edited_flag_carries_through_from_the_server() {
+        // Join replay collapses every revision into one row and sends no
+        // `+draft/edit`, so the server's `+freeq.at/edited` (surfaced as
+        // `edited`) is the only signal that a message was ever revised.
+        // Without this a message edited before you arrived read as original.
+        assertTrue(MessageMapper.fromIrc(ircMsg(edited = true)).isEdited)
+        assertFalse(MessageMapper.fromIrc(ircMsg(edited = false)).isEdited)
     }
 
     @Test fun reactions_persisted_on_history_message_populate_into_chat_message() {

--- a/freeq-android/freeq/src/test/java/com/freeq/model/ReactionOpTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/ReactionOpTest.kt
@@ -1,0 +1,48 @@
+package com.freeq.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The line a reaction actually puts on the wire.
+ *
+ * Un-reacting used to transmit nothing: the send path toggled local state and
+ * only sent when the toggle *added*, so taking a reaction back updated this
+ * device's screen and left it in place for everyone else. These assert the
+ * outbound line, not just local state, because local state was never the part
+ * that was broken.
+ */
+class ReactionOpTest {
+    private val target = "#freeq"
+    private val msgId = "01JABCDEF"
+    private val emoji = "🔥"
+
+    @Test fun reacting_sends_react() {
+        assertEquals(
+            "@+react=$emoji;+reply=$msgId TAGMSG $target",
+            ReactionOp.line(target, msgId, emoji, alreadyReacted = false),
+        )
+    }
+
+    @Test fun un_reacting_sends_unreact() {
+        assertEquals(
+            "@+freeq.at/unreact=$emoji;+reply=$msgId TAGMSG $target",
+            ReactionOp.line(target, msgId, emoji, alreadyReacted = true),
+        )
+    }
+
+    @Test fun the_two_ops_differ_only_in_the_tag() {
+        // Same reply id and target either way — the server resolves the
+        // message by that id, and it is the same message in both directions.
+        val add = ReactionOp.line(target, msgId, emoji, alreadyReacted = false)
+        val remove = ReactionOp.line(target, msgId, emoji, alreadyReacted = true)
+        assertEquals(add.substringAfter(";"), remove.substringAfter(";"))
+    }
+
+    @Test fun a_dm_target_uses_the_same_shape() {
+        assertEquals(
+            "@+react=$emoji;+reply=$msgId TAGMSG bob",
+            ReactionOp.line("bob", msgId, emoji, alreadyReacted = false),
+        )
+    }
+}

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -738,7 +738,12 @@ function FullMessageImpl({ msg, channel, onNickClick }: MessageProps) {
           )}
           <span className="text-xs text-fg-dim whitespace-nowrap cursor-default" title={msg.timestamp.toLocaleString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' })}>{formatTime(msg.timestamp)}</span>
           {msg.isStreaming && <span className="text-xs text-blue-400 animate-pulse">streaming…</span>}
-          {msg.editOf && !msg.isStreaming && <span className="text-xs text-fg-dim">(edited)</span>}
+          {/* `editOf` covers an edit seen live; the tag covers one replayed on
+              join, where the server collapses the revisions into a single row
+              and nothing else in the wire form says it was ever edited. */}
+          {(msg.editOf || msg.tags['+freeq.at/edited'] === '1') && !msg.isStreaming && (
+            <span className="text-xs text-fg-dim">(edited)</span>
+          )}
           {msg.encrypted && <EncryptedBadge />}
         </div>
         <MessageContent msg={msg} channel={channel} onNickClick={onNickClick} />

--- a/freeq-app/src/store.bugs.test.ts
+++ b/freeq-app/src/store.bugs.test.ts
@@ -709,7 +709,10 @@ describe('mergeHistory edit reconciliation', () => {
     ]);
     const msgs = s().channels.get(ch)!.messages;
     expect(msgs).toHaveLength(1);
-    expect(msgs[0].id).toBe('e1');
+    // The held id survives the reconciliation: an edit changes the text, not
+    // which message this is. Re-keying to the revision's id was what made
+    // reactions and pending deletes stop resolving after a reload.
+    expect(msgs[0].id).toBe('m0');
     expect(msgs[0].text).toBe('original - edited');
     expect(msgs[0].editOf).toBe('m0');
   });
@@ -722,23 +725,41 @@ describe('mergeHistory edit reconciliation', () => {
     ]);
     const msgs = s().channels.get(ch)!.messages;
     expect(msgs).toHaveLength(1);
-    expect(msgs[0].id).toBe('e1');
+    expect(msgs[0].id).toBe('m0');
     expect(msgs[0].text).toBe('original - edited');
   });
 
-  it('chained live edits still match a root-anchored replayed row', () => {
+  it('repeated live edits still match a root-anchored replayed row', () => {
     s().addMessage(ch, at('2026-07-20T14:35:00Z', 'm0', 'original'));
-    // Two live edits, chained references (iOS behavior): e2 edits e1.
+    // Every edit names the identity the client holds — which never moves, so
+    // there is no chain to follow. (The server also normalizes `+draft/edit`
+    // to the root before broadcasting, so this is what arrives on the wire.)
     (s() as any).editMessage(ch, 'm0', 'edited once', 'e1');
-    (s() as any).editMessage(ch, 'e1', 'edited twice', 'e2');
+    (s() as any).editMessage(ch, 'm0', 'edited twice', 'e2');
     // Replay delivers the final collapsed row root-anchored to m0.
     (s() as any).mergeHistory(ch, [
       at('2026-07-20T14:37:00Z', 'e2', 'edited twice', 'm0'),
     ]);
     const msgs = s().channels.get(ch)!.messages;
     expect(msgs).toHaveLength(1);
-    expect(msgs[0].id).toBe('e2');
+    expect(msgs[0].id).toBe('m0');
     expect(msgs[0].text).toBe('edited twice');
+  });
+
+  it('a replayed edit carries its reactions onto the held row', () => {
+    // Reactions arrive attached to whichever revision they were filed
+    // against. Dropping them on reconciliation is what made reactions on an
+    // edited message disappear on every reload.
+    s().addMessage(ch, at('2026-07-20T14:35:00Z', 'm0', 'original'));
+    const incoming = {
+      ...at('2026-07-20T14:36:00Z', 'e1', 'original - edited', 'm0'),
+      reactions: new Map([['🔥', new Set(['alice'])]]),
+    };
+    s().mergeHistory(ch, [incoming]);
+    const msgs = s().channels.get(ch)!.messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe('m0');
+    expect([...(msgs[0].reactions?.get('🔥') ?? [])]).toEqual(['alice']);
   });
 
   it('edit row with no held original still lands as a single row', () => {
@@ -782,7 +803,8 @@ describe('edit/delete authorship gate', () => {
     s().addMessage(ch, at('m3', 'alice', 'v1'));
     (s() as any).editMessage(ch, 'm3', 'v2', 'e3', false, 'alice', undefined);
     expect(s().channels.get(ch)!.messages[0].text).toBe('v2');
-    (s() as any).deleteMessage(ch, 'e3', 'ALICE', undefined);
+    // The delete names the identity the message keeps, not the revision.
+    (s() as any).deleteMessage(ch, 'm3', 'ALICE', undefined);
     expect(s().channels.get(ch)!.messages[0].deleted).toBe(true);
   });
 });
@@ -793,21 +815,18 @@ describe('edit/delete authorship gate', () => {
 
 describe('delete after edit', () => {
   it('marks an edited message deleted when the delete names the ORIGINAL msgid', () => {
-    // editMessage re-keys the message to the edit's msgid (`id: newMsgId`) and
-    // keeps the chain root in `editOf`. Deletes always name the ORIGINAL msgid —
-    // that is the identity clients hold and what the server relays in
-    // +draft/delete. deleteMessage matched only `m.id === msgId`, so after an
-    // edit the delete found nothing and the message stayed visible, even though
-    // the server had removed it. editMessage already matches id OR editOf;
-    // deleteMessage must too.
+    // Deletes always name the ORIGINAL msgid — that is the identity clients
+    // hold and what the server relays in +draft/delete. A delete of an edited
+    // message used to find nothing and leave it visible after the server had
+    // removed it.
     ensureChannel('#test');
     useStore.getState().addMessage('#test', mkMsg({ id: 'orig', text: 'secret v1' }));
     useStore.getState().editMessage('#test', 'orig', 'secret v2', 'edit1');
 
-    // Sanity: the edit re-keyed the row and recorded the chain root.
+    // Sanity: the edit changed the text and left the identity alone.
     const afterEdit = useStore.getState().channels.get('#test')!
       .messages.find((m) => m.editOf === 'orig');
-    expect(afterEdit?.id).toBe('edit1');
+    expect(afterEdit?.id).toBe('orig');
     expect(afterEdit?.text).toBe('secret v2');
 
     useStore.getState().deleteMessage('#test', 'orig');
@@ -818,15 +837,41 @@ describe('delete after edit', () => {
     expect(m?.text).toBe('');
   });
 
-  it('still deletes when the delete names the edit revision', () => {
-    // The other end of the same chain: whichever id the caller holds must work.
+  it('still deletes a row an older build re-keyed to the edit revision', () => {
+    // Rows written by a build that re-keyed on edit are still in IndexedDB and
+    // still on screen: id = the revision, editOf = the root. The server names
+    // the root, so the `editOf` arm of the match is what reaches them. This is
+    // the transition cover; it can go once such rows can't be around.
+    ensureChannel('#test');
+    useStore.getState().addMessage(
+      '#test',
+      mkMsg({ id: 'edit1', text: 'v2', editOf: 'orig' }),
+    );
+    useStore.getState().deleteMessage('#test', 'orig');
+    const m = useStore.getState().channels.get('#test')!
+      .messages.find((x) => x.id === 'edit1');
+    expect(m?.deleted).toBe(true);
+  });
+
+  it('a reaction outlives an edit and is removed by the same id', () => {
+    // The reason the key has to be stable. Reacting, then editing, then
+    // un-reacting: every one of those names the message. When the edit moved
+    // the key, the un-react (and the reaction chip itself) stopped resolving —
+    // the tally kept a reaction the user had already taken back.
     ensureChannel('#test');
     useStore.getState().addMessage('#test', mkMsg({ id: 'orig', text: 'v1' }));
+    useStore.getState().addReaction('#test', 'orig', '🔥', 'alice');
     useStore.getState().editMessage('#test', 'orig', 'v2', 'edit1');
-    useStore.getState().deleteMessage('#test', 'edit1');
-    const m = useStore.getState().channels.get('#test')!
-      .messages.find((x) => x.id === 'edit1' || x.editOf === 'orig');
-    expect(m?.deleted).toBe(true);
+
+    const edited = useStore.getState().channels.get('#test')!
+      .messages.find((m) => m.id === 'orig');
+    expect(edited?.text).toBe('v2');
+    expect([...(edited?.reactions?.get('🔥') ?? [])]).toEqual(['alice']);
+
+    useStore.getState().removeReaction('#test', 'orig', '🔥', 'alice');
+    const after = useStore.getState().channels.get('#test')!
+      .messages.find((m) => m.id === 'orig');
+    expect(after?.reactions?.get('🔥')).toBeUndefined();
   });
 
   it('does not delete unrelated messages', () => {

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -770,9 +770,22 @@ export const useStore = create<Store>((set, get) => ({
           (e) => e.id === anchor || e.editOf === anchor,
         );
         if (idx >= 0) {
-          ch.messages = ch.messages.map((e, i) =>
-            i === idx ? { ...e, text: m.text, id: m.id, editOf: e.editOf ?? anchor } : e,
-          );
+          ch.messages = ch.messages.map((e, i) => {
+            if (i !== idx) return e;
+            // Keep the held id: the message is the same message. Reactions
+            // come back attached to whichever revision they were filed
+            // against, so carry them onto the row we keep — otherwise every
+            // reload dropped the reactions on an edited message.
+            const reactions = m.reactions
+              ? new Map([...(e.reactions ?? new Map()), ...m.reactions])
+              : e.reactions;
+            return {
+              ...e,
+              text: m.text,
+              editOf: e.editOf ?? anchor,
+              ...(reactions ? { reactions } : {}),
+            };
+          });
           reconciled = true;
           continue;
         }
@@ -808,7 +821,10 @@ export const useStore = create<Store>((set, get) => ({
     get().addMessage(channel, msg);
   },
 
-  editMessage: (channel, originalMsgId, newText, newMsgId, isStreaming, editorNick, editorAccount) => set((s) => {
+  // `_newMsgId` — the revision's own wire id — is deliberately unused: the
+  // message keeps the id it was born with. Still accepted because the wire
+  // and the SDK event carry it; droppable once no caller passes it.
+  editMessage: (channel, originalMsgId, newText, _newMsgId, isStreaming, editorNick, editorAccount) => set((s) => {
     // Authorship gate: only the original sender may edit. The server
     // enforces this when the thread is persisted; for unpersisted (guest)
     // threads it relays without a check, so the client is the authority.
@@ -826,13 +842,14 @@ export const useStore = create<Store>((set, get) => ({
     const channels = new Map(s.channels);
     const ch = channels.get(channel.toLowerCase());
     if (ch) {
-      // Match on id OR editOf — handles chained edits (e.g., streaming)
-      // where the first edit changes id but subsequent edits still reference the original
+      // An edit changes the text, never the key. The message keeps the id it
+      // was born with — which is the id the server files reactions, pins and
+      // deletes under, and the id a reload replays it under.
+      // `editOf` records that it was edited (the "(edited)" marker) and, for
+      // the transition, still matches events that name a superseded id.
       ch.messages = ch.messages.map((m) =>
         (m.id === originalMsgId || m.editOf === originalMsgId) && authorOk(m)
-          // editOf keeps the ROOT of the edit chain so chained edits and
-          // replayed collapsed rows keep matching each other.
-          ? { ...m, text: displayText, id: newMsgId || m.id, editOf: m.editOf ?? originalMsgId, isStreaming: !!isStreaming }
+          ? { ...m, text: displayText, editOf: m.editOf ?? originalMsgId, isStreaming: !!isStreaming }
           : m
       );
       channels.set(channel.toLowerCase(), { ...ch });
@@ -844,7 +861,7 @@ export const useStore = create<Store>((set, get) => ({
       if (batch.target.toLowerCase() !== channel.toLowerCase()) continue;
       batch.messages = batch.messages.map((m) =>
         (m.id === originalMsgId || m.editOf === originalMsgId) && authorOk(m)
-          ? { ...m, text: displayText, id: newMsgId || m.id, editOf: m.editOf ?? originalMsgId, isStreaming: !!isStreaming }
+          ? { ...m, text: displayText, editOf: m.editOf ?? originalMsgId, isStreaming: !!isStreaming }
           : m
       );
       batches.set(id, batch);
@@ -865,12 +882,10 @@ export const useStore = create<Store>((set, get) => ({
       if (deleterNick) return deleterNick.toLowerCase() === m.from.toLowerCase();
       return true;
     };
-    // Match on id OR editOf, exactly as editMessage does. An edit re-keys the
-    // message to the edit's msgid and records the chain root in editOf, while a
-    // delete always names the ORIGINAL msgid — that's the identity clients hold
-    // and what the server relays in +draft/delete. Matching only on id meant a
-    // delete of an edited message found nothing and left it on screen after the
-    // server had removed it.
+    // Match on id OR editOf. Ids are stable now, so `id` alone would do for
+    // anything this build wrote — the `editOf` arm is transition cover for
+    // rows a previous build re-keyed to an edit's msgid, which are still in
+    // IndexedDB and still on screen. Removable once those can't be around.
     ch.messages = ch.messages.map((m) =>
       (m.id === msgId || m.editOf === msgId) && authorOk(m)
         ? { ...m, deleted: true, text: '' }

--- a/freeq-ios/Generated/freeq.swift
+++ b/freeq-ios/Generated/freeq.swift
@@ -1768,12 +1768,13 @@ public struct IrcMessage {
     public var account: String?
     public var origin: String?
     public var reactions: [ReactionTally]
+    public var edited: Bool
     public var dmKey: String?
     public var coordination: CoordinationEvent?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(fromNick: String, target: String, text: String, msgid: String?, replyTo: String?, replacesMsgid: String?, editOf: String?, batchId: String?, pinMsgid: String?, unpinMsgid: String?, isAction: Bool, isSigned: Bool, timestampMs: Int64, account: String?, origin: String?, reactions: [ReactionTally], dmKey: String?, coordination: CoordinationEvent?) {
+    public init(fromNick: String, target: String, text: String, msgid: String?, replyTo: String?, replacesMsgid: String?, editOf: String?, batchId: String?, pinMsgid: String?, unpinMsgid: String?, isAction: Bool, isSigned: Bool, timestampMs: Int64, account: String?, origin: String?, reactions: [ReactionTally], edited: Bool, dmKey: String?, coordination: CoordinationEvent?) {
         self.fromNick = fromNick
         self.target = target
         self.text = text
@@ -1790,6 +1791,7 @@ public struct IrcMessage {
         self.account = account
         self.origin = origin
         self.reactions = reactions
+        self.edited = edited
         self.dmKey = dmKey
         self.coordination = coordination
     }
@@ -1850,6 +1852,9 @@ extension IrcMessage: Equatable, Hashable {
         if lhs.reactions != rhs.reactions {
             return false
         }
+        if lhs.edited != rhs.edited {
+            return false
+        }
         if lhs.dmKey != rhs.dmKey {
             return false
         }
@@ -1876,6 +1881,7 @@ extension IrcMessage: Equatable, Hashable {
         hasher.combine(account)
         hasher.combine(origin)
         hasher.combine(reactions)
+        hasher.combine(edited)
         hasher.combine(dmKey)
         hasher.combine(coordination)
     }
@@ -1906,6 +1912,7 @@ public struct FfiConverterTypeIrcMessage: FfiConverterRustBuffer {
                 account: FfiConverterOptionString.read(from: &buf), 
                 origin: FfiConverterOptionString.read(from: &buf), 
                 reactions: FfiConverterSequenceTypeReactionTally.read(from: &buf), 
+                edited: FfiConverterBool.read(from: &buf), 
                 dmKey: FfiConverterOptionString.read(from: &buf), 
                 coordination: FfiConverterOptionTypeCoordinationEvent.read(from: &buf)
         )
@@ -1928,6 +1935,7 @@ public struct FfiConverterTypeIrcMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.account, into: &buf)
         FfiConverterOptionString.write(value.origin, into: &buf)
         FfiConverterSequenceTypeReactionTally.write(value.reactions, into: &buf)
+        FfiConverterBool.write(value.edited, into: &buf)
         FfiConverterOptionString.write(value.dmKey, into: &buf)
         FfiConverterOptionTypeCoordinationEvent.write(value.coordination, into: &buf)
     }

--- a/freeq-ios/Tests/FreeqIosCoreTests/DeleteAfterEditTests.swift
+++ b/freeq-ios/Tests/FreeqIosCoreTests/DeleteAfterEditTests.swift
@@ -3,10 +3,8 @@ import XCTest
 
 /// Deleting an *edited* message must still work.
 ///
-/// `applyEdit` rewrites the in-memory id to the edit's msgid and records the
-/// chain root in `editOf` (so chained edits keep matching). Deletes always name
-/// the ORIGINAL msgid — that is the identity clients hold and what the server
-/// relays in `+draft/delete`. `applyDelete` went through
+/// Deletes always name the ORIGINAL msgid — that is the identity clients hold
+/// and what the server relays in `+draft/delete`. `applyDelete` went through
 /// `findMessage(byId:)`, which matches `id` only, so after any edit the delete
 /// found nothing and the message stayed on screen even though the server had
 /// removed it.
@@ -20,8 +18,8 @@ final class DeleteAfterEditTests: XCTestCase {
         let ch = ChannelState(name: "#t")
         ch.appendIfNew(msg("orig", "secret v1"))
         ch.applyEdit(originalId: "orig", newId: "edit1", newText: "secret v2")
-        // Sanity: the edit re-keyed the row.
-        XCTAssertEqual(ch.messages.first?.id, "edit1")
+        // Sanity: the edit changed the text and left the identity alone.
+        XCTAssertEqual(ch.messages.first?.id, "orig")
         XCTAssertEqual(ch.messages.first?.editOf, "orig")
 
         ch.applyDelete(msgId: "orig")
@@ -31,12 +29,16 @@ final class DeleteAfterEditTests: XCTestCase {
         XCTAssertEqual(m?.text, "")
     }
 
-    func testDeleteByEditIdStillWorks() {
-        // The other end of the chain: whichever id the caller holds must work.
+    func testDeleteReachesARowAnOlderBuildReKeyed() {
+        // Rows written by a build that re-keyed on edit are still in the local
+        // cache: id = the revision, editOf = the root. The server names the
+        // root, so the `editOf` arm of the match is what reaches them. This is
+        // the transition cover; it can go once such rows can't be around.
         let ch = ChannelState(name: "#t")
-        ch.appendIfNew(msg("orig", "v1"))
-        ch.applyEdit(originalId: "orig", newId: "edit1", newText: "v2")
-        ch.applyDelete(msgId: "edit1")
+        var stale = msg("edit1", "v2")
+        stale.editOf = "orig"
+        ch.appendIfNew(stale)
+        ch.applyDelete(msgId: "orig")
         XCTAssertEqual(ch.messages.first?.isDeleted, true)
     }
 

--- a/freeq-ios/Tests/FreeqIosCoreTests/EditDedupTests.swift
+++ b/freeq-ios/Tests/FreeqIosCoreTests/EditDedupTests.swift
@@ -41,14 +41,16 @@ final class EditDedupTests: XCTestCase {
         ch.applyEdit(originalId: "01A", newId: "01C", newText: "v3")
         XCTAssertEqual(ch.messages.count, 1)
         XCTAssertEqual(ch.messages[0].text, "v3")
-        XCTAssertEqual(ch.messages[0].id, "01C")
+        XCTAssertEqual(ch.messages[0].id, "01A", "edits change text, not identity")
     }
 
-    func testApplyEditReindexesByCurrentId() {
+    func testApplyEditLeavesTheIndexOnTheOriginalId() {
         let ch = ChannelState(name: "#ship")
         ch.appendIfNew(msg("01A", "v1", at: 1))
         ch.applyEdit(originalId: "01A", newId: "01B", newText: "v2")
-        // The index must resolve the CURRENT id after the swap.
-        XCTAssertNotNil(ch.findMessage(byId: "01B"))
+        // The message is still itself: the index resolves the id it was born
+        // with, and a revision id resolves to nothing (clients never hold one).
+        XCTAssertNotNil(ch.findMessage(byId: "01A"))
+        XCTAssertNil(ch.findMessage(byId: "01B"))
     }
 }

--- a/freeq-ios/freeq/Models/AppState.swift
+++ b/freeq-ios/freeq/Models/AppState.swift
@@ -2672,6 +2672,10 @@ final class SwiftEventHandler: @unchecked Sendable, EventHandler {
                 isAction: ircMsg.isAction,
                 timestamp: Date(timeIntervalSince1970: Double(ircMsg.timestampMs) / 1000.0),
                 replyTo: ircMsg.replyTo,
+                // Covers both signals: a live edit (`edit_of`) and one the
+                // server already collapsed into join replay, which carries no
+                // `+draft/edit` and would otherwise read as the original.
+                isEdited: ircMsg.edited,
                 isSigned: ircMsg.isSigned,
                 isEncrypted: wasEncrypted,
                 origin: ircMsg.origin,
@@ -2694,7 +2698,7 @@ final class SwiftEventHandler: @unchecked Sendable, EventHandler {
                         batch.messages[idx].text = displayText
                         batch.messages[idx].isEdited = true
                         batch.messages[idx].editOf = batch.messages[idx].editOf ?? editOf
-                        if let newId = ircMsg.msgid { batch.messages[idx].id = newId }
+                        // Keeps the id it was born with — see ChannelState.applyEdit.
                         // Reactions attach to the msgid the user reacted to —
                         // usually the latest edit id — so replay delivers
                         // them ON the edit row. Merge them or reactions on

--- a/freeq-ios/freeq/Models/ChannelState.swift
+++ b/freeq-ios/freeq/Models/ChannelState.swift
@@ -104,25 +104,22 @@ class ChannelState: ObservableObject, Identifiable {
     }
 
     func applyEdit(originalId: String, newId: String?, newText: String) {
-        // Match the current id OR a prior editOf: chained edits keep
-        // referencing the original msgid after the first edit rewrote the
-        // in-memory id (parity with macOS).
+        // Match the current id OR a prior editOf. `editOf` covers rows a
+        // previous build re-keyed to a revision's msgid and cached locally.
         if let idx = findMessage(byId: originalId)
             ?? messages.firstIndex(where: { $0.editOf == originalId }) {
             messages[idx].text = newText
             messages[idx].isEdited = true
             messages[idx].editOf = messages[idx].editOf ?? originalId
-            // Keep the original id registered so a replayed pre-edit row
-            // dedups instead of resurrecting alongside the edited one.
+            // The id does NOT move to the revision's. A message keeps the id
+            // it was born with — the one the server files reactions, pins and
+            // deletes under, and the one replay returns it under. The row
+            // still rebuilds on screen: `renderKey` folds in the text and the
+            // edited flag, so the identity the list diffs on changes anyway.
             messageIds.insert(originalId)
-            if let newId = newId {
-                let oldId = messages[idx].id
-                messages[idx].id = newId
-                messageIds.insert(newId)
-                // Re-key the index: the slot is unchanged, only its id moved.
-                messageIndex.removeValue(forKey: oldId)
-                messageIndex[newId] = idx
-            }
+            // The revision's id still counts as seen, so a later replay of
+            // that row isn't mistaken for a new message.
+            if let newId = newId { messageIds.insert(newId) }
         }
     }
 

--- a/freeq-ios/freeqTests/BufferRoutingTests.swift
+++ b/freeq-ios/freeqTests/BufferRoutingTests.swift
@@ -476,7 +476,7 @@ final class DMSelfEchoRoutingTests: XCTestCase {
             fromNick: me, target: peer, text: "hi bob", msgid: "m1",
             replyTo: nil, replacesMsgid: nil, editOf: nil, batchId: nil,
             pinMsgid: nil, unpinMsgid: nil, isAction: false, isSigned: false,
-            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], dmKey: nil)
+            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], edited: false, dmKey: nil, coordination: nil)
         handler(s).handleEvent(.message(msg: irc))
 
         let dm = s.dmBuffers.first(where: { $0.name == peer })
@@ -495,7 +495,7 @@ final class DMSelfEchoRoutingTests: XCTestCase {
             fromNick: me, target: peer, text: "fixed", msgid: "m1-v2",
             replyTo: nil, replacesMsgid: "m1", editOf: "m1", batchId: nil,
             pinMsgid: nil, unpinMsgid: nil, isAction: false, isSigned: false,
-            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], dmKey: nil)
+            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], edited: true, dmKey: nil, coordination: nil)
         handler(s).handleEvent(.message(msg: editIrc))
 
         XCTAssertEqual(dm.messages.first?.text, "fixed")
@@ -564,14 +564,14 @@ final class DMSelfEchoRoutingTests: XCTestCase {
             fromNick: me, target: peer, text: "one", msgid: "m1",
             replyTo: nil, replacesMsgid: nil, editOf: nil, batchId: nil,
             pinMsgid: nil, unpinMsgid: nil, isAction: false, isSigned: false,
-            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], dmKey: nil)
+            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], edited: false, dmKey: nil, coordination: nil)
         h.handleEvent(.message(msg: send))
 
         let edit = IrcMessage(
             fromNick: me, target: peer, text: "two", msgid: "m1-v2",
             replyTo: nil, replacesMsgid: "m1", editOf: "m1", batchId: nil,
             pinMsgid: nil, unpinMsgid: nil, isAction: false, isSigned: false,
-            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], dmKey: nil)
+            timestampMs: Int64(Date().timeIntervalSince1970 * 1000), account: nil, origin: nil, reactions: [], edited: true, dmKey: nil, coordination: nil)
         h.handleEvent(.message(msg: edit))
 
         XCTAssertNil(s.dmBuffers.first(where: { $0.name.lowercased() == me }))

--- a/freeq-macos/Generated/freeq.swift
+++ b/freeq-macos/Generated/freeq.swift
@@ -1768,12 +1768,13 @@ public struct IrcMessage {
     public var account: String?
     public var origin: String?
     public var reactions: [ReactionTally]
+    public var edited: Bool
     public var dmKey: String?
     public var coordination: CoordinationEvent?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(fromNick: String, target: String, text: String, msgid: String?, replyTo: String?, replacesMsgid: String?, editOf: String?, batchId: String?, pinMsgid: String?, unpinMsgid: String?, isAction: Bool, isSigned: Bool, timestampMs: Int64, account: String?, origin: String?, reactions: [ReactionTally], dmKey: String?, coordination: CoordinationEvent?) {
+    public init(fromNick: String, target: String, text: String, msgid: String?, replyTo: String?, replacesMsgid: String?, editOf: String?, batchId: String?, pinMsgid: String?, unpinMsgid: String?, isAction: Bool, isSigned: Bool, timestampMs: Int64, account: String?, origin: String?, reactions: [ReactionTally], edited: Bool, dmKey: String?, coordination: CoordinationEvent?) {
         self.fromNick = fromNick
         self.target = target
         self.text = text
@@ -1790,6 +1791,7 @@ public struct IrcMessage {
         self.account = account
         self.origin = origin
         self.reactions = reactions
+        self.edited = edited
         self.dmKey = dmKey
         self.coordination = coordination
     }
@@ -1850,6 +1852,9 @@ extension IrcMessage: Equatable, Hashable {
         if lhs.reactions != rhs.reactions {
             return false
         }
+        if lhs.edited != rhs.edited {
+            return false
+        }
         if lhs.dmKey != rhs.dmKey {
             return false
         }
@@ -1876,6 +1881,7 @@ extension IrcMessage: Equatable, Hashable {
         hasher.combine(account)
         hasher.combine(origin)
         hasher.combine(reactions)
+        hasher.combine(edited)
         hasher.combine(dmKey)
         hasher.combine(coordination)
     }
@@ -1906,6 +1912,7 @@ public struct FfiConverterTypeIrcMessage: FfiConverterRustBuffer {
                 account: FfiConverterOptionString.read(from: &buf), 
                 origin: FfiConverterOptionString.read(from: &buf), 
                 reactions: FfiConverterSequenceTypeReactionTally.read(from: &buf), 
+                edited: FfiConverterBool.read(from: &buf), 
                 dmKey: FfiConverterOptionString.read(from: &buf), 
                 coordination: FfiConverterOptionTypeCoordinationEvent.read(from: &buf)
         )
@@ -1928,6 +1935,7 @@ public struct FfiConverterTypeIrcMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.account, into: &buf)
         FfiConverterOptionString.write(value.origin, into: &buf)
         FfiConverterSequenceTypeReactionTally.write(value.reactions, into: &buf)
+        FfiConverterBool.write(value.edited, into: &buf)
         FfiConverterOptionString.write(value.dmKey, into: &buf)
         FfiConverterOptionTypeCoordinationEvent.write(value.coordination, into: &buf)
     }

--- a/freeq-macos/Tests/FreeqMacosCoreTests/CoreModelTests.swift
+++ b/freeq-macos/Tests/FreeqMacosCoreTests/CoreModelTests.swift
@@ -61,7 +61,7 @@ final class CoreModelTests: XCTestCase {
         ch.applyEdit(originalId: "orig", newId: "edit-1", newText: "fixed")
         XCTAssertEqual(ch.messages[0].text, "fixed")
         XCTAssertTrue(ch.messages[0].isEdited)
-        XCTAssertEqual(ch.messages[0].id, "edit-1")
+        XCTAssertEqual(ch.messages[0].id, "orig", "an edit changes text, not identity")
         // The replacement id is now known — its echo must not re-append.
         ch.appendIfNew(msg("edit-1", "echo"))
         XCTAssertEqual(ch.messages.count, 1)
@@ -101,7 +101,7 @@ final class CoreModelTests: XCTestCase {
         ch.applyEdit(originalId: "orig", newId: "edit-2", newText: "second")
         XCTAssertEqual(ch.messages.count, 1)
         XCTAssertEqual(ch.messages[0].text, "second")
-        XCTAssertEqual(ch.messages[0].id, "edit-2")
+        XCTAssertEqual(ch.messages[0].id, "orig", "repeated edits keep the original id")
     }
 
     func testApplyEditOnUnknownIdIsNoop() {

--- a/freeq-macos/Tests/FreeqMacosCoreTests/DeleteAfterEditTests.swift
+++ b/freeq-macos/Tests/FreeqMacosCoreTests/DeleteAfterEditTests.swift
@@ -3,9 +3,7 @@ import XCTest
 
 /// Deleting an *edited* message must still work.
 ///
-/// `applyEdit` rewrites the in-memory id to the edit's msgid and records the
-/// chain root in `editOf` (so chained edits keep matching). Deletes always name
-/// the ORIGINAL msgid — that is the identity clients hold and what the server
+/// Deletes always name the ORIGINAL msgid — that is the identity clients hold and what the server
 /// relays in `+draft/delete`. `applyDelete` went through
 /// `findMessage(byId:)`, which matches `id` only, so after any edit the delete
 /// found nothing and the message stayed on screen even though the server had
@@ -20,8 +18,8 @@ final class DeleteAfterEditTests: XCTestCase {
         let ch = ChannelState(name: "#t")
         ch.appendIfNew(msg("orig", "secret v1"))
         ch.applyEdit(originalId: "orig", newId: "edit1", newText: "secret v2")
-        // Sanity: the edit re-keyed the row.
-        XCTAssertEqual(ch.messages.first?.id, "edit1")
+        // Sanity: the edit changed the text and left the identity alone.
+        XCTAssertEqual(ch.messages.first?.id, "orig")
         XCTAssertEqual(ch.messages.first?.editOf, "orig")
 
         ch.applyDelete(msgId: "orig")
@@ -31,12 +29,15 @@ final class DeleteAfterEditTests: XCTestCase {
         XCTAssertEqual(m?.text, "")
     }
 
-    func testDeleteByEditIdStillWorks() {
-        // The other end of the chain: whichever id the caller holds must work.
+    func testDeleteReachesARowAnOlderBuildReKeyed() {
+        // Rows written by a build that re-keyed on edit are still in the local
+        // cache: id = the revision, editOf = the root. The server names the
+        // root, so the `editOf` arm of the match is what reaches them.
         let ch = ChannelState(name: "#t")
-        ch.appendIfNew(msg("orig", "v1"))
-        ch.applyEdit(originalId: "orig", newId: "edit1", newText: "v2")
-        ch.applyDelete(msgId: "edit1")
+        var stale = msg("edit1", "v2")
+        stale.editOf = "orig"
+        ch.appendIfNew(stale)
+        ch.applyDelete(msgId: "orig")
         XCTAssertEqual(ch.messages.first?.isDeleted, true)
     }
 

--- a/freeq-macos/freeq-macos/Models/AppState.swift
+++ b/freeq-macos/freeq-macos/Models/AppState.swift
@@ -1205,6 +1205,19 @@ class AppState {
             }
         }
         dmBuffers.append(dm)
+        // Ask the server for this thread's history. The local cache above only
+        // has what this device saw; without this, anything sent while you were
+        // logged out — and every server-persisted reaction — was missing until
+        // something else happened to refetch. Channels have always done this
+        // from the NAMES-END path; DM threads never did.
+        //
+        // Only when the request can actually succeed: the server refuses an
+        // unauthenticated requester (ACCOUNT_REQUIRED) and a target it can't
+        // resolve to an account (INVALID_TARGET). Asking anyway trades a round
+        // trip for a FAIL and a console error.
+        if authenticatedDID != nil, DidDisplay.isDid(nick) || didForNick(nick) != nil {
+            requestHistory(channel: nick)
+        }
         attemptRestoreLastChannel()
         return dm
     }
@@ -1717,7 +1730,10 @@ extension AppState {
                 isAction: msg.isAction,
                 timestamp: Date(timeIntervalSince1970: Double(msg.timestampMs) / 1000.0),
                 replyTo: msg.replyTo,
-                isEdited: msg.editOf != nil,
+                // `edited` covers both signals: a live edit (`edit_of`) and one
+                // the server already collapsed into join replay, which carries
+                // no `+draft/edit` and would otherwise read as the original.
+                isEdited: msg.edited,
                 isSigned: msg.isSigned,
                 isEncrypted: wasEncrypted,
                 origin: msg.origin,
@@ -1738,7 +1754,7 @@ extension AppState {
                         batch.messages[idx].text = displayText
                         batch.messages[idx].isEdited = true
                         batch.messages[idx].editOf = batch.messages[idx].editOf ?? editOf
-                        if let newId = msg.msgid { batch.messages[idx].id = newId }
+                        // Keeps the id it was born with — see ChannelState.applyEdit.
                     } else {
                         batch.messages.append(message)
                     }

--- a/freeq-macos/freeq-macos/Models/ChannelState.swift
+++ b/freeq-macos/freeq-macos/Models/ChannelState.swift
@@ -105,20 +105,20 @@ class ChannelState: Identifiable {
     }
 
     func applyEdit(originalId: String, newId: String?, newText: String) {
-        // Match on the current id OR a prior editOf: chained edits keep
-        // referencing the original msgid even after the first edit rewrote
-        // the in-memory id.
+        // Match on the current id OR a prior editOf. `editOf` covers rows a
+        // previous build re-keyed to a revision's msgid and cached locally.
         if let idx = messages.firstIndex(where: { $0.id == originalId || $0.editOf == originalId }) {
             messages[idx].text = newText
             messages[idx].isEdited = true
             messages[idx].editOf = messages[idx].editOf ?? originalId
-            // Keep the original id registered so a later cache-loaded copy
-            // keyed under it is recognized as a duplicate.
+            // The id does NOT move to the revision's. A message keeps the id
+            // it was born with — the one the server files reactions, pins and
+            // deletes under, and the one replay returns it under. Moving it
+            // was what left reactions stranded on an edited message.
             messageIds.insert(originalId)
-            if let newId {
-                messages[idx].id = newId
-                messageIds.insert(newId)
-            }
+            // The revision's id still counts as seen, so a later replay of
+            // that row isn't mistaken for a new message.
+            if let newId { messageIds.insert(newId) }
         }
     }
 

--- a/freeq-sdk-ffi/src/freeq.udl
+++ b/freeq-sdk-ffi/src/freeq.udl
@@ -17,6 +17,7 @@ dictionary IrcMessage {
     string? account;
     string? origin;
     sequence<ReactionTally> reactions;
+    boolean edited;
     string? dm_key;
     CoordinationEvent? coordination;
 };

--- a/freeq-sdk-ffi/src/lib.rs
+++ b/freeq-sdk-ffi/src/lib.rs
@@ -61,6 +61,13 @@ pub struct IrcMessage {
     /// server's `+freeq.at/reactions` tag (CHATHISTORY / JOIN replay).
     /// Live reactions still arrive as separate `TagMsg` events.
     pub reactions: Vec<ReactionTally>,
+    /// This message has been edited since it was sent.
+    ///
+    /// A live edit is recognizable from `edit_of`, but join replay collapses
+    /// every revision into one row and sends no `+draft/edit` — so without
+    /// the server's `+freeq.at/edited` tag (which this reads), a message
+    /// edited before you joined renders as though it were the original.
+    pub edited: bool,
     /// For a DM: the canonical conversation key — the peer's DID when known,
     /// else their nick. `None` for channel messages. Key DM threads by this,
     /// not by from/target (which flip with message direction).
@@ -536,6 +543,8 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
                 .get("+freeq.at/reactions")
                 .map(|raw| parse_reactions_tag(raw))
                 .unwrap_or_default();
+            let is_edited = edit_of.is_some()
+                || tags.get("+freeq.at/edited").map(|v| v == "1").unwrap_or(false);
             // Agent coordination event: the `+freeq.at/event` tag (with the
             // `freeq.at/` unprefixed fallback some senders use) turns this
             // message into a structured card on every client.
@@ -570,6 +579,9 @@ fn convert_event(event: &freeq_sdk::event::Event) -> Option<FreeqEvent> {
                     account: tags.get("account").cloned(),
                     origin: tags.get("+freeq.at/origin").cloned(),
                     reactions,
+                    // Either signal: `edit_of` for an edit seen live, the tag
+                    // for one the server already collapsed into replay.
+                    edited: is_edited,
                     dm_key: dm_key.clone(),
                     coordination,
                 },
@@ -2450,6 +2462,40 @@ mod tests {
     #[test]
     fn parse_reactions_tag_empty_input() {
         assert!(parse_reactions_tag("").is_empty());
+    }
+
+    /// A message edited before you joined arrives already collapsed: the
+    /// server sends one row, the current text, and no `+draft/edit` to hint
+    /// that it was ever revised. `+freeq.at/edited` is the only signal, so a
+    /// client that doesn't surface it renders the revision as the original.
+    #[test]
+    fn convert_event_message_marks_edited_from_replay_tag() {
+        let mk = |extra: Option<(&str, &str)>| {
+            let mut tags = std::collections::HashMap::new();
+            tags.insert("msgid".to_string(), "01ABC".to_string());
+            if let Some((k, v)) = extra {
+                tags.insert(k.to_string(), v.to_string());
+            }
+            let ev = freeq_sdk::event::Event::Message {
+                from: "alice".to_string(),
+                target: "#naptest".to_string(),
+                text: "hi".to_string(),
+                tags,
+                dm_key: None,
+            };
+            let FreeqEvent::Message { msg } = convert_event(&ev).expect("exposed event") else {
+                panic!("expected Message variant");
+            };
+            msg
+        };
+
+        assert!(!mk(None).edited, "an untouched message must not be marked");
+        assert!(
+            mk(Some(("+freeq.at/edited", "1"))).edited,
+            "replay marker ignored — an edited message would look original"
+        );
+        // A live edit is still recognizable on its own.
+        assert!(mk(Some(("+draft/edit", "01ORIG"))).edited);
     }
 
     #[test]

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -1436,7 +1436,10 @@ describe('onNickCollision policy', () => {
     expect(batches).toHaveLength(1);
     const msgs = batches[0][1];
     expect(msgs).toHaveLength(1);
-    expect(msgs[0].id).toBe('E1');
+    // The collapsed row keeps the ORIGINAL id. An edit changes the text, not
+    // which message this is — and the id it keeps is the one the server files
+    // reactions, pins and deletes under.
+    expect(msgs[0].id).toBe('M0');
     expect(msgs[0].text).toBe('original - edited');
     const nicks = msgs[0].reactions?.get('🔥');
     expect(nicks && [...nicks].sort()).toEqual(['alice', 'bob']);

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -1709,16 +1709,19 @@ export class FreeqClient extends EventEmitter {
               editBatch.messages[idx] = {
                 ...prev,
                 text: displayText,
-                id: msg.tags['msgid'] || prev.id,
+                // The id does NOT move to the edit's. A message keeps the id
+                // it was born with, so anything holding a reference to it —
+                // a reaction, a pending delete, a reply — still resolves.
                 editOf: prev.editOf ?? editOf,
                 ...(mergedReactions ? { reactions: mergedReactions } : {}),
               };
               break;
             }
             // Original row absent from this batch window — deliver the
-            // edit as its own row rather than losing the content.
+            // edit as its own row rather than losing the content, keyed by
+            // the message's identity rather than this revision's wire id.
             editBatch.messages.push({
-              id: msg.tags['msgid'] || crypto.randomUUID(),
+              id: editOf,
               from,
               text: displayText,
               timestamp: msg.tags['time'] ? new Date(msg.tags['time']) : new Date(),

--- a/freeq-server/Cargo.toml
+++ b/freeq-server/Cargo.toml
@@ -63,6 +63,7 @@ toml = "0.8"
 # moq-token's backend choice — enabling BOTH jsonwebtoken backends makes
 # the crate panic at runtime until a provider is installed manually.
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+rusqlite_migration = "2.4"
 
 [features]
 default = []

--- a/freeq-server/src/connection/channel.rs
+++ b/freeq-server/src/connection/channel.rs
@@ -522,6 +522,14 @@ pub(super) fn handle_join(
                     std::collections::HashMap::new()
                 };
 
+                // Replay carries one entry per logical message, so an edited
+                // message arrives as its current text with no `+draft/edit` to
+                // hint at the revision — this is what lets a late joiner render
+                // "(edited)".
+                if has_tags_cap && hist.edited {
+                    msg_tags.insert("+freeq.at/edited".to_string(), "1".to_string());
+                }
+
                 // Add msgid tag if available
                 if has_tags_cap && let Some(ref mid) = hist.msgid {
                     msg_tags.insert("msgid".to_string(), mid.clone());

--- a/freeq-server/src/connection/helpers.rs
+++ b/freeq-server/src/connection/helpers.rs
@@ -22,6 +22,19 @@ pub fn cloaked_host_for_did(did: Option<&str>) -> String {
 }
 use super::Connection;
 
+/// The id a message keeps for life: its original msgid, unchanged by edits.
+///
+/// Reactions, pins and deletes may name any revision — clients differ, and a
+/// federated peer may relay whichever one it holds. Resolving to the root here
+/// means the DB, the in-memory history and every receiver of the relayed event
+/// agree on one identity per logical message. An id with no row (an unpersisted
+/// guest-DM message) is its own root.
+pub fn root_msgid(state: &Arc<SharedState>, msgid: &str) -> String {
+    state
+        .with_db(|db| Ok(db.root_of(msgid)))
+        .unwrap_or_else(|| msgid.to_string())
+}
+
 /// Resolved target of a nick within a channel's roster.
 ///
 /// This is the canonical way to resolve a nick for any operation that

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -546,6 +546,7 @@ pub(super) fn handle_tagmsg(
                 target: target.to_string(),
                 tags: tags.clone(),
                 origin: state.server_iroh_id.lock().clone().unwrap_or_default(),
+                account: conn.authenticated_did.clone(),
             },
         );
     } else {
@@ -602,6 +603,7 @@ pub(super) fn handle_tagmsg(
                 target: target.to_string(),
                 tags: tags.clone(),
                 origin: state.server_iroh_id.lock().clone().unwrap_or_default(),
+                account: conn.authenticated_did.clone(),
             },
         );
     }
@@ -1039,6 +1041,7 @@ pub(super) fn handle_privmsg_with_multiline(
                     sig,
                     account: conn.authenticated_did.clone(),
                     recipient_did: super::routing::recipient_did_for_target(state, target),
+                    replaces_msgid: None,
                     tags: s2s_tags,
                     // When this message originated as a draft/multiline
                     // batch, ship the per-line breakdown so the peer
@@ -1189,6 +1192,7 @@ pub(super) fn handle_privmsg_with_multiline(
                         sig: pm_tags.get("+freeq.at/sig").cloned(),
                         account: conn.authenticated_did.clone(),
                         recipient_did: super::routing::recipient_did_for_target(state, target),
+                        replaces_msgid: None,
                         tags: s2s_tags,
                         multiline_lines: multiline_lines.map(|lines| {
                             lines
@@ -2373,6 +2377,10 @@ fn handle_edit(
                 sig,
                 account: conn.authenticated_did.clone(),
                 recipient_did: super::routing::recipient_did_for_target(state, target),
+                // Tells the peer this revises a message it already has, rather
+                // than being one. `+draft/edit` can't carry it: the relayed tag
+                // map is filtered to `+freeq.at/*`.
+                replaces_msgid: Some(original_msgid.to_string()),
                 tags: s2s_tags,
                 // Multi-line edit: pass the per-line breakdown so peer
                 // servers can re-emit BATCH frames to their own
@@ -2652,6 +2660,29 @@ fn handle_delete(conn: &Connection, target: &str, original_msgid: &str, state: &
                 let _ = tx.try_send(tagged_line.clone());
             }
         }
+        drop(conns);
+        drop(tag_caps);
+
+        // Relay to peers. This has to be an explicit broadcast: `handle_tagmsg`
+        // dispatches here and returns, so the generic TAGMSG relay below it
+        // never runs for a delete — which is why deletes used to stop at the
+        // origin, leaving the message readable on every other server.
+        s2s_broadcast(
+            state,
+            crate::s2s::S2sMessage::Tagmsg {
+                event_id: s2s_next_event_id(state),
+                from: nick.to_string(),
+                target: target.to_string(),
+                tags: std::collections::HashMap::from([(
+                    "+draft/delete".to_string(),
+                    original_msgid.to_string(),
+                )]),
+                origin: state.server_iroh_id.lock().clone().unwrap_or_default(),
+                // The peer authorizes the delete against the message's author;
+                // a nick alone would let any peer assert its way to one.
+                account: conn.authenticated_did.clone(),
+            },
+        );
     } else {
         // DM: deliver the delete to every local session bound to the target
         // (a nick or a `did:`), fanning out across the DID's devices — and

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -1620,6 +1620,14 @@ pub(super) fn handle_search(
     // search_messages returns newest-first; replay oldest-first so the
     // batch reads like CHATHISTORY output.
     messages.reverse();
+    // A search hit is a pointer, not a replay event: address it by the root —
+    // the id clients hold the message under. This also keys the reactions
+    // lookup in replay_rows_as_batch, which files reactions by root.
+    for row in &mut messages {
+        if row.root_msgid.is_some() {
+            row.msgid = row.root_msgid.clone();
+        }
+    }
 
     let has_tags = state.cap_message_tags.lock().contains(session_id);
     let has_time = state.cap_server_time.lock().contains(session_id);

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -1161,16 +1161,24 @@ pub(super) fn handle_privmsg_with_multiline(
 
         // Route through the federation routing layer.
         // See routing.rs for why we NEVER gate on remote_members here.
-        use super::routing::{RouteResult, relay_to_nick};
+        use super::routing::{RelayIdentity, RouteResult, relay_to_nick};
         let from_nick = conn.nick.as_deref().unwrap_or("*").to_string();
         match relay_to_nick(
             state,
             &from_nick,
-            conn.authenticated_did.as_deref(),
             target,
             text,
             s2s_next_event_id(state),
             multiline_lines,
+            RelayIdentity {
+                account: conn.authenticated_did.as_deref(),
+                // The id this server assigned. A peer that mints its own leaves
+                // the two servers unable to name the same message.
+                msgid: Some(&pm_msgid),
+                sig: pm_tags.get("+freeq.at/sig").map(|s| s.as_str()),
+                replaces_msgid: None,
+                tags: crate::s2s::relay_coordination_tags(&pm_tags),
+            },
         ) {
             RouteResult::Local(ref session) => {
                 // Target is local — deliver to ALL sessions for target's DID (multi-device).
@@ -2450,11 +2458,19 @@ fn handle_edit(
         match relay_to_nick(
             state,
             &from_nick,
-            conn.authenticated_did.as_deref(),
             target,
             new_text,
             s2s_next_event_id(state),
             multiline_lines.as_deref(),
+            super::routing::RelayIdentity {
+                account: conn.authenticated_did.as_deref(),
+                msgid: Some(&edit_msgid),
+                sig: full_tags.get("+freeq.at/sig").map(|s| s.as_str()),
+                // What makes this an edit on the far side rather than a second
+                // message in the thread.
+                replaces_msgid: Some(original_msgid),
+                tags: crate::s2s::relay_coordination_tags(&full_tags),
+            },
         ) {
             RouteResult::Local(ref session) => {
                 // Find all sessions for target's DID (multi-device support)
@@ -2704,7 +2720,27 @@ fn handle_delete(conn: &Connection, target: &str, original_msgid: &str, state: &
                 let _ = tx.try_send(tagged_line.clone());
             }
         }
-        // Note: For federated DM deletes, we'd need S2S support — not implemented yet
+        drop(conns);
+        drop(tag_caps);
+
+        // The recipient may be on another server, or be reading this thread
+        // from one. Relay unconditionally, the same way the DM PRIVMSG path
+        // does — peers dedup by event_id, and one with no local session for
+        // the target simply no-ops.
+        s2s_broadcast(
+            state,
+            crate::s2s::S2sMessage::Tagmsg {
+                event_id: s2s_next_event_id(state),
+                from: nick.to_string(),
+                target: target.to_string(),
+                tags: std::collections::HashMap::from([(
+                    "+draft/delete".to_string(),
+                    original_msgid.to_string(),
+                )]),
+                origin: state.server_iroh_id.lock().clone().unwrap_or_default(),
+                account: conn.authenticated_did.clone(),
+            },
+        );
     }
 }
 

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -215,6 +215,24 @@ pub(super) fn handle_tagmsg(
             tags.entry(canonical.to_string()).or_insert(v);
         }
     }
+    // Resolve the message being acted on to its root id before anything —
+    // persistence, local fan-out and the S2S relay all read this map, so
+    // rewriting here is what makes every receiver of any revision hear the one
+    // identity the message keeps for life.
+    {
+        let acts_on_a_message =
+            tags.contains_key("+react") || tags.contains_key("+freeq.at/unreact");
+        if acts_on_a_message
+            && let Some(target_msgid) = tags.get("+reply")
+        {
+            let root = super::helpers::root_msgid(state, target_msgid);
+            tags.insert("+reply".to_string(), root);
+        }
+        if let Some(deleted) = tags.get("+draft/delete") {
+            let root = super::helpers::root_msgid(state, deleted);
+            tags.insert("+draft/delete".to_string(), root);
+        }
+    }
     let tags = &tags;
 
     // ── Message deletion (+draft/delete=<msgid>) ──
@@ -871,6 +889,7 @@ pub(super) fn handle_privmsg_with_multiline(
                     timestamp,
                     tags: history_tags,
                     msgid: Some(msgid.clone()),
+                    edited: false,
                 });
                 while ch.history.len() > MAX_HISTORY {
                     ch.history.pop_front();
@@ -2058,6 +2077,13 @@ fn handle_edit(
     let nick = conn.nick_or_star();
     let is_channel = target.starts_with('#') || target.starts_with('&');
 
+    // An edit changes content, never identity. Anchor to the root so the
+    // stored row, the in-memory entry and the `+draft/edit` tag every receiver
+    // sees all name the same message, whichever revision the editor's client
+    // held.
+    let root_msgid = super::helpers::root_msgid(state, original_msgid);
+    let original_msgid: &str = &root_msgid;
+
     // Verify authorship: look up original message by msgid, resolving the
     // canonical dm_key for DMs (target may be a nick or a DID).
     let original = find_original_message(conn, target, original_msgid, is_channel, state);
@@ -2131,7 +2157,9 @@ fn handle_edit(
     // Build tags with edit reference + new msgid
     let mut full_tags = tags.clone();
     full_tags.insert("msgid".to_string(), edit_msgid.clone());
-    // Keep the +draft/edit tag so clients know this is an edit
+    // Keep the +draft/edit tag so clients know this is an edit — pointing at
+    // the root, which is the id they hold the message under.
+    full_tags.insert("+draft/edit".to_string(), original_msgid.to_string());
 
     // Verify/sign edited message
     let edit_timestamp = std::time::SystemTime::now()
@@ -2216,11 +2244,12 @@ fn handle_edit(
     };
 
     // Store in DB
-    let store_tags: std::collections::HashMap<String, String> = tags
+    let mut store_tags: std::collections::HashMap<String, String> = tags
         .iter()
         .filter(|(k, _)| *k != "msgid")
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
+    store_tags.insert("+draft/edit".to_string(), original_msgid.to_string());
     // For DMs, store under the canonical dm_key (not the nick) so
     // edits appear in CHATHISTORY alongside the original message.
     // store_channel was captured from the original row above.
@@ -2252,6 +2281,9 @@ fn handle_edit(
                 if hist.msgid.as_deref() == Some(original_msgid) {
                     hist.text = new_text.to_string();
                     // Don't change hist.msgid — keep original stable for chained edits
+                    // Join replay collapses revisions into this one entry, so
+                    // without the flag a late joiner can't tell it was edited.
+                    hist.edited = true;
                     break;
                 }
             }

--- a/freeq-server/src/connection/mod.rs
+++ b/freeq-server/src/connection/mod.rs
@@ -1079,7 +1079,6 @@ where
                     continue;
                 }
                 let channel = normalize_channel(&msg.params[0]);
-                let msgid = &msg.params[1];
                 let is_pin = msg.command == "PIN";
 
                 // Check op status (or server oper)
@@ -1099,6 +1098,10 @@ where
                     send(&state, &session_id, format!("{reply}\r\n"));
                     continue;
                 }
+
+                // Pin the message, not a revision of it: an op pinning after an
+                // edit must land on the same entry as one pinning before.
+                let msgid = &helpers::root_msgid(&state, &msg.params[1]);
 
                 let mut channels = state.channels.lock();
                 if let Some(ch) = channels.get_mut(&channel) {

--- a/freeq-server/src/connection/routing.rs
+++ b/freeq-server/src/connection/routing.rs
@@ -101,6 +101,7 @@ pub(crate) fn relay_to_nick(
                 sig: None,   // PM relay — sig not available at routing layer
                 account: account.map(|a| a.to_string()),
                 recipient_did: recipient_did_for_target(state, target),
+                replaces_msgid: None,
                 tags: s2s_tags,
                 multiline_lines: multiline_lines.map(|lines| {
                     lines

--- a/freeq-server/src/connection/routing.rs
+++ b/freeq-server/src/connection/routing.rs
@@ -47,6 +47,30 @@ pub(crate) enum RouteResult {
     Unreachable,
 }
 
+/// Who a relayed DM is and what it does — everything beyond the body that has
+/// to survive the hop.
+///
+/// Grouped rather than passed positionally because the relay used to drop all
+/// of it: a DM to a user on another server crossed with no msgid, so the peer
+/// minted its own and the two servers held the same message under two
+/// identities. Nothing that names a message across servers — an edit, a
+/// delete, a reaction — can work while that is true.
+#[derive(Default)]
+pub(crate) struct RelayIdentity<'a> {
+    /// Sender's DID (the `account` tag), origin-stamped.
+    pub account: Option<&'a str>,
+    /// The message's own id. `None` makes the receiver mint one.
+    pub msgid: Option<&'a str>,
+    /// `+freeq.at/sig`. Origin attestation only — the peer cannot verify it
+    /// (the signed timestamp doesn't cross the hop), so it travels for parity
+    /// with channel messages, not as proof.
+    pub sig: Option<&'a str>,
+    /// Set when this message is an edit: the root id of what it revises.
+    pub replaces_msgid: Option<&'a str>,
+    /// Coordination tags, already filtered by `relay_coordination_tags`.
+    pub tags: std::collections::HashMap<String, String>,
+}
+
 /// Route a PRIVMSG/NOTICE to a nick. Checks local first, then relays
 /// to all S2S peers if federation is active. Never gates on
 /// `remote_members` — that's a display cache, not a routing table.
@@ -60,11 +84,11 @@ pub(crate) enum RouteResult {
 pub(crate) fn relay_to_nick(
     state: &Arc<SharedState>,
     from: &str,
-    account: Option<&str>,
     target: &str,
     text: &str,
     event_id: String,
     multiline_lines: Option<&[crate::connection::draft_multiline::BatchLine]>,
+    identity: RelayIdentity<'_>,
 ) -> RouteResult {
     // 1. Local delivery. A `did:` target resolves through `did_sessions`
     //    (any one bound session — the caller's fan-out reaches the rest via
@@ -90,18 +114,21 @@ pub(crate) fn relay_to_nick(
         let manager = state.s2s_manager.lock().clone();
         if let Some(m) = manager {
             let (s2s_text, s2s_tags) =
-                crate::s2s::encode_privmsg_text_for_s2s(text, std::collections::HashMap::new());
+                crate::s2s::encode_privmsg_text_for_s2s(text, identity.tags);
             m.broadcast(crate::s2s::S2sMessage::Privmsg {
                 event_id,
                 from: from.to_string(),
                 target: target.to_string(),
                 text: s2s_text,
                 origin,
-                msgid: None, // PM relay — no msgid (recipient server assigns)
-                sig: None,   // PM relay — sig not available at routing layer
-                account: account.map(|a| a.to_string()),
+                // The origin's id, so both servers hold this message under one
+                // identity. Without it the receiver mints its own and every
+                // later edit, delete or reaction names something it can't find.
+                msgid: identity.msgid.map(|m| m.to_string()),
+                sig: identity.sig.map(|s| s.to_string()),
+                account: identity.account.map(|a| a.to_string()),
                 recipient_did: recipient_did_for_target(state, target),
-                replaces_msgid: None,
+                replaces_msgid: identity.replaces_msgid.map(|r| r.to_string()),
                 tags: s2s_tags,
                 multiline_lines: multiline_lines.map(|lines| {
                     lines
@@ -330,11 +357,14 @@ mod tests {
         match relay_to_nick(
             &state,
             "alice",
-            Some("did:plc:alice"),
             "did:plc:bob",
             "hi",
             "evt-1".to_string(),
             None,
+            RelayIdentity {
+                account: Some("did:plc:alice"),
+                ..Default::default()
+            },
         ) {
             RouteResult::Local(sid) => assert_eq!(sid, "sess-b1"),
             _ => panic!("expected Local for a DID with a local session"),

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -129,6 +129,10 @@ pub struct MessageRow {
     pub msgid: Option<String>,
     /// If this is an edit, the msgid of the original message it replaces.
     pub replaces_msgid: Option<String>,
+    /// The identity of the logical message this row is a revision of — the
+    /// original msgid, and equal to `msgid` for an original. NULL only on rows
+    /// old enough to have no msgid at all.
+    pub root_msgid: Option<String>,
     /// Unix timestamp when this message was deleted (soft delete).
     pub deleted_at: Option<u64>,
     /// DID of the sender (if authenticated at send time).
@@ -286,6 +290,183 @@ impl Db {
         Ok(())
     }
 
+    /// Walk `replaces_msgid` back-pointers to the oldest revision. Upgrade-only:
+    /// rows written since `root_msgid` exists are stamped at insert time, so
+    /// this runs solely over rows that predate the column. Bounded — a
+    /// malformed back-pointer cycle must not spin.
+    fn migration_root_of(&self, channel: &str, msgid: &str) -> SqlResult<String> {
+        let mut root = msgid.to_string();
+        for _ in 0..64 {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT replaces_msgid FROM messages WHERE channel = ?1 AND msgid = ?2")?;
+            let parent: Option<String> = stmt
+                .query_map(params![channel, &root], |r| r.get::<_, Option<String>>(0))?
+                .next()
+                .transpose()?
+                .flatten();
+            match parent {
+                Some(p) if !p.is_empty() && p != root => root = p,
+                _ => break,
+            }
+        }
+        Ok(root)
+    }
+
+    /// One-time upgrade: stamp `root_msgid` on rows that predate the column,
+    /// then re-file reactions and pins under the root they annotate.
+    ///
+    /// A message's identity is its original msgid for life; an edit changes
+    /// content, not identity. Before `root_msgid` existed, an operation could
+    /// name either end of an edit chain, so the same logical message could
+    /// collect reactions and pins under two different ids. Re-filing them under
+    /// the root is what makes those tallies agree afterwards.
+    ///
+    /// Idempotent (`WHERE root_msgid IS NULL`, and the re-file is a no-op once
+    /// every id is already a root), so re-running is safe. A fresh database is
+    /// born with the column and stamps every row at insert, so the guard
+    /// matches zero rows and none of this executes.
+    ///
+    /// An id with no message row — an unpersisted guest-DM message — is its own
+    /// root and is left untouched everywhere.
+    fn backfill_root_msgids(&self) -> SqlResult<()> {
+        // Originals: identity is the msgid itself.
+        self.conn.execute(
+            "UPDATE messages SET root_msgid = msgid
+             WHERE root_msgid IS NULL AND msgid IS NOT NULL
+               AND (replaces_msgid IS NULL OR replaces_msgid = '')",
+            [],
+        )?;
+
+        // Edits: walk the back-pointers.
+        let pending: Vec<(String, String)> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT channel, msgid FROM messages
+                 WHERE root_msgid IS NULL AND msgid IS NOT NULL",
+            )?;
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<SqlResult<Vec<_>>>()?
+        };
+        for (channel, msgid) in pending {
+            let root = self.migration_root_of(&channel, &msgid)?;
+            self.conn.execute(
+                "UPDATE messages SET root_msgid = ?1 WHERE channel = ?2 AND msgid = ?3",
+                params![root, channel, msgid],
+            )?;
+        }
+
+        self.backfill_reaction_roots()?;
+        self.backfill_pin_roots()?;
+        Ok(())
+    }
+
+    /// Re-file reactions under the root of the message they annotate.
+    /// `reactions` is `UNIQUE(target_msgid, reactor_nick, emoji)`, so one person
+    /// who reacted against two revisions of the same message has two rows that
+    /// would collide on rewrite — the earlier row wins and the later is dropped,
+    /// which is the same tally the two rows were always meant to represent.
+    fn backfill_reaction_roots(&self) -> SqlResult<()> {
+        let rewrites: Vec<(String, String)> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT DISTINCT r.target_msgid, m.root_msgid
+                 FROM reactions r JOIN messages m ON m.msgid = r.target_msgid
+                 WHERE m.root_msgid IS NOT NULL AND m.root_msgid <> r.target_msgid",
+            )?;
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<SqlResult<Vec<_>>>()?
+        };
+        for (old_id, root) in rewrites {
+            // Of a colliding pair, drop the later row. The `<=` / `<` split
+            // means a tie drops the revision row, never both.
+            self.conn.execute(
+                "DELETE FROM reactions WHERE target_msgid = ?1 AND EXISTS (
+                     SELECT 1 FROM reactions keep
+                     WHERE keep.target_msgid = ?2
+                       AND keep.reactor_nick = reactions.reactor_nick
+                       AND keep.emoji = reactions.emoji
+                       AND keep.timestamp <= reactions.timestamp
+                 )",
+                params![old_id, root],
+            )?;
+            self.conn.execute(
+                "DELETE FROM reactions WHERE target_msgid = ?2 AND EXISTS (
+                     SELECT 1 FROM reactions keep
+                     WHERE keep.target_msgid = ?1
+                       AND keep.reactor_nick = reactions.reactor_nick
+                       AND keep.emoji = reactions.emoji
+                       AND keep.timestamp < reactions.timestamp
+                 )",
+                params![old_id, root],
+            )?;
+            // OR IGNORE + sweep: a surviving collision must not abort startup.
+            self.conn.execute(
+                "UPDATE OR IGNORE reactions SET target_msgid = ?1 WHERE target_msgid = ?2",
+                params![root, old_id],
+            )?;
+            self.conn.execute(
+                "DELETE FROM reactions WHERE target_msgid = ?1",
+                params![old_id],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Re-file pins under the root of the message they pin. `pins` is
+    /// `UNIQUE(channel, msgid)`; a message pinned under two revisions keeps the
+    /// earliest `pinned_at` — the moment it was actually first pinned.
+    fn backfill_pin_roots(&self) -> SqlResult<()> {
+        let rewrites: Vec<(String, String, String)> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT DISTINCT p.channel, p.msgid, m.root_msgid
+                 FROM pins p JOIN messages m ON m.msgid = p.msgid
+                 WHERE m.root_msgid IS NOT NULL AND m.root_msgid <> p.msgid",
+            )?;
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+                .collect::<SqlResult<Vec<_>>>()?
+        };
+        for (channel, old_id, root) in rewrites {
+            self.conn.execute(
+                "UPDATE pins SET pinned_at = (
+                     SELECT MIN(pinned_at) FROM pins
+                     WHERE channel = ?1 AND msgid IN (?2, ?3)
+                 )
+                 WHERE channel = ?1 AND msgid = ?3",
+                params![channel, old_id, root],
+            )?;
+            self.conn.execute(
+                "UPDATE OR IGNORE pins SET msgid = ?1 WHERE channel = ?2 AND msgid = ?3",
+                params![root, channel, old_id],
+            )?;
+            self.conn.execute(
+                "DELETE FROM pins WHERE channel = ?1 AND msgid = ?2",
+                params![channel, old_id],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// The root msgid of the logical message `msgid` belongs to — its identity
+    /// for life, unchanged by edits. An id with no row (an unpersisted guest-DM
+    /// message) is its own root.
+    ///
+    /// This is the single definition of "the same message"; reactions, pins and
+    /// deletes all file and look up by what it returns.
+    pub fn root_of(&self, msgid: &str) -> String {
+        self.conn
+            .query_row(
+                "SELECT root_msgid, msgid FROM messages WHERE msgid = ?1 LIMIT 1",
+                params![msgid],
+                |r| {
+                    let root: Option<String> = r.get(0)?;
+                    let own: Option<String> = r.get(1)?;
+                    Ok(root.or(own))
+                },
+            )
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| msgid.to_string())
+    }
+
     fn init(&self) -> SqlResult<()> {
         self.conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         self.conn.execute_batch("PRAGMA foreign_keys=ON;")?;
@@ -417,6 +598,7 @@ impl Db {
             "ALTER TABLE channels ADD COLUMN encrypted_only INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE messages ADD COLUMN msgid TEXT",
             "ALTER TABLE messages ADD COLUMN replaces_msgid TEXT",
+            "ALTER TABLE messages ADD COLUMN root_msgid TEXT",
             "ALTER TABLE messages ADD COLUMN deleted_at INTEGER",
             "ALTER TABLE messages ADD COLUMN sender_did TEXT",
             "ALTER TABLE identities ADD COLUMN last_auth_at INTEGER",
@@ -434,6 +616,17 @@ impl Db {
         // whole messages table under the global DB lock.
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_messages_sender_did ON messages(sender_did)",
+            [],
+        )?;
+        // `root_of` runs on every reaction, pin and delete, and the delete
+        // sweep selects a whole revision family by root — both would otherwise
+        // full-scan `messages` under the global DB lock.
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_msgid ON messages(msgid)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_root_msgid ON messages(root_msgid)",
             [],
         )?;
 
@@ -640,6 +833,10 @@ impl Db {
             ",
         )?;
 
+        // Last: it re-files `reactions` and `pins` rows, so both tables have to
+        // exist by now.
+        self.backfill_root_msgids()?;
+
         Ok(())
     }
 
@@ -706,8 +903,10 @@ impl Db {
             }
             let before_ts = before.map(|b| b as i64).unwrap_or(i64::MAX);
             let mut stmt = self.conn.prepare(
+                // Results carry the root id: a hit on an edited message must be
+                // addressable by the identity every client holds it under.
                 "SELECT m.id, m.channel, m.sender, m.text, m.timestamp, m.tags_json,
-                        m.msgid, m.replaces_msgid, m.deleted_at, m.sender_did
+                        COALESCE(m.root_msgid, m.msgid), m.replaces_msgid, m.deleted_at, m.sender_did, m.root_msgid
                  FROM messages_fts
                  JOIN messages m ON m.id = messages_fts.rowid
                  WHERE messages_fts MATCH ?1
@@ -733,9 +932,15 @@ impl Db {
         let before_ts = before.map(|b| b as i64).unwrap_or(i64::MAX);
         let mut stmt = self.conn.prepare(
             "SELECT id, channel, sender, text, timestamp, tags_json,
-                    msgid, replaces_msgid, deleted_at, sender_did
-             FROM messages
+                    COALESCE(root_msgid, msgid), replaces_msgid, deleted_at, sender_did, root_msgid
+             FROM messages m
              WHERE channel = ?1 AND deleted_at IS NULL AND timestamp < ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM messages newer
+                   WHERE newer.channel = m.channel
+                     AND newer.root_msgid = m.root_msgid
+                     AND newer.id > m.id
+               )
              ORDER BY timestamp DESC, id DESC
              LIMIT ?3",
         )?;
@@ -1011,9 +1216,10 @@ impl Db {
         } else {
             text.to_string()
         };
+        // An original message is its own root — its identity for life.
         self.conn.execute(
-            "INSERT INTO messages (channel, sender, text, timestamp, tags_json, msgid, sender_did)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO messages (channel, sender, text, timestamp, tags_json, msgid, root_msgid, sender_did)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, ?7)",
             params![
                 channel,
                 sender,
@@ -1051,7 +1257,7 @@ impl Db {
     ) -> SqlResult<Vec<MessageRow>> {
         let mut rows_vec = if let Some(before_ts) = before {
             let mut stmt = self.conn.prepare(
-                "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+                "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
                  FROM messages
                  WHERE channel = ?1 AND deleted_at IS NULL AND timestamp < ?2
                  ORDER BY timestamp DESC, id DESC
@@ -1064,7 +1270,7 @@ impl Db {
             rows.collect::<SqlResult<Vec<_>>>()?
         } else {
             let mut stmt = self.conn.prepare(
-                "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+                "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
                  FROM messages
                  WHERE channel = ?1 AND deleted_at IS NULL
                  ORDER BY timestamp DESC, id DESC
@@ -1092,7 +1298,7 @@ impl Db {
         limit: usize,
     ) -> SqlResult<Vec<MessageRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
              FROM messages
              WHERE channel = ?1 AND deleted_at IS NULL AND timestamp > ?2
              ORDER BY timestamp ASC, id ASC
@@ -1120,7 +1326,7 @@ impl Db {
         limit: usize,
     ) -> SqlResult<Vec<MessageRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
              FROM messages
              WHERE channel = ?1 AND deleted_at IS NULL AND timestamp > ?2 AND timestamp < ?3
              ORDER BY timestamp ASC, id ASC
@@ -1186,7 +1392,7 @@ impl Db {
         msgid: &str,
     ) -> SqlResult<Option<MessageRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
              FROM messages
              WHERE channel = ?1 AND msgid = ?2
              LIMIT 1"
@@ -1207,7 +1413,7 @@ impl Db {
     /// Find a message by msgid across all channels.
     pub fn find_message_by_msgid(&self, msgid: &str) -> SqlResult<Option<MessageRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did
+            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
              FROM messages
              WHERE msgid = ?1 AND deleted_at IS NULL
              LIMIT 1",
@@ -1225,82 +1431,75 @@ impl Db {
         }
     }
 
-    /// Soft-delete a message by setting deleted_at timestamp.
-    /// Every msgid belonging to the same logical message as `msgid`.
+    /// The current text of the logical message `msgid` names — the newest
+    /// revision, whichever revision was asked for.
     ///
-    /// An edit is stored as a *new* row carrying `replaces_msgid`, so one
-    /// logical message can span several rows. This walks up to the root
-    /// revision and then collects everything that (transitively) replaces it,
-    /// so callers can act on the message rather than on one revision of it.
-    /// Both walks are bounded: a malformed `replaces_msgid` cycle must not spin.
-    fn revision_family(&self, channel: &str, msgid: &str) -> SqlResult<Vec<String>> {
-        let mut root = msgid.to_string();
-        for _ in 0..64 {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT replaces_msgid FROM messages WHERE channel = ?1 AND msgid = ?2")?;
-            let parent: Option<String> = stmt
-                .query_map(params![channel, &root], |r| r.get::<_, Option<String>>(0))?
-                .next()
-                .transpose()?
-                .flatten();
-            match parent {
-                Some(p) if !p.is_empty() && p != root => root = p,
-                _ => break,
-            }
-        }
-
-        let mut family = vec![root.clone()];
-        let mut frontier = vec![root];
-        while let Some(current) = frontier.pop() {
-            let mut stmt = self.conn.prepare(
-                "SELECT msgid FROM messages
-                 WHERE channel = ?1 AND replaces_msgid = ?2 AND msgid IS NOT NULL",
-            )?;
-            let children: Vec<String> = stmt
-                .query_map(params![channel, &current], |r| r.get(0))?
-                .collect::<SqlResult<Vec<String>>>()?;
-            for child in children {
-                if !family.contains(&child) {
-                    family.push(child.clone());
-                    frontier.push(child);
+    /// Displays that quote a message (pins, most visibly) need the version the
+    /// author last wrote, not the one whose id happens to be on file.
+    pub fn current_revision(&self, msgid: &str) -> SqlResult<Option<MessageRow>> {
+        let root = self.root_of(msgid);
+        let mut stmt = self.conn.prepare(
+            "SELECT id, channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, deleted_at, sender_did, root_msgid
+             FROM messages
+             WHERE root_msgid = ?1 AND deleted_at IS NULL
+             ORDER BY timestamp DESC, id DESC
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query_map(params![root], map_message_row)?;
+        match rows.next() {
+            Some(row) => {
+                let mut msg = row?;
+                if let Some(ref key) = self.encryption_key {
+                    msg.text = decrypt_at_rest(key, &msg.text);
                 }
+                Ok(Some(msg))
             }
-            if family.len() > 512 {
-                break; // safety valve; no legitimate message has 512 revisions
-            }
+            None => Ok(None),
         }
-        Ok(family)
     }
 
     /// Soft-delete a message *and every revision of it*.
     ///
-    /// Clients keep the ORIGINAL msgid as a message's identity (that's the point
-    /// of `+draft/edit=<original>`), so a delete names the original while the
+    /// A message's identity is its original msgid for life (that's the point of
+    /// `+draft/edit=<original>`), so a delete names the original while the
     /// current text may live in a later edit row. Marking only the exact msgid
     /// left the newest text — the version the author most wants gone — readable
-    /// in CHATHISTORY and in FTS search. Either end of the family may be named.
+    /// in CHATHISTORY and in FTS search. Either end of the family may be named:
+    /// every row of one logical message carries the same `root_msgid`.
     pub fn soft_delete_message(&self, channel: &str, msgid: &str) -> SqlResult<usize> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 
-        let family = self.revision_family(channel, msgid)?;
+        let root = self.root_of(msgid);
+
+        // The msgids of every revision. Pins and reactions are filed under the
+        // root, but a row written before that was true may still name a
+        // revision, so the sweeps below clear the whole set.
+        let family: Vec<String> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT msgid FROM messages
+                 WHERE channel = ?1 AND root_msgid = ?2 AND msgid IS NOT NULL",
+            )?;
+            let mut rows: Vec<String> = stmt
+                .query_map(params![channel, &root], |r| r.get(0))?
+                .collect::<SqlResult<Vec<String>>>()?;
+            if !rows.iter().any(|m| m == &root) {
+                rows.push(root.clone());
+            }
+            rows
+        };
 
         // Resolve to row ids first so the FTS delete and the UPDATE act on
         // exactly the same set, with uniformly-typed bind parameters.
         let ph = family.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let ids: Vec<i64> = {
-            let sql = format!(
+            let mut stmt = self.conn.prepare(
                 "SELECT id FROM messages
-                 WHERE channel = ? AND deleted_at IS NULL AND msgid IN ({ph})"
-            );
-            let mut binds: Vec<String> = Vec::with_capacity(family.len() + 1);
-            binds.push(channel.to_string());
-            binds.extend(family.iter().cloned());
-            let mut stmt = self.conn.prepare(&sql)?;
-            stmt.query_map(rusqlite::params_from_iter(binds.iter()), |r| r.get(0))?
+                 WHERE channel = ?1 AND deleted_at IS NULL AND root_msgid = ?2",
+            )?;
+            stmt.query_map(params![channel, &root], |r| r.get(0))?
                 .collect::<SqlResult<Vec<i64>>>()?
         };
         if ids.is_empty() {
@@ -1424,6 +1623,11 @@ impl Db {
     }
 
     /// Store an edit (a new message that replaces an old one).
+    ///
+    /// The new row carries the *root* of what it replaces, so every revision of
+    /// one logical message shares an identity no matter which revision the
+    /// editor named. Only the newest revision stays in the search index —
+    /// otherwise a search for pre-edit text surfaces superseded revisions.
     pub fn insert_edit(
         &self,
         channel: &str,
@@ -1441,18 +1645,31 @@ impl Db {
         } else {
             text.to_string()
         };
+        let root = self.root_of(replaces_msgid);
         self.conn.execute(
-            "INSERT INTO messages (channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, sender_did)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![channel, sender, stored_text, timestamp as i64, tags_json, msgid, replaces_msgid, sender_did],
+            "INSERT INTO messages (channel, sender, text, timestamp, tags_json, msgid, replaces_msgid, root_msgid, sender_did)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![channel, sender, stored_text, timestamp as i64, tags_json, msgid, replaces_msgid, root, sender_did],
         )?;
-        self.fts_index(self.conn.last_insert_rowid(), text)?;
+        let rowid = self.conn.last_insert_rowid();
+        if self.fts_enabled() {
+            self.conn.execute(
+                "DELETE FROM messages_fts WHERE rowid IN (
+                     SELECT id FROM messages WHERE channel = ?1 AND root_msgid = ?2 AND id <> ?3
+                 )",
+                params![channel, root, rowid],
+            )?;
+        }
+        self.fts_index(rowid, text)?;
         Ok(())
     }
 
     // ── Reactions ──────────────────────────────────────────────────────
 
     /// Store a reaction. Upsert — duplicate (msgid, nick, emoji) is ignored.
+    ///
+    /// Filed against the root, so reacting to an edited message lands on the
+    /// same row whichever revision the reactor's client named.
     pub fn store_reaction(
         &self,
         target_msgid: &str,
@@ -1462,6 +1679,7 @@ impl Db {
         emoji: &str,
         timestamp: u64,
     ) -> SqlResult<()> {
+        let target_msgid = &self.root_of(target_msgid);
         self.conn.execute(
             "INSERT OR IGNORE INTO reactions (target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -1486,6 +1704,7 @@ impl Db {
         reactor_did: Option<&str>,
         emoji: &str,
     ) -> SqlResult<usize> {
+        let target_msgid = &self.root_of(target_msgid);
         let changed = match reactor_did {
             Some(did) => self.conn.execute(
                 "DELETE FROM reactions WHERE target_msgid = ?1 AND emoji = ?2
@@ -1547,6 +1766,9 @@ impl Db {
     // ── Pins ──────────────────────────────────────────────────────────
 
     /// Store a pin. Duplicate (channel, msgid) is ignored.
+    ///
+    /// Filed against the root, so a message can't end up pinned twice by being
+    /// pinned once before an edit and once after.
     pub fn store_pin(
         &self,
         channel: &str,
@@ -1554,6 +1776,7 @@ impl Db {
         pinned_by: &str,
         pinned_at: u64,
     ) -> SqlResult<()> {
+        let msgid = &self.root_of(msgid);
         self.conn.execute(
             "INSERT OR IGNORE INTO pins (channel, msgid, pinned_by, pinned_at)
              VALUES (?1, ?2, ?3, ?4)",
@@ -1564,6 +1787,7 @@ impl Db {
 
     /// Remove a pin.
     pub fn remove_pin(&self, channel: &str, msgid: &str) -> SqlResult<usize> {
+        let msgid = &self.root_of(msgid);
         let changed = self.conn.execute(
             "DELETE FROM pins WHERE channel = ?1 AND msgid = ?2",
             params![channel, msgid],
@@ -1617,40 +1841,6 @@ impl Db {
             Ok((channel, ts as u64))
         })?;
         rows.collect()
-    }
-
-    /// Edit a message (update text by msgid).
-    pub fn edit_message(
-        &self,
-        msgid: &str,
-        _sender: &str,
-        new_text: &str,
-        new_msgid: Option<&str>,
-    ) -> SqlResult<()> {
-        let stored_text = if let Some(ref key) = self.encryption_key {
-            encrypt_at_rest(key, new_text)
-        } else {
-            new_text.to_string()
-        };
-        if let Some(new_id) = new_msgid {
-            self.conn.execute(
-                "UPDATE messages SET text = ?1, replaces_msgid = ?2 WHERE msgid = ?3",
-                params![stored_text, new_id, msgid],
-            )?;
-        } else {
-            self.conn.execute(
-                "UPDATE messages SET text = ?1 WHERE msgid = ?2",
-                params![stored_text, msgid],
-            )?;
-        }
-        if self.fts_enabled() {
-            self.conn.execute(
-                "INSERT OR REPLACE INTO messages_fts (rowid, text)
-                 SELECT id, ?1 FROM messages WHERE msgid = ?2",
-                params![new_text, msgid],
-            )?;
-        }
-        Ok(())
     }
 
     // ── Pre-key bundles (E2EE) ────────────────────────────────────────
@@ -2020,6 +2210,7 @@ fn map_message_row(row: &rusqlite::Row) -> SqlResult<MessageRow> {
         .unwrap_or(None)
         .map(|v| v as u64);
     let sender_did: Option<String> = row.get(9).unwrap_or(None);
+    let root_msgid: Option<String> = row.get(10).unwrap_or(None);
     Ok(MessageRow {
         id: row.get(0)?,
         channel: row.get(1)?,
@@ -2029,6 +2220,7 @@ fn map_message_row(row: &rusqlite::Row) -> SqlResult<MessageRow> {
         tags,
         msgid,
         replaces_msgid,
+        root_msgid,
         deleted_at,
         sender_did,
     })
@@ -2365,6 +2557,22 @@ mod tests {
         );
     }
 
+    /// Store an edit of `replaces` as the client sends one: a new row with its
+    /// own msgid, pointing back at the message it revises.
+    fn edit(db: &Db, channel: &str, text: &str, ts: u64, msgid: &str, replaces: &str) {
+        db.insert_edit(
+            channel,
+            "alice!a@host",
+            text,
+            ts,
+            &HashMap::new(),
+            msgid,
+            replaces,
+            Some("did:plc:alice"),
+        )
+        .unwrap();
+    }
+
     /// Deleting a message must remove every revision of it.
     ///
     /// An edit is a separate row carrying `replaces_msgid`, and clients keep the
@@ -2579,6 +2787,262 @@ mod tests {
         );
     }
 
+    // ── Message identity: one root id per logical message ──────────────
+
+    /// Simulate a database written before `root_msgid` existed: clear the
+    /// stamps so the next backfill has to derive them from the back-pointers.
+    fn strip_root_ids(db: &Db) {
+        db.conn
+            .execute("UPDATE messages SET root_msgid = NULL", [])
+            .unwrap();
+    }
+
+    fn reaction_rows(db: &Db, msgid: &str) -> Vec<(String, String, u64)> {
+        let mut stmt = db
+            .conn
+            .prepare(
+                "SELECT reactor_nick, emoji, timestamp FROM reactions
+                 WHERE target_msgid = ?1 ORDER BY timestamp",
+            )
+            .unwrap();
+        stmt.query_map(params![msgid], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get::<_, i64>(2)? as u64))
+        })
+        .unwrap()
+        .collect::<SqlResult<Vec<_>>>()
+        .unwrap()
+    }
+
+    #[test]
+    fn an_edit_inherits_the_original_identity() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+        edit(&db, "#c", "v3", 120, "id-3", "id-2");
+
+        // Every revision resolves to the id the client has held since v1 —
+        // including one named by the id of an intermediate revision.
+        assert_eq!(db.root_of("id-1"), "id-1");
+        assert_eq!(db.root_of("id-2"), "id-1");
+        assert_eq!(db.root_of("id-3"), "id-1");
+        // An id with no row is its own root (unpersisted guest-DM messages).
+        assert_eq!(db.root_of("id-nowhere"), "id-nowhere");
+    }
+
+    #[test]
+    fn backfill_roots_a_three_deep_chain() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+        edit(&db, "#c", "v3", 120, "id-3", "id-2");
+        msg(&db, "#c", "unrelated", 130, "id-other");
+        strip_root_ids(&db);
+
+        db.backfill_root_msgids().unwrap();
+
+        assert_eq!(db.root_of("id-3"), "id-1");
+        assert_eq!(db.root_of("id-2"), "id-1");
+        assert_eq!(db.root_of("id-other"), "id-other");
+        // Re-running must not disturb what the first pass settled.
+        db.backfill_root_msgids().unwrap();
+        assert_eq!(db.root_of("id-3"), "id-1");
+    }
+
+    /// Two revisions of one message could each collect the same person's
+    /// reaction. Re-filing both under the root collides on
+    /// `UNIQUE(target_msgid, reactor_nick, emoji)`; the earliest survives,
+    /// whichever revision it was filed against.
+    #[test]
+    fn backfill_dedups_reactions_across_revisions() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+        msg(&db, "#c", "v1", 100, "id-a");
+        edit(&db, "#c", "v2", 110, "id-b", "id-a");
+        strip_root_ids(&db);
+
+        // Reacted before the edit and again after it — the double-file the
+        // root id exists to prevent.
+        for (target, ts) in [("id-1", 105u64), ("id-2", 115)] {
+            db.conn
+                .execute(
+                    "INSERT INTO reactions (target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp)
+                     VALUES (?1, '#c', 'bob', NULL, '🔥', ?2)",
+                    params![target, ts as i64],
+                )
+                .unwrap();
+        }
+        // Same, with the revision carrying the *earlier* of the two.
+        for (target, ts) in [("id-a", 205u64), ("id-b", 105)] {
+            db.conn
+                .execute(
+                    "INSERT INTO reactions (target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp)
+                     VALUES (?1, '#c', 'bob', NULL, '👍', ?2)",
+                    params![target, ts as i64],
+                )
+                .unwrap();
+        }
+
+        db.backfill_root_msgids().unwrap();
+
+        assert_eq!(
+            reaction_rows(&db, "id-1"),
+            vec![("bob".to_string(), "🔥".to_string(), 105)],
+            "one person reacting once must not read as two"
+        );
+        assert!(reaction_rows(&db, "id-2").is_empty());
+        assert_eq!(
+            reaction_rows(&db, "id-a"),
+            vec![("bob".to_string(), "👍".to_string(), 105)],
+            "the earliest reaction survives even when it named the revision"
+        );
+    }
+
+    #[test]
+    fn backfill_dedups_pins_across_revisions() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+        strip_root_ids(&db);
+        // Pinned before the edit, and again after it under the revision's id.
+        db.conn
+            .execute(
+                "INSERT INTO pins (channel, msgid, pinned_by, pinned_at) VALUES
+                 ('#c', 'id-1', 'alice', 101), ('#c', 'id-2', 'alice', 111)",
+                [],
+            )
+            .unwrap();
+
+        db.backfill_root_msgids().unwrap();
+
+        let pins = db.get_pins("#c").unwrap();
+        assert_eq!(pins.len(), 1, "one message, one pin");
+        assert_eq!(pins[0].msgid, "id-1");
+        assert_eq!(pins[0].pinned_at, 101, "keeps when it was first pinned");
+    }
+
+    /// At-rest encryption covers message text only — the ids the backfill walks
+    /// are stored plaintext — so an encrypted database upgrades identically.
+    #[test]
+    fn backfill_runs_on_an_encrypted_database() {
+        let db = Db::open_encrypted_memory([3u8; 32]).unwrap();
+        msg(&db, "#c", "v1", 100, "enc-1");
+        edit(&db, "#c", "v2", 110, "enc-2", "enc-1");
+        db.conn
+            .execute(
+                "INSERT INTO reactions (target_msgid, channel, reactor_nick, reactor_did, emoji, timestamp)
+                 VALUES ('enc-2', '#c', 'bob', NULL, '🔥', 115)",
+                [],
+            )
+            .unwrap();
+        strip_root_ids(&db);
+
+        db.backfill_root_msgids().unwrap();
+
+        assert_eq!(db.root_of("enc-2"), "enc-1");
+        assert_eq!(reaction_rows(&db, "enc-1").len(), 1);
+        assert_eq!(db.current_revision("enc-1").unwrap().unwrap().text, "v2");
+    }
+
+    /// Reacting to an edited message must land on the message, whichever
+    /// revision the reactor's client named — and un-reacting must find it
+    /// again from the other end.
+    #[test]
+    fn reactions_file_and_clear_under_the_root() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+
+        db.store_reaction("id-2", "#c", "bob", Some("did:plc:bob"), "🔥", 111)
+            .unwrap();
+        assert_eq!(reaction_rows(&db, "id-1").len(), 1, "filed under the root");
+
+        // A second client of the same person naming the other id must not
+        // double the tally.
+        db.store_reaction("id-1", "#c", "bob", Some("did:plc:bob"), "🔥", 112)
+            .unwrap();
+        assert_eq!(reaction_rows(&db, "id-1").len(), 1, "one person, one row");
+
+        assert_eq!(
+            db.remove_reaction("id-1", "bob", Some("did:plc:bob"), "🔥")
+                .unwrap(),
+            1,
+            "un-reacting by the original id clears a reaction made on the edit"
+        );
+        assert!(reaction_rows(&db, "id-1").is_empty());
+    }
+
+    #[test]
+    fn pins_file_and_clear_under_the_root() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+
+        db.store_pin("#c", "id-1", "alice", 101).unwrap();
+        db.store_pin("#c", "id-2", "alice", 111).unwrap();
+        let pins = db.get_pins("#c").unwrap();
+        assert_eq!(pins.len(), 1, "pinning before and after an edit is one pin");
+        assert_eq!(pins[0].msgid, "id-1");
+
+        // Unpinned by the revision's id — the same message, so it must clear.
+        assert_eq!(db.remove_pin("#c", "id-2").unwrap(), 1);
+        assert!(db.get_pins("#c").unwrap().is_empty());
+    }
+
+    /// What a pin quotes is the message, so it must follow the edits.
+    #[test]
+    fn current_revision_returns_the_newest_text() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#c", "v1", 100, "id-1");
+        edit(&db, "#c", "v2", 110, "id-2", "id-1");
+        edit(&db, "#c", "v3", 120, "id-3", "id-2");
+
+        for named in ["id-1", "id-2", "id-3"] {
+            assert_eq!(
+                db.current_revision(named).unwrap().unwrap().text,
+                "v3",
+                "asked by {named}"
+            );
+        }
+        assert!(db.current_revision("id-nowhere").unwrap().is_none());
+    }
+
+    /// A DM lives under a canonical `dm:` key rather than a channel name;
+    /// resolution is by message lookup, so it must work there identically.
+    #[test]
+    fn root_resolution_works_in_a_dm_thread() {
+        let db = Db::open_memory().unwrap();
+        let dm = "dm:did:plc:alice,did:plc:bob";
+        msg(&db, dm, "v1", 100, "dm-1");
+        edit(&db, dm, "v2", 110, "dm-2", "dm-1");
+
+        db.store_reaction("dm-2", dm, "bob", Some("did:plc:bob"), "🔥", 111)
+            .unwrap();
+        assert_eq!(reaction_rows(&db, "dm-1").len(), 1);
+        assert_eq!(
+            db.remove_reaction("dm-1", "bob", Some("did:plc:bob"), "🔥")
+                .unwrap(),
+            1
+        );
+    }
+
+    /// An id nobody has a row for — an unpersisted guest DM — is its own root
+    /// and must pass through every path untouched.
+    #[test]
+    fn unknown_ids_pass_through_unchanged() {
+        let db = Db::open_memory().unwrap();
+        db.store_reaction("ghost", "#c", "bob", None, "🔥", 100)
+            .unwrap();
+        assert_eq!(reaction_rows(&db, "ghost").len(), 1);
+        assert_eq!(db.remove_reaction("ghost", "bob", None, "🔥").unwrap(), 1);
+
+        db.store_pin("#c", "ghost", "alice", 100).unwrap();
+        assert_eq!(db.get_pins("#c").unwrap()[0].msgid, "ghost");
+        assert_eq!(db.remove_pin("#c", "ghost").unwrap(), 1);
+
+        assert_eq!(db.soft_delete_message("#c", "ghost").unwrap(), 0);
+    }
+
     #[test]
     fn recent_nick_for_did_recovers_bare_nick_from_history() {
         let db = Db::open_memory().unwrap();
@@ -2771,8 +3235,7 @@ mod tests {
     fn search_reflects_edits() {
         let db = Db::open_memory().unwrap();
         msg(&db, "#dev", "original wording", 100, "m1");
-        db.edit_message("m1", "alice!a@host", "revised phrasing", Some("m2"))
-            .unwrap();
+        edit(&db, "#dev", "revised phrasing", 200, "m2", "m1");
 
         assert!(
             db.search_messages("#dev", "original", 50, None)
@@ -2781,6 +3244,27 @@ mod tests {
         );
         let hits = db.search_messages("#dev", "revised", 50, None).unwrap();
         assert_eq!(hits.len(), 1);
+        // The hit is addressable by the id every client holds the message
+        // under — the original, not the revision's own id.
+        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+    }
+
+    /// Encrypted databases search by decrypt-and-scan rather than FTS; a
+    /// superseded revision must not surface there either.
+    #[test]
+    fn search_reflects_edits_on_encrypted_database() {
+        let db = Db::open_encrypted_memory([9u8; 32]).unwrap();
+        msg(&db, "#dev", "original wording", 100, "m1");
+        edit(&db, "#dev", "revised phrasing", 200, "m2", "m1");
+
+        assert!(
+            db.search_messages("#dev", "original", 50, None)
+                .unwrap()
+                .is_empty()
+        );
+        let hits = db.search_messages("#dev", "revised", 50, None).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
     }
 
     #[test]

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -116,6 +116,20 @@ pub struct ReactionRow {
     pub timestamp: u64,
 }
 
+/// Who wrote a message, and where it is filed — the minimum needed to
+/// authorize an operation on a message without reading its contents.
+#[derive(Debug, Clone)]
+pub struct MessageAuthorship {
+    /// The channel key the row is filed under, spelled as it was stored.
+    pub channel: String,
+    /// Full hostmask of the author, as stored.
+    pub sender: String,
+    /// Author's DID, when they were authenticated at send time.
+    pub sender_did: Option<String>,
+    /// Whether the message is already soft-deleted.
+    pub deleted: bool,
+}
+
 /// A persisted message row.
 #[derive(Debug, Clone)]
 pub struct MessageRow {
@@ -1429,6 +1443,38 @@ impl Db {
             }
             None => Ok(None),
         }
+    }
+
+    /// Who wrote the logical message `msgid` names, and where it is filed.
+    ///
+    /// Keyed on `msgid` alone, deliberately. A msgid is a globally unique ULID
+    /// and `root_of` already resolves identity without a channel, whereas a
+    /// channel name arrives from a peer spelled the way its user typed it and is
+    /// stored that way, while the in-memory channel map is keyed lowercase.
+    /// Scoping an *authorization* lookup by channel therefore made the answer
+    /// depend on that casing — a miss reads as "no such message", which is the
+    /// permissive answer. There is no casing of a ULID that finds someone
+    /// else's message.
+    ///
+    /// Resolves to the root first, so naming any revision answers for the
+    /// message. Soft-deleted rows are included: an operation on an
+    /// already-deleted message still has an author, and callers that must
+    /// refuse a deleted target need to be able to see that it is deleted.
+    pub fn message_authorship(&self, msgid: &str) -> SqlResult<Option<MessageAuthorship>> {
+        let root = self.root_of(msgid);
+        let mut stmt = self.conn.prepare(
+            "SELECT channel, sender, sender_did, deleted_at FROM messages
+             WHERE msgid = ?1 LIMIT 1",
+        )?;
+        let mut rows = stmt.query_map(params![root], |r| {
+            Ok(MessageAuthorship {
+                channel: r.get(0)?,
+                sender: r.get(1)?,
+                sender_did: r.get(2).unwrap_or(None),
+                deleted: r.get::<_, Option<i64>>(3).unwrap_or(None).is_some(),
+            })
+        })?;
+        rows.next().transpose()
     }
 
     /// The current text of the logical message `msgid` names — the newest

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -958,17 +958,18 @@ impl Db {
             }
             let before_ts = before.map(|b| b as i64).unwrap_or(i64::MAX);
             let mut stmt = self.conn.prepare(
-                // Results carry the root id: a hit on an edited message must be
-                // addressable by the identity every client holds it under.
+                // Rows come back as themselves (`msgid` = the row's own id,
+                // like every other query); the SEARCH and REST handlers
+                // re-address hits by `root_msgid` — the id clients hold the
+                // message under — when they emit.
                 //
                 // Superseded revisions are excluded, matching the
                 // decrypt-and-scan path below. An edit made since the upgrade
                 // leaves the index on its own, but rows indexed before it are
                 // still there, and returning them alongside the current one
-                // yields two hits carrying the same root id — the duplicate
-                // identity this keying exists to prevent.
+                // yields two hits for one logical message.
                 "SELECT m.id, m.channel, m.sender, m.text, m.timestamp, m.tags_json,
-                        COALESCE(m.root_msgid, m.msgid), m.replaces_msgid, m.deleted_at, m.sender_did, m.root_msgid
+                        m.msgid, m.replaces_msgid, m.deleted_at, m.sender_did, m.root_msgid
                  FROM messages_fts
                  JOIN messages m ON m.id = messages_fts.rowid
                  WHERE messages_fts MATCH ?1
@@ -1000,7 +1001,7 @@ impl Db {
         let before_ts = before.map(|b| b as i64).unwrap_or(i64::MAX);
         let mut stmt = self.conn.prepare(
             "SELECT id, channel, sender, text, timestamp, tags_json,
-                    COALESCE(root_msgid, msgid), replaces_msgid, deleted_at, sender_did, root_msgid
+                    msgid, replaces_msgid, deleted_at, sender_did, root_msgid
              FROM messages m
              WHERE channel = ?1 AND deleted_at IS NULL AND timestamp < ?2
                AND NOT EXISTS (
@@ -3344,9 +3345,10 @@ mod tests {
         );
         let hits = db.search_messages("#dev", "revised", 50, None).unwrap();
         assert_eq!(hits.len(), 1);
-        // The hit is addressable by the id every client holds the message
-        // under — the original, not the revision's own id.
-        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+        // The row comes back as itself; the root rides alongside for the
+        // handlers to address the hit by.
+        assert_eq!(hits[0].msgid.as_deref(), Some("m2"));
+        assert_eq!(hits[0].root_msgid.as_deref(), Some("m1"));
     }
 
     /// Encrypted databases search by decrypt-and-scan rather than FTS; a
@@ -3364,7 +3366,8 @@ mod tests {
         );
         let hits = db.search_messages("#dev", "revised", 50, None).unwrap();
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+        assert_eq!(hits[0].msgid.as_deref(), Some("m2"));
+        assert_eq!(hits[0].root_msgid.as_deref(), Some("m1"));
     }
 
     /// A revision indexed before the upgrade is still in the FTS table —
@@ -3412,7 +3415,8 @@ mod tests {
             hits.iter().map(|h| (&h.text, &h.msgid)).collect::<Vec<_>>()
         );
         assert_eq!(hits[0].text, "shared word revised");
-        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+        assert_eq!(hits[0].msgid.as_deref(), Some("m2"));
+        assert_eq!(hits[0].root_msgid.as_deref(), Some("m1"));
     }
 
     /// The data migration runs once and stamps the schema, instead of

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -6,12 +6,41 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use rusqlite::{Connection, OptionalExtension, Result as SqlResult, params};
+use rusqlite::{Connection, OptionalExtension, Result as SqlResult, Transaction, params};
+use rusqlite_migration::{HookResult, M, Migrations};
 
 use crate::server::{BanEntry, ChannelState, TopicInfo};
 
 /// Prefix for encrypted-at-rest message content.
 const EAR_PREFIX: &str = "EAR1:";
+
+/// The one-time migration ladder, tracked in SQLite's `PRAGMA user_version`
+/// (its application-owned version slot). Append-only: a new migration is a new
+/// entry at the end of this list. `rusqlite_migration` runs each pending entry
+/// and its version stamp inside one transaction — a crash leaves the database
+/// exactly at the previous rung, so migrations need not be idempotent — and
+/// refuses to open a database stamped newer than this list knows.
+///
+/// Slot 1 is an empty placeholder, deliberately reserved for the schema
+/// baseline: the idempotent CREATE/ALTER statements `init()` replays on every
+/// boot are meant to move here verbatim in a follow-up, making this ladder the
+/// single schema authority. Reserving the slot now keeps that refactor a
+/// content swap instead of a renumbering, which stamped databases in the wild
+/// could never tolerate. (`migrate_signing_keys_to_kid_history` predates the
+/// ladder and keeps its own shape-based guard.)
+fn migration_ladder() -> Migrations<'static> {
+    Migrations::new(vec![
+        // 1: reserved for the schema baseline — see above.
+        M::up(""),
+        // 2: a message's identity is its original msgid for life — stamp
+        //    `root_msgid` on rows that predate the column and re-file
+        //    reactions and pins under the root they annotate.
+        M::up_with_hook("", |tx: &Transaction| -> HookResult {
+            Db::backfill_root_msgids(tx)?;
+            Ok(())
+        }),
+    ])
+}
 
 /// Encrypt text with AES-256-GCM for storage at rest.
 /// Panics on encryption failure — this indicates a broken key or AES implementation
@@ -180,7 +209,7 @@ impl Db {
     /// Open (or create) the database at the given path.
     pub fn open<P: AsRef<Path>>(path: P) -> SqlResult<Self> {
         let conn = Connection::open(path)?;
-        let db = Self {
+        let mut db = Self {
             conn,
             encryption_key: None,
         };
@@ -191,7 +220,7 @@ impl Db {
     /// Open a database with encryption at rest for message content.
     pub fn open_encrypted<P: AsRef<Path>>(path: P, key: [u8; 32]) -> SqlResult<Self> {
         let conn = Connection::open(path)?;
-        let db = Self {
+        let mut db = Self {
             conn,
             encryption_key: Some(key),
         };
@@ -202,7 +231,7 @@ impl Db {
     /// Open an in-memory database (for testing).
     pub fn open_memory() -> SqlResult<Self> {
         let conn = Connection::open_in_memory()?;
-        let db = Self {
+        let mut db = Self {
             conn,
             encryption_key: None,
         };
@@ -213,7 +242,7 @@ impl Db {
     /// Open an in-memory database with encryption at rest (for testing).
     pub fn open_encrypted_memory(key: [u8; 32]) -> SqlResult<Self> {
         let conn = Connection::open_in_memory()?;
-        let db = Self {
+        let mut db = Self {
             conn,
             encryption_key: Some(key),
         };
@@ -238,7 +267,7 @@ impl Db {
             "INSERT INTO signing_keys (did, pubkey, registered_at) VALUES ('did:plc:legacy', ?1, 0)",
             params![&[7u8; 32][..]],
         )?;
-        let db = Self {
+        let mut db = Self {
             conn,
             encryption_key: None,
         };
@@ -308,11 +337,10 @@ impl Db {
     /// rows written since `root_msgid` exists are stamped at insert time, so
     /// this runs solely over rows that predate the column. Bounded — a
     /// malformed back-pointer cycle must not spin.
-    fn migration_root_of(&self, channel: &str, msgid: &str) -> SqlResult<String> {
+    fn migration_root_of(conn: &Connection, channel: &str, msgid: &str) -> SqlResult<String> {
         let mut root = msgid.to_string();
         for _ in 0..64 {
-            let mut stmt = self
-                .conn
+            let mut stmt = conn
                 .prepare("SELECT replaces_msgid FROM messages WHERE channel = ?1 AND msgid = ?2")?;
             let parent: Option<String> = stmt
                 .query_map(params![channel, &root], |r| r.get::<_, Option<String>>(0))?
@@ -343,9 +371,9 @@ impl Db {
     ///
     /// An id with no message row — an unpersisted guest-DM message — is its own
     /// root and is left untouched everywhere.
-    fn backfill_root_msgids(&self) -> SqlResult<()> {
+    fn backfill_root_msgids(conn: &Connection) -> SqlResult<()> {
         // Originals: identity is the msgid itself.
-        self.conn.execute(
+        conn.execute(
             "UPDATE messages SET root_msgid = msgid
              WHERE root_msgid IS NULL AND msgid IS NOT NULL
                AND (replaces_msgid IS NULL OR replaces_msgid = '')",
@@ -354,7 +382,7 @@ impl Db {
 
         // Edits: walk the back-pointers.
         let pending: Vec<(String, String)> = {
-            let mut stmt = self.conn.prepare(
+            let mut stmt = conn.prepare(
                 "SELECT channel, msgid FROM messages
                  WHERE root_msgid IS NULL AND msgid IS NOT NULL",
             )?;
@@ -362,15 +390,15 @@ impl Db {
                 .collect::<SqlResult<Vec<_>>>()?
         };
         for (channel, msgid) in pending {
-            let root = self.migration_root_of(&channel, &msgid)?;
-            self.conn.execute(
+            let root = Self::migration_root_of(conn, &channel, &msgid)?;
+            conn.execute(
                 "UPDATE messages SET root_msgid = ?1 WHERE channel = ?2 AND msgid = ?3",
                 params![root, channel, msgid],
             )?;
         }
 
-        self.backfill_reaction_roots()?;
-        self.backfill_pin_roots()?;
+        Self::backfill_reaction_roots(conn)?;
+        Self::backfill_pin_roots(conn)?;
         Ok(())
     }
 
@@ -379,9 +407,9 @@ impl Db {
     /// who reacted against two revisions of the same message has two rows that
     /// would collide on rewrite — the earlier row wins and the later is dropped,
     /// which is the same tally the two rows were always meant to represent.
-    fn backfill_reaction_roots(&self) -> SqlResult<()> {
+    fn backfill_reaction_roots(conn: &Connection) -> SqlResult<()> {
         let rewrites: Vec<(String, String)> = {
-            let mut stmt = self.conn.prepare(
+            let mut stmt = conn.prepare(
                 "SELECT DISTINCT r.target_msgid, m.root_msgid
                  FROM reactions r JOIN messages m ON m.msgid = r.target_msgid
                  WHERE m.root_msgid IS NOT NULL AND m.root_msgid <> r.target_msgid",
@@ -392,7 +420,7 @@ impl Db {
         for (old_id, root) in rewrites {
             // Of a colliding pair, drop the later row. The `<=` / `<` split
             // means a tie drops the revision row, never both.
-            self.conn.execute(
+            conn.execute(
                 "DELETE FROM reactions WHERE target_msgid = ?1 AND EXISTS (
                      SELECT 1 FROM reactions keep
                      WHERE keep.target_msgid = ?2
@@ -402,7 +430,7 @@ impl Db {
                  )",
                 params![old_id, root],
             )?;
-            self.conn.execute(
+            conn.execute(
                 "DELETE FROM reactions WHERE target_msgid = ?2 AND EXISTS (
                      SELECT 1 FROM reactions keep
                      WHERE keep.target_msgid = ?1
@@ -413,11 +441,11 @@ impl Db {
                 params![old_id, root],
             )?;
             // OR IGNORE + sweep: a surviving collision must not abort startup.
-            self.conn.execute(
+            conn.execute(
                 "UPDATE OR IGNORE reactions SET target_msgid = ?1 WHERE target_msgid = ?2",
                 params![root, old_id],
             )?;
-            self.conn.execute(
+            conn.execute(
                 "DELETE FROM reactions WHERE target_msgid = ?1",
                 params![old_id],
             )?;
@@ -428,9 +456,9 @@ impl Db {
     /// Re-file pins under the root of the message they pin. `pins` is
     /// `UNIQUE(channel, msgid)`; a message pinned under two revisions keeps the
     /// earliest `pinned_at` — the moment it was actually first pinned.
-    fn backfill_pin_roots(&self) -> SqlResult<()> {
+    fn backfill_pin_roots(conn: &Connection) -> SqlResult<()> {
         let rewrites: Vec<(String, String, String)> = {
-            let mut stmt = self.conn.prepare(
+            let mut stmt = conn.prepare(
                 "SELECT DISTINCT p.channel, p.msgid, m.root_msgid
                  FROM pins p JOIN messages m ON m.msgid = p.msgid
                  WHERE m.root_msgid IS NOT NULL AND m.root_msgid <> p.msgid",
@@ -439,7 +467,7 @@ impl Db {
                 .collect::<SqlResult<Vec<_>>>()?
         };
         for (channel, old_id, root) in rewrites {
-            self.conn.execute(
+            conn.execute(
                 "UPDATE pins SET pinned_at = (
                      SELECT MIN(pinned_at) FROM pins
                      WHERE channel = ?1 AND msgid IN (?2, ?3)
@@ -447,11 +475,11 @@ impl Db {
                  WHERE channel = ?1 AND msgid = ?3",
                 params![channel, old_id, root],
             )?;
-            self.conn.execute(
+            conn.execute(
                 "UPDATE OR IGNORE pins SET msgid = ?1 WHERE channel = ?2 AND msgid = ?3",
                 params![root, channel, old_id],
             )?;
-            self.conn.execute(
+            conn.execute(
                 "DELETE FROM pins WHERE channel = ?1 AND msgid = ?2",
                 params![channel, old_id],
             )?;
@@ -465,6 +493,10 @@ impl Db {
     ///
     /// This is the single definition of "the same message"; reactions, pins and
     /// deletes all file and look up by what it returns.
+    ///
+    /// Deliberately not channel-scoped: a ULID is globally unique, so the id
+    /// alone identifies the row. `migration_root_of` is channel-scoped only
+    /// because the backfill iterates per channel.
     pub fn root_of(&self, msgid: &str) -> String {
         self.conn
             .query_row(
@@ -481,7 +513,7 @@ impl Db {
             .unwrap_or_else(|| msgid.to_string())
     }
 
-    fn init(&self) -> SqlResult<()> {
+    fn init(&mut self) -> SqlResult<()> {
         self.conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         self.conn.execute_batch("PRAGMA foreign_keys=ON;")?;
         self.conn.execute_batch(
@@ -847,9 +879,18 @@ impl Db {
             ",
         )?;
 
-        // Last: it re-files `reactions` and `pins` rows, so both tables have to
-        // exist by now.
-        self.backfill_root_msgids()?;
+        // Last: the migration ladder, after every statement above, so a
+        // pending migration sees fully-shaped tables (the root_msgid backfill
+        // re-files `reactions` and `pins` rows, so both have to exist by now).
+        migration_ladder()
+            .to_latest(&mut self.conn)
+            .map_err(|e| match e {
+                rusqlite_migration::Error::RusqliteError { err, .. } => err,
+                other => rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+                    Some(other.to_string()),
+                ),
+            })?;
 
         Ok(())
     }
@@ -919,6 +960,13 @@ impl Db {
             let mut stmt = self.conn.prepare(
                 // Results carry the root id: a hit on an edited message must be
                 // addressable by the identity every client holds it under.
+                //
+                // Superseded revisions are excluded, matching the
+                // decrypt-and-scan path below. An edit made since the upgrade
+                // leaves the index on its own, but rows indexed before it are
+                // still there, and returning them alongside the current one
+                // yields two hits carrying the same root id — the duplicate
+                // identity this keying exists to prevent.
                 "SELECT m.id, m.channel, m.sender, m.text, m.timestamp, m.tags_json,
                         COALESCE(m.root_msgid, m.msgid), m.replaces_msgid, m.deleted_at, m.sender_did, m.root_msgid
                  FROM messages_fts
@@ -927,6 +975,12 @@ impl Db {
                    AND m.channel = ?2
                    AND m.deleted_at IS NULL
                    AND m.timestamp < ?3
+                   AND NOT EXISTS (
+                       SELECT 1 FROM messages newer
+                       WHERE newer.channel = m.channel
+                         AND newer.root_msgid = m.root_msgid
+                         AND newer.id > m.id
+                   )
                  ORDER BY m.timestamp DESC, m.id DESC
                  LIMIT ?4",
             )?;
@@ -2884,13 +2938,13 @@ mod tests {
         msg(&db, "#c", "unrelated", 130, "id-other");
         strip_root_ids(&db);
 
-        db.backfill_root_msgids().unwrap();
+        Db::backfill_root_msgids(&db.conn).unwrap();
 
         assert_eq!(db.root_of("id-3"), "id-1");
         assert_eq!(db.root_of("id-2"), "id-1");
         assert_eq!(db.root_of("id-other"), "id-other");
         // Re-running must not disturb what the first pass settled.
-        db.backfill_root_msgids().unwrap();
+        Db::backfill_root_msgids(&db.conn).unwrap();
         assert_eq!(db.root_of("id-3"), "id-1");
     }
 
@@ -2929,7 +2983,7 @@ mod tests {
                 .unwrap();
         }
 
-        db.backfill_root_msgids().unwrap();
+        Db::backfill_root_msgids(&db.conn).unwrap();
 
         assert_eq!(
             reaction_rows(&db, "id-1"),
@@ -2959,7 +3013,7 @@ mod tests {
             )
             .unwrap();
 
-        db.backfill_root_msgids().unwrap();
+        Db::backfill_root_msgids(&db.conn).unwrap();
 
         let pins = db.get_pins("#c").unwrap();
         assert_eq!(pins.len(), 1, "one message, one pin");
@@ -2983,7 +3037,7 @@ mod tests {
             .unwrap();
         strip_root_ids(&db);
 
-        db.backfill_root_msgids().unwrap();
+        Db::backfill_root_msgids(&db.conn).unwrap();
 
         assert_eq!(db.root_of("enc-2"), "enc-1");
         assert_eq!(reaction_rows(&db, "enc-1").len(), 1);
@@ -3311,6 +3365,115 @@ mod tests {
         let hits = db.search_messages("#dev", "revised", 50, None).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+    }
+
+    /// A revision indexed before the upgrade is still in the FTS table —
+    /// nothing rewrites existing index rows. Searching a word both revisions
+    /// share must not return the message twice, since both hits would carry
+    /// the same root id: one message, two results, which is the duplicate
+    /// identity the root keying exists to prevent.
+    #[test]
+    fn search_returns_one_hit_when_an_old_revision_is_still_indexed() {
+        let db = Db::open_memory().unwrap();
+        msg(&db, "#dev", "shared word original", 100, "m1");
+        edit(&db, "#dev", "shared word revised", 200, "m2", "m1");
+
+        // Undo the edit-time index prune to stand in for a row indexed before
+        // the upgrade, then confirm the stale revision really is searchable.
+        let old_rowid: i64 = db
+            .conn
+            .query_row(
+                "SELECT id FROM messages WHERE msgid = 'm1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT OR REPLACE INTO messages_fts (rowid, text) VALUES (?1, 'shared word original')",
+                params![old_rowid],
+            )
+            .unwrap();
+        let indexed: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts WHERE rowid = ?1",
+                params![old_rowid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(indexed, 1, "precondition: the old revision is indexed");
+
+        let hits = db.search_messages("#dev", "shared", 50, None).unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "one message, one hit: {:?}",
+            hits.iter().map(|h| (&h.text, &h.msgid)).collect::<Vec<_>>()
+        );
+        assert_eq!(hits[0].text, "shared word revised");
+        assert_eq!(hits[0].msgid.as_deref(), Some("m1"));
+    }
+
+    /// The data migration runs once and stamps the schema, instead of
+    /// re-scanning `reactions` and `pins` on every start to conclude there is
+    /// nothing to move.
+    #[test]
+    fn the_root_msgid_migration_runs_once_and_stamps_the_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("freeq.db");
+        {
+            let db = Db::open(&path).unwrap();
+            msg(&db, "#c", "v1", 100, "id-1");
+            edit(&db, "#c", "v2", 110, "id-2", "id-1");
+            assert_eq!(
+                db.conn
+                    .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                    .unwrap(),
+                2,
+                "first open stamps the schema"
+            );
+        }
+
+        // Reopening finds the stamp and skips the backfill; the identities it
+        // established are still the ones on file.
+        let db = Db::open(&path).unwrap();
+        assert_eq!(
+            db.conn
+                .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert_eq!(db.root_of("id-2"), "id-1");
+        assert_eq!(db.current_revision("id-1").unwrap().unwrap().text, "v2");
+    }
+
+    /// A database written before the stamp existed still gets migrated: the
+    /// gate is a floor, not a marker that only new databases carry.
+    #[test]
+    fn an_unstamped_database_is_migrated_on_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("freeq.db");
+        {
+            let db = Db::open(&path).unwrap();
+            msg(&db, "#c", "v1", 100, "id-1");
+            edit(&db, "#c", "v2", 110, "id-2", "id-1");
+            // Roll back to what an older build left behind: roots unstamped,
+            // schema version never set.
+            db.conn
+                .execute("UPDATE messages SET root_msgid = NULL", [])
+                .unwrap();
+            db.conn.execute_batch("PRAGMA user_version = 0").unwrap();
+        }
+
+        let db = Db::open(&path).unwrap();
+        assert_eq!(db.root_of("id-2"), "id-1", "the backfill ran on open");
+        assert_eq!(
+            db.conn
+                .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
     }
 
     #[test]

--- a/freeq-server/src/s2s.rs
+++ b/freeq-server/src/s2s.rs
@@ -271,6 +271,18 @@ pub enum S2sMessage {
         /// → older peers omit it (wire back-compat).
         #[serde(default)]
         recipient_did: Option<String>,
+        /// When this message is an edit, the identity of the message it
+        /// revises — the **root** msgid, the id that message keeps for life.
+        ///
+        /// Without it a relayed edit is indistinguishable from a new message,
+        /// so the receiving peer files a second row and shows its users a
+        /// duplicate that never links back to the original. The local wire
+        /// carries this as `+draft/edit`, which cannot ride in `tags`: that map
+        /// is filtered to `+freeq.at/*` on both send and receive. `serde(default)`
+        /// → older peers omit it and the receiver treats the message as new,
+        /// which is exactly today's behavior.
+        #[serde(default)]
+        replaces_msgid: Option<String>,
         /// Application coordination tags (`+freeq.at/event` etc.) that ride
         /// with the message so federated clients render the same card the
         /// origin shows. `serde(default)` → older peers omit it, deserialize
@@ -347,6 +359,18 @@ pub enum S2sMessage {
         /// IRCv3 tags (e.g. +react, +reply, +typing).
         tags: HashMap<String, String>,
         origin: String,
+        /// Acting user's DID — the value of the IRCv3 `account` tag, stamped by
+        /// the origin from its authenticated session, never client-set (the
+        /// same trust shape as `Privmsg.account`).
+        ///
+        /// A remote actor is not in the receiver's `nick_owners` (that map is
+        /// seeded from identities that authenticated *here*), so without this
+        /// the receiver can only identify a federated actor by nick. That is
+        /// enough for a reaction, but not for authorizing a delete — a nick is
+        /// peer-assertable. `serde(default)` → older peers omit it, and the
+        /// receiver falls back to the nick lookup exactly as before.
+        #[serde(default)]
+        account: Option<String>,
     },
 
     /// A user joined a channel.
@@ -1581,6 +1605,7 @@ mod tests {
             sig: None,
             account: None,
             recipient_did: None,
+            replaces_msgid: None,
             tags: HashMap::new(),
             multiline_lines: None,
         };
@@ -1684,6 +1709,7 @@ mod tests {
             sig: None,
             account: None,
             recipient_did: None,
+            replaces_msgid: None,
             tags: HashMap::new(),
             multiline_lines: None,
         };
@@ -1706,6 +1732,7 @@ mod tests {
                     sig: None,
                     account: None,
                     recipient_did: None,
+                    replaces_msgid: None,
                     tags: HashMap::new(),
                     multiline_lines: None,
                 };
@@ -2051,6 +2078,7 @@ mod tests {
             sig: None,
             account: None,
             recipient_did: None,
+            replaces_msgid: None,
             tags: tags.clone(),
             multiline_lines: None,
         };

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2753,6 +2753,58 @@ fn federated_delete_authorized(
     })
 }
 
+/// May a federated actor edit this message here?
+///
+/// **Author only.** Unlike a delete there is no op route: an op may remove
+/// content, but rewriting it would put the op's words under another user's name.
+/// This is the same authorship rule `handle_edit` applies to a local edit,
+/// including its refusal to edit an already-deleted message; a federated edit
+/// arrived without any check at all, so a peer could revise anyone's message.
+///
+/// That mattered more than it looks: the receiving history path revises the
+/// *existing* entry in place, leaving its `from` untouched, so an unauthorized
+/// edit rewrote the author's words under the author's name for every later
+/// joiner, and `current_revision` (what a pin renders) followed.
+///
+/// A message we hold no row for is nothing to protect — an edit of something
+/// that predates us, or in an unpersisted guest DM thread, still arrives.
+/// `channel_history_key` (lowercase, channels only) is checked in that case:
+/// with no database at all the in-memory history is the only record of who
+/// wrote a message, and it must still be honoured.
+fn federated_edit_authorized(
+    state: &Arc<SharedState>,
+    channel_history_key: Option<&str>,
+    root_msgid: &str,
+    actor_nick: &str,
+    actor_did: Option<&str>,
+) -> bool {
+    if let Some(Some(row)) = state.with_db(|db| db.message_authorship(root_msgid)) {
+        // A deleted message has no editable text; a revision of it would
+        // resurrect nothing and confuse every client's view.
+        return !row.deleted && federated_actor_is_author(&row, actor_nick, actor_did);
+    }
+
+    let Some(key) = channel_history_key else {
+        return true;
+    };
+    let channels = state.channels.lock();
+    let Some(entry) = channels.get(key).and_then(|ch| {
+        ch.history
+            .iter()
+            .find(|h| h.msgid.as_deref() == Some(root_msgid))
+    }) else {
+        return true;
+    };
+    // History carries no DID, so nick is all there is here. Weaker than the
+    // row check, and only ever reached when there is no row to do better with.
+    entry
+        .from
+        .split('!')
+        .next()
+        .unwrap_or("")
+        .eq_ignore_ascii_case(actor_nick)
+}
+
 /// Process an incoming S2S message. Exposed as pub(crate) for adversarial testing.
 pub(crate) async fn process_s2s_message(
     state: &Arc<SharedState>,
@@ -3198,6 +3250,30 @@ pub(crate) async fn process_s2s_message(
                 .filter(|r| !r.is_empty())
                 .map(|r| crate::connection::helpers::root_msgid(state, &r));
 
+            // An edit may only come from the author. Dropped rather than
+            // downgraded to a plain message: a local edit that fails the same
+            // check is not delivered either (FAIL AUTHOR_MISMATCH), and relaying
+            // it as new text would put words in the channel that the origin's
+            // user never asked to send as a new message.
+            let actor_nick = from.split('!').next().unwrap_or(&from).to_string();
+            if let Some(ref root) = edit_of {
+                let history_key = (target.starts_with('#') || target.starts_with('&'))
+                    .then(|| target.to_lowercase());
+                if !federated_edit_authorized(
+                    state,
+                    history_key.as_deref(),
+                    root,
+                    &actor_nick,
+                    account.as_deref(),
+                ) {
+                    tracing::warn!(
+                        target = %target, msgid = %root, by = %actor_nick,
+                        "S2S edit rejected: actor is not the author"
+                    );
+                    return;
+                }
+            }
+
             // Peer-provided coordination tags. Re-filter on receipt (never
             // trust the sending peer to have filtered correctly): keep only
             // `+freeq.at/*` minus `+freeq.at/sig` (re-attested locally),
@@ -3301,12 +3377,25 @@ pub(crate) async fn process_s2s_message(
                         // twice, permanently.
                         let revised = edit_of.as_ref().and_then(|root| {
                             ch.history
-                                .iter_mut()
-                                .find(|h| h.msgid.as_deref() == Some(root.as_str()))
+                                .iter()
+                                .position(|h| h.msgid.as_deref() == Some(root.as_str()))
                         });
-                        if let Some(hist) = revised {
-                            hist.text = text.clone();
-                            hist.edited = true;
+                        // Second lock on the door `federated_edit_authorized`
+                        // shut: revising leaves `from` as it was, so writing one
+                        // user's text into another's entry publishes the editor's
+                        // words under the author's name. Never do it, whatever
+                        // the gate concluded.
+                        let author_matches = revised.is_some_and(|i| {
+                            ch.history[i].from.split('!').next() == from.split('!').next()
+                        });
+                        if let (Some(i), true) = (revised, author_matches) {
+                            ch.history[i].text = text.clone();
+                            ch.history[i].edited = true;
+                        } else if revised.is_some() {
+                            tracing::warn!(
+                                channel = %target, from = %from,
+                                "S2S edit dropped: would rewrite another user's history entry"
+                            );
                         } else {
                             ch.history.push_back(HistoryMessage {
                                 from: from.clone(),
@@ -7866,7 +7955,7 @@ mod s2s_adversarial_tests {
 
     const AUTHOR_DID: &str = "did:plc:fedauthor";
 
-    /// Relay a channel message from the peer. Returns its msgid.
+    /// Relay a channel message from the peer, as alice (the author).
     async fn relay_message(
         state: &Arc<SharedState>,
         mgr: &Arc<S2sManager>,
@@ -7875,19 +7964,46 @@ mod s2s_adversarial_tests {
         text: &str,
         replaces: Option<&str>,
     ) {
+        relay_message_as(
+            state,
+            mgr,
+            channel,
+            msgid,
+            text,
+            replaces,
+            "alice!a@remote",
+            Some(AUTHOR_DID),
+        )
+        .await;
+    }
+
+    /// As `relay_message`, with the actor spelled out — the peer chooses both
+    /// the nick and the `account` DID it stamps, so a test of who may act on a
+    /// message has to be able to choose them too.
+    #[allow(clippy::too_many_arguments)]
+    async fn relay_message_as(
+        state: &Arc<SharedState>,
+        mgr: &Arc<S2sManager>,
+        channel: &str,
+        msgid: &str,
+        text: &str,
+        replaces: Option<&str>,
+        from: &str,
+        account: Option<&str>,
+    ) {
         process_s2s_message(
             state,
             mgr,
             PEER,
             S2sMessage::Privmsg {
                 event_id: format!("{PEER}:{msgid}"),
-                from: "alice!a@remote".to_string(),
+                from: from.to_string(),
                 target: channel.to_string(),
                 text: text.to_string(),
                 origin: PEER.to_string(),
                 msgid: Some(msgid.to_string()),
                 sig: None,
-                account: Some(AUTHOR_DID.to_string()),
+                account: account.map(|a| a.to_string()),
                 recipient_did: None,
                 replaces_msgid: replaces.map(|r| r.to_string()),
                 tags: HashMap::new(),
@@ -8068,6 +8184,202 @@ mod s2s_adversarial_tests {
                 .unwrap_or_default()
                 .is_empty(),
             "a revision survived a delete naming the other one"
+        );
+    }
+
+    /// An edit may only come from the author. This is the forgery the gate
+    /// exists for: the history entry is revised in place and keeps its `from`,
+    /// so an accepted stranger's edit would show every later joiner the author
+    /// saying words the author never wrote.
+    #[tokio::test]
+    async fn s2s_edit_from_a_stranger_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedforge2");
+
+        relay_message(&state, &mgr, "#fedforge2", "id-1", "alice original", None).await;
+        relay_message_as(
+            &state,
+            &mgr,
+            "#fedforge2",
+            "id-forge",
+            "I never said that",
+            Some("id-1"),
+            "mallory!m@remote",
+            Some("did:plc:mallory"),
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fedforge2"),
+            vec![(
+                Some("id-1".to_string()),
+                "alice original".to_string(),
+                false
+            )],
+            "a stranger rewrote the author's message under the author's name"
+        );
+        let current = state
+            .with_db(|db| db.current_revision("id-1"))
+            .flatten()
+            .expect("row");
+        assert_eq!(current.text, "alice original");
+        assert_eq!(current.sender, "alice!a@remote");
+    }
+
+    /// A nick alone is never evidence: the row names a DID, so an actor without
+    /// one cannot be its author no matter what nick the peer asserts.
+    #[tokio::test]
+    async fn s2s_edit_without_an_actor_did_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fednodid2");
+
+        relay_message(&state, &mgr, "#fednodid2", "id-1", "alice original", None).await;
+        relay_message_as(
+            &state,
+            &mgr,
+            "#fednodid2",
+            "id-forge",
+            "impersonated",
+            Some("id-1"),
+            "alice!a@remote",
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fednodid2"),
+            vec![(
+                Some("id-1".to_string()),
+                "alice original".to_string(),
+                false
+            )],
+            "nick-only matching would let any peer rewrite anything"
+        );
+    }
+
+    /// An op may delete content but not rewrite it — deleting removes words,
+    /// editing would put new ones in someone else's mouth. Deliberately
+    /// stricter than the delete gate.
+    #[tokio::test]
+    async fn s2s_edit_from_an_op_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedopedit");
+        add_remote_member(&state, "#fedopedit", "moderator", true);
+
+        relay_message(&state, &mgr, "#fedopedit", "id-1", "alice original", None).await;
+        relay_message_as(
+            &state,
+            &mgr,
+            "#fedopedit",
+            "id-forge",
+            "moderated for you",
+            Some("id-1"),
+            "moderator!m@remote",
+            Some("did:plc:mod"),
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fedopedit"),
+            vec![(
+                Some("id-1".to_string()),
+                "alice original".to_string(),
+                false
+            )],
+            "an op rewrote another user's words"
+        );
+    }
+
+    /// The author's own edit still lands — the gate must not cost the feature
+    /// it protects.
+    #[tokio::test]
+    async fn s2s_edit_from_the_author_is_accepted() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedauthoredit");
+
+        relay_message(&state, &mgr, "#fedauthoredit", "id-1", "v1", None).await;
+        relay_message(&state, &mgr, "#fedauthoredit", "id-2", "v2", Some("id-1")).await;
+
+        assert_eq!(
+            history_of(&state, "#fedauthoredit"),
+            vec![(Some("id-1".to_string()), "v2".to_string(), true)],
+            "the author's edit must revise the message it names"
+        );
+    }
+
+    /// A deleted message has no text to revise, matching `handle_edit`'s local
+    /// refusal — otherwise an edit re-seeds content the author asked to remove.
+    #[tokio::test]
+    async fn s2s_edit_of_a_deleted_message_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#feddeleted");
+
+        relay_message(&state, &mgr, "#feddeleted", "id-1", "gone", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "#feddeleted",
+            "id-1",
+            "alice!a@remote",
+            Some(AUTHOR_DID),
+        )
+        .await;
+        relay_message(
+            &state,
+            &mgr,
+            "#feddeleted",
+            "id-2",
+            "back again",
+            Some("id-1"),
+        )
+        .await;
+
+        assert!(
+            history_of(&state, "#feddeleted").is_empty(),
+            "an edit resurrected a deleted message"
+        );
+    }
+
+    /// With no database the in-memory history is the only record of who wrote
+    /// what, and it still has to be honoured.
+    #[tokio::test]
+    async fn s2s_edit_from_a_stranger_is_rejected_without_a_database() {
+        let state = test_state();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fednodb");
+
+        relay_message(&state, &mgr, "#fednodb", "id-1", "alice original", None).await;
+        relay_message_as(
+            &state,
+            &mgr,
+            "#fednodb",
+            "id-forge",
+            "I never said that",
+            Some("id-1"),
+            "mallory!m@remote",
+            Some("did:plc:mallory"),
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fednodb"),
+            vec![(
+                Some("id-1".to_string()),
+                "alice original".to_string(),
+                false
+            )],
+            "with no row to check, history authorship is the only defense"
         );
     }
 

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2687,6 +2687,59 @@ fn sanitize_s2s_str(s: &str, max_len: usize) -> String {
         .collect()
 }
 
+/// May a federated actor delete this message here?
+///
+/// Two ways in, mirroring what a local delete accepts:
+/// - **The author.** DID against the stored row's `sender_did`. A nick match is
+///   accepted only when the row has no DID at all (a guest's message) — for a
+///   row that names a DID, a nick is not evidence, and a peer can assert any
+///   nick it likes.
+/// - **A channel op**, via the same roster check the federated Kick/Mode path
+///   uses. Channels only: a DM has no roster, so authorship is the only route.
+///
+/// A message we hold no row for is nothing to protect — let it through so the
+/// TAGMSG still reaches clients, exactly as an unpersisted local delete does.
+fn federated_delete_authorized(
+    state: &Arc<SharedState>,
+    storage_key: &str,
+    root_msgid: &str,
+    actor_nick: &str,
+    actor_did: Option<&str>,
+    is_channel: bool,
+) -> bool {
+    let row = state.with_db(|db| db.get_message_by_msgid(storage_key, root_msgid));
+    let Some(Some(row)) = row else {
+        return true;
+    };
+
+    let is_author = match (row.sender_did.as_deref(), actor_did) {
+        (Some(row_did), Some(actor)) => row_did == actor,
+        (Some(_), None) => false,
+        (None, _) => row
+            .sender
+            .split('!')
+            .next()
+            .unwrap_or("")
+            .eq_ignore_ascii_case(actor_nick),
+    };
+    if is_author {
+        return true;
+    }
+    if !is_channel {
+        return false;
+    }
+
+    let channels = state.channels.lock();
+    channels.get(storage_key).is_some_and(|ch| {
+        ch.remote_member(actor_nick).is_some_and(|rm| {
+            rm.is_op
+                || rm.did.as_ref().is_some_and(|d| {
+                    ch.founder_did.as_deref() == Some(d) || ch.did_ops.contains(d)
+                })
+        })
+    })
+}
+
 /// Process an incoming S2S message. Exposed as pub(crate) for adversarial testing.
 pub(crate) async fn process_s2s_message(
     state: &Arc<SharedState>,
@@ -3101,6 +3154,7 @@ pub(crate) async fn process_s2s_message(
             sig,
             account,
             recipient_did: stamped_recipient_did,
+            replaces_msgid,
             tags: relayed_tags,
             multiline_lines,
             ..
@@ -3121,6 +3175,15 @@ pub(crate) async fn process_s2s_message(
 
             // Generate a local msgid if the remote didn't send one
             let msgid = msgid.unwrap_or_else(crate::msgid::generate);
+
+            // An edit names the message it revises. Resolve to our own root:
+            // the peer names the root too, but an id we've never seen is its
+            // own root, so this is also what makes an edit of a message that
+            // predates us behave sanely instead of vanishing.
+            let edit_of: Option<String> = replaces_msgid
+                .map(|r| sanitize_s2s_str(&r, 100))
+                .filter(|r| !r.is_empty())
+                .map(|r| crate::connection::helpers::root_msgid(state, &r));
 
             // Peer-provided coordination tags. Re-filter on receipt (never
             // trust the sending peer to have filtered correctly): keep only
@@ -3150,6 +3213,11 @@ pub(crate) async fn process_s2s_message(
                 let mut tags = HashMap::new();
                 tags.extend(relay_tags.iter().map(|(k, v)| (k.clone(), v.clone())));
                 tags.insert("msgid".to_string(), msgid.clone());
+                // Restore the linkage the `+freeq.at/*` tag filter drops on the
+                // wire, so our clients see an edit rather than a new message.
+                if let Some(ref root) = edit_of {
+                    tags.insert("+draft/edit".to_string(), root.clone());
+                }
                 if let Some(ref sig) = sig {
                     tags.insert("+freeq.at/sig".to_string(), sig.clone());
                 }
@@ -3213,16 +3281,34 @@ pub(crate) async fn process_s2s_message(
                     }
                     let mut channels = state.channels.lock();
                     if let Some(ch) = channels.get_mut(&channel_key) {
-                        ch.history.push_back(HistoryMessage {
-                            from: from.clone(),
-                            text: text.clone(),
-                            timestamp,
-                            tags: tags.clone(),
-                            msgid: Some(msgid.clone()),
-                            edited: false,
+                        // An edit revises the entry we already hold; only a
+                        // brand-new message gets a new one. Appending an edit
+                        // instead — which is what happened before the wire
+                        // carried the linkage — showed our users the message
+                        // twice, permanently.
+                        let revised = edit_of.as_ref().and_then(|root| {
+                            ch.history
+                                .iter_mut()
+                                .find(|h| h.msgid.as_deref() == Some(root.as_str()))
                         });
-                        while ch.history.len() > MAX_HISTORY {
-                            ch.history.pop_front();
+                        if let Some(hist) = revised {
+                            hist.text = text.clone();
+                            hist.edited = true;
+                        } else {
+                            ch.history.push_back(HistoryMessage {
+                                from: from.clone(),
+                                text: text.clone(),
+                                timestamp,
+                                tags: tags.clone(),
+                                // An edit of a message we never saw still keys
+                                // on the root — the identity everyone else
+                                // holds it under.
+                                msgid: Some(edit_of.clone().unwrap_or_else(|| msgid.clone())),
+                                edited: edit_of.is_some(),
+                            });
+                            while ch.history.len() > MAX_HISTORY {
+                                ch.history.pop_front();
+                            }
                         }
                     }
                     drop(channels);
@@ -3234,8 +3320,20 @@ pub(crate) async fn process_s2s_message(
                         .or_else(|| state.nick_owners.lock().get(sender_nick).cloned());
                     // Persist the coordination tags (incl. +freeq.at/origin) so
                     // CHATHISTORY replay carries them, like the DM persist path.
-                    state.with_db(|db| {
-                        db.insert_message(
+                    state.with_db(|db| match edit_of {
+                        // Same shape as a local edit: a new row that carries
+                        // the root, so the pair reads as one message here too.
+                        Some(ref root) => db.insert_edit(
+                            &target,
+                            &from,
+                            &text,
+                            timestamp,
+                            &relay_tags,
+                            &msgid,
+                            root,
+                            s2s_sender_did.as_deref(),
+                        ),
+                        None => db.insert_message(
                             &target,
                             &from,
                             &text,
@@ -3243,7 +3341,7 @@ pub(crate) async fn process_s2s_message(
                             &relay_tags,
                             Some(&msgid),
                             s2s_sender_did.as_deref(),
-                        )
+                        ),
                     });
                 }
 
@@ -3482,10 +3580,25 @@ pub(crate) async fn process_s2s_message(
         }
 
         S2sMessage::Tagmsg {
-            from, target, tags, ..
+            from,
+            target,
+            tags,
+            account,
+            ..
         } => {
             let from = sanitize_s2s_str(&from, 512);
             let target = sanitize_s2s_str(&target, 200);
+            // Actor DID, origin-stamped. Older peers send none, so keep the
+            // nick lookup as the fallback — it resolves for anyone who has
+            // authenticated here, which is what we relied on before.
+            let actor_nick = from.split('!').next().unwrap_or(&from).to_string();
+            let actor_did = account.map(|a| sanitize_s2s_str(&a, 512)).or_else(|| {
+                state
+                    .nick_owners
+                    .lock()
+                    .get(&actor_nick.to_lowercase())
+                    .cloned()
+            });
 
             // Normalize draft tags
             let mut tags = tags.clone();
@@ -3506,8 +3619,8 @@ pub(crate) async fn process_s2s_message(
 
             // Persist reactions
             if let (Some(emoji), Some(target_msgid)) = (tags.get("+react"), tags.get("+reply")) {
-                let nick = from.split('!').next().unwrap_or(&from).to_string();
-                let did = state.nick_owners.lock().get(&nick.to_lowercase()).cloned();
+                let nick = actor_nick.clone();
+                let did = actor_did.clone();
                 let ts = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -3527,12 +3640,52 @@ pub(crate) async fn process_s2s_message(
             if let (Some(emoji), Some(target_msgid)) =
                 (tags.get("+freeq.at/unreact"), tags.get("+reply"))
             {
-                let nick = from.split('!').next().unwrap_or(&from).to_string();
-                let did = state.nick_owners.lock().get(&nick.to_lowercase()).cloned();
+                let nick = actor_nick.clone();
+                let did = actor_did.clone();
                 let emoji = emoji.clone();
                 let target_msgid = target_msgid.clone();
                 state
                     .with_db(|db| db.remove_reaction(&target_msgid, &nick, did.as_deref(), &emoji));
+            }
+
+            // Apply a federated delete to our own state. Relaying it to live
+            // clients is not enough — without this the row survives here, so
+            // the message returns on the next join or restart.
+            if let Some(deleted_msgid) = tags.get("+draft/delete").cloned() {
+                let root = crate::connection::helpers::root_msgid(state, &deleted_msgid);
+                let is_channel = target.starts_with('#') || target.starts_with('&');
+                let storage_key = if is_channel {
+                    target.to_lowercase()
+                } else {
+                    // A DM lives under the canonical key of the two DIDs, not
+                    // the wire target.
+                    match (
+                        actor_did.as_deref(),
+                        crate::connection::routing::recipient_did_for_target(state, &target)
+                            .as_deref(),
+                    ) {
+                        (Some(a), Some(b)) => crate::db::canonical_dm_key(a, b),
+                        _ => target.clone(),
+                    }
+                };
+
+                if federated_delete_authorized(state, &storage_key, &root, &actor_nick, actor_did.as_deref(), is_channel)
+                {
+                    state.with_db(|db| db.soft_delete_message(&storage_key, &root));
+                    if is_channel {
+                        let mut channels = state.channels.lock();
+                        if let Some(ch) = channels.get_mut(&storage_key) {
+                            ch.history.retain(|h| h.msgid.as_deref() != Some(root.as_str()));
+                            ch.pins.retain(|p| p.msgid != root);
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        target = %target, msgid = %root, by = %actor_nick,
+                        "S2S delete rejected: actor is neither the author nor an op"
+                    );
+                    return;
+                }
             }
 
             // Wire forms — identical for channel and DM delivery.
@@ -5313,6 +5466,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5367,6 +5521,7 @@ mod s2s_adversarial_tests {
                     sig: None,
                     account: None,
                     recipient_did: None,
+                    replaces_msgid: None,
                     tags: HashMap::new(),
                     multiline_lines: None,
                 },
@@ -5454,6 +5609,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: Some(s2s_multiline_lines(&["first", "second", "third"])),
             },
@@ -5506,6 +5662,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5570,6 +5727,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5625,6 +5783,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5682,6 +5841,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5738,6 +5898,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -5787,6 +5948,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: Some(s2s_multiline_lines(&["first", "second"])),
             },
@@ -6027,6 +6189,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -6216,6 +6379,7 @@ mod s2s_adversarial_tests {
                     sig: None,
                     account: None,
                     recipient_did: None,
+                    replaces_msgid: None,
                     tags: HashMap::new(),
                     multiline_lines: None,
                 },
@@ -6323,6 +6487,7 @@ mod s2s_adversarial_tests {
                     sig: None,
                     account: None,
                     recipient_did: None,
+                    replaces_msgid: None,
                     tags: HashMap::new(),
                     multiline_lines: None,
                 },
@@ -6494,6 +6659,7 @@ mod s2s_adversarial_tests {
                 target: "#react-test".to_string(),
                 tags,
                 origin: PEER.to_string(),
+                account: None,
             },
         )
         .await;
@@ -6532,6 +6698,7 @@ mod s2s_adversarial_tests {
                 target: "#s2s-unreact".to_string(),
                 tags: react,
                 origin: PEER.to_string(),
+                account: None,
             },
         )
         .await;
@@ -6557,6 +6724,7 @@ mod s2s_adversarial_tests {
                 target: "#s2s-unreact".to_string(),
                 tags: unreact,
                 origin: PEER.to_string(),
+                account: None,
             },
         )
         .await;
@@ -6609,6 +6777,7 @@ mod s2s_adversarial_tests {
                 target: "#draft-test".to_string(),
                 tags,
                 origin: PEER.to_string(),
+                account: None,
             },
         )
         .await;
@@ -6660,6 +6829,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -6709,6 +6879,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -6755,6 +6926,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -6797,6 +6969,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: None,
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -6840,6 +7013,7 @@ mod s2s_adversarial_tests {
                 sig: None,
                 account: Some("did:plc:alice".to_string()),
                 recipient_did: None,
+                replaces_msgid: None,
                 tags: HashMap::new(),
                 multiline_lines: None,
             },
@@ -7643,6 +7817,348 @@ mod s2s_adversarial_tests {
             crdt.map(|(t, _)| t),
             Some("welcome to tchan".to_string()),
             "sync-adopted topic must be seeded into the CRDT"
+        );
+    }
+
+    // ── Federated edits and deletes ────────────────────────────────
+    //
+    // A message's identity is its original msgid on every server that holds
+    // it. These cover the wire carrying enough for a peer to honour that:
+    // `replaces_msgid` so an edit revises rather than duplicates, and a
+    // `+draft/delete` Tagmsg so a delete actually deletes.
+
+    const AUTHOR_DID: &str = "did:plc:fedauthor";
+
+    /// Relay a channel message from the peer. Returns its msgid.
+    async fn relay_message(
+        state: &Arc<SharedState>,
+        mgr: &Arc<S2sManager>,
+        channel: &str,
+        msgid: &str,
+        text: &str,
+        replaces: Option<&str>,
+    ) {
+        process_s2s_message(
+            state,
+            mgr,
+            PEER,
+            S2sMessage::Privmsg {
+                event_id: format!("{PEER}:{msgid}"),
+                from: "alice!a@remote".to_string(),
+                target: channel.to_string(),
+                text: text.to_string(),
+                origin: PEER.to_string(),
+                msgid: Some(msgid.to_string()),
+                sig: None,
+                account: Some(AUTHOR_DID.to_string()),
+                recipient_did: None,
+                replaces_msgid: replaces.map(|r| r.to_string()),
+                tags: HashMap::new(),
+                multiline_lines: None,
+            },
+        )
+        .await;
+    }
+
+    async fn relay_delete(
+        state: &Arc<SharedState>,
+        mgr: &Arc<S2sManager>,
+        channel: &str,
+        msgid: &str,
+        from: &str,
+        account: Option<&str>,
+    ) {
+        let mut tags = HashMap::new();
+        tags.insert("+draft/delete".to_string(), msgid.to_string());
+        process_s2s_message(
+            state,
+            mgr,
+            PEER,
+            S2sMessage::Tagmsg {
+                event_id: format!("{PEER}:del-{msgid}-{from}"),
+                from: from.to_string(),
+                target: channel.to_string(),
+                tags,
+                origin: PEER.to_string(),
+                account: account.map(|a| a.to_string()),
+            },
+        )
+        .await;
+    }
+
+    fn history_of(state: &Arc<SharedState>, channel: &str) -> Vec<(Option<String>, String, bool)> {
+        state
+            .channels
+            .lock()
+            .get(channel)
+            .map(|ch| {
+                ch.history
+                    .iter()
+                    .map(|h| (h.msgid.clone(), h.text.clone(), h.edited))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// A federated edit revises the message we already hold. Before the wire
+    /// carried the linkage the peer filed it as a new message, so every user
+    /// on this side saw the message twice — permanently, in CHATHISTORY.
+    #[tokio::test]
+    async fn s2s_edit_revises_in_place_instead_of_duplicating() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedit");
+
+        relay_message(&state, &mgr, "#fedit", "id-orig", "v1", None).await;
+        relay_message(&state, &mgr, "#fedit", "id-edit", "v2", Some("id-orig")).await;
+
+        assert_eq!(
+            history_of(&state, "#fedit"),
+            vec![(Some("id-orig".to_string()), "v2".to_string(), true)],
+            "one logical message, keyed by the id everyone holds it under, \
+             carrying the newest text and marked edited"
+        );
+        // The DB keeps both revisions, joined by the root — the same shape a
+        // local edit produces.
+        assert_eq!(state.with_db(|db| Ok(db.root_of("id-edit"))), Some("id-orig".to_string()));
+        assert_eq!(
+            state
+                .with_db(|db| db.current_revision("id-orig"))
+                .flatten()
+                .map(|r| r.text),
+            Some("v2".to_string())
+        );
+    }
+
+    /// An edit of a message this server never saw (it joined late, or the
+    /// original predates the linkage) must still show up, keyed by the root.
+    #[tokio::test]
+    async fn s2s_edit_of_an_unseen_message_still_arrives() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedunseen");
+
+        relay_message(&state, &mgr, "#fedunseen", "id-edit", "v2", Some("id-never")).await;
+
+        assert_eq!(
+            history_of(&state, "#fedunseen"),
+            vec![(Some("id-never".to_string()), "v2".to_string(), true)],
+            "an edit whose original we never saw must not vanish"
+        );
+    }
+
+    /// The local wire carries edit linkage in `+draft/edit`, which the S2S tag
+    /// filter drops — the receiver has to put it back or its own clients see a
+    /// new message.
+    #[tokio::test]
+    async fn s2s_edit_restores_the_edit_tag_for_local_clients() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedtag");
+
+        let (tx, mut rx) = mpsc::channel(16);
+        state.connections.lock().insert("s-1".to_string(), tx);
+        state.nick_to_session.lock().insert("watcher", "s-1");
+        state
+            .channels
+            .lock()
+            .get_mut("#fedtag")
+            .unwrap()
+            .members
+            .insert("s-1".to_string());
+        state.cap_message_tags.lock().insert("s-1".to_string());
+
+        relay_message(&state, &mgr, "#fedtag", "id-1", "v1", None).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        relay_message(&state, &mgr, "#fedtag", "id-2", "v2", Some("id-1")).await;
+
+        let line = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout")
+            .expect("channel closed");
+        assert!(
+            line.contains("+draft/edit=id-1"),
+            "clients must be told this revises id-1: {line}"
+        );
+    }
+
+    /// A federated delete has to reach this server's own storage. Relaying it
+    /// live is not enough — the row outlives the event, so the message returns
+    /// on the next join and after every restart.
+    #[tokio::test]
+    async fn s2s_delete_applies_to_local_storage() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#feddel");
+
+        relay_message(&state, &mgr, "#feddel", "id-1", "secret", None).await;
+        relay_delete(&state, &mgr, "#feddel", "id-1", "alice!a@remote", Some(AUTHOR_DID)).await;
+
+        assert!(
+            history_of(&state, "#feddel").is_empty(),
+            "deleted message still in memory — a joiner would be replayed it"
+        );
+        assert!(
+            state
+                .with_db(|db| db.get_messages("#feddel", 50, None))
+                .unwrap_or_default()
+                .is_empty(),
+            "deleted message still readable in history"
+        );
+    }
+
+    /// …and a delete naming the *edit* still takes the whole message, because
+    /// both ids are the same message.
+    #[tokio::test]
+    async fn s2s_delete_by_the_edit_id_removes_every_revision() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#feddel2");
+
+        relay_message(&state, &mgr, "#feddel2", "id-1", "v1", None).await;
+        relay_message(&state, &mgr, "#feddel2", "id-2", "v2", Some("id-1")).await;
+        relay_delete(&state, &mgr, "#feddel2", "id-2", "alice!a@remote", Some(AUTHOR_DID)).await;
+
+        assert!(history_of(&state, "#feddel2").is_empty());
+        assert!(
+            state
+                .with_db(|db| db.get_messages("#feddel2", 50, None))
+                .unwrap_or_default()
+                .is_empty(),
+            "a revision survived a delete naming the other one"
+        );
+    }
+
+    /// A nick is peer-assertable, so a stranger's delete must not land.
+    #[tokio::test]
+    async fn s2s_delete_from_a_stranger_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedforge");
+
+        relay_message(&state, &mgr, "#fedforge", "id-1", "keep me", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "#fedforge",
+            "id-1",
+            "mallory!m@remote",
+            Some("did:plc:mallory"),
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fedforge").len(),
+            1,
+            "a non-author non-op deleted someone else's message"
+        );
+    }
+
+    /// The row names a DID, so an actor who can't produce one is not the
+    /// author — no matter what nick the peer asserts.
+    #[tokio::test]
+    async fn s2s_delete_without_an_actor_did_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fednodid");
+
+        relay_message(&state, &mgr, "#fednodid", "id-1", "keep me", None).await;
+        // Same nick as the author, no DID — the shape an old peer sends.
+        relay_delete(&state, &mgr, "#fednodid", "id-1", "alice!a@remote", None).await;
+
+        assert_eq!(
+            history_of(&state, "#fednodid").len(),
+            1,
+            "nick-only matching would make any peer able to delete anything"
+        );
+    }
+
+    /// Ops moderate across the federation, the same way Kick and Mode do.
+    #[tokio::test]
+    async fn s2s_delete_from_a_remote_op_is_accepted() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedop");
+        add_remote_member(&state, "#fedop", "moderator", true);
+
+        relay_message(&state, &mgr, "#fedop", "id-1", "spam", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "#fedop",
+            "id-1",
+            "moderator!m@remote",
+            Some("did:plc:mod"),
+        )
+        .await;
+
+        assert!(
+            history_of(&state, "#fedop").is_empty(),
+            "a federated op must be able to delete in the channel they moderate"
+        );
+    }
+
+    /// The stamped actor DID is what makes a remote user's reaction removable
+    /// by identity rather than by nick.
+    #[tokio::test]
+    async fn s2s_reaction_records_the_stamped_actor_did() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedreact");
+
+        let mut tags = HashMap::new();
+        tags.insert("+react".to_string(), "🔥".to_string());
+        tags.insert("+reply".to_string(), "id-1".to_string());
+        process_s2s_message(
+            &state,
+            &mgr,
+            PEER,
+            S2sMessage::Tagmsg {
+                event_id: format!("{PEER}:react-did"),
+                from: "alice!a@remote".to_string(),
+                target: "#fedreact".to_string(),
+                tags,
+                origin: PEER.to_string(),
+                account: Some(AUTHOR_DID.to_string()),
+            },
+        )
+        .await;
+
+        let stored = state
+            .with_db(|db| db.get_reactions_for_messages(&["id-1"]))
+            .expect("db present");
+        assert_eq!(
+            stored.get("id-1").and_then(|v| v.first()).and_then(|r| r.reactor_did.clone()),
+            Some(AUTHOR_DID.to_string()),
+            "a remote reactor with no local identity was stored nick-only"
+        );
+    }
+
+    /// An older peer sends neither field. Both must degrade to exactly what
+    /// happened before they existed.
+    #[tokio::test]
+    async fn old_peer_without_the_new_fields_behaves_as_before() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedold");
+
+        // No replaces_msgid → a new message, appended, not a revision.
+        relay_message(&state, &mgr, "#fedold", "id-1", "v1", None).await;
+        relay_message(&state, &mgr, "#fedold", "id-2", "v2", None).await;
+        assert_eq!(
+            history_of(&state, "#fedold").len(),
+            2,
+            "two unlinked messages must stay two messages"
         );
     }
 }

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -364,8 +364,13 @@ pub struct HistoryMessage {
     pub timestamp: u64,
     /// IRCv3 tags from the original message (for rich media replay).
     pub tags: HashMap<String, String>,
-    /// ULID message ID (IRCv3 `msgid` tag).
+    /// ULID message ID (IRCv3 `msgid` tag). Stays the *original* id across
+    /// edits — a message's identity for life.
     pub msgid: Option<String>,
+    /// The text has been edited since it was sent. Join replay carries one
+    /// entry per logical message, so this is the only thing that tells a late
+    /// joiner the version they're reading isn't the original.
+    pub edited: bool,
 }
 
 /// Maximum number of history messages to keep per channel.
@@ -1476,17 +1481,44 @@ impl Server {
                 let messages = db
                     .get_messages(name, crate::server::MAX_HISTORY, None)
                     .map_err(|e| anyhow::anyhow!("Failed to load messages for {name}: {e}"))?;
+                // An edit is a separate row, so a revised message comes back as
+                // several rows. In-memory history holds one entry per logical
+                // message, keyed by its root id and carrying the newest text —
+                // otherwise every restart turns an edited message into two
+                // entries in the next joiner's replay.
+                let mut by_root: HashMap<String, usize> = HashMap::new();
                 for msg in messages {
                     let mut tags = msg.tags;
                     if let Some(ref did) = msg.sender_did {
                         tags.insert("account".to_string(), did.clone());
+                    }
+                    // Replay presents the collapsed entry as the message
+                    // itself, not as an edit of something the joiner never saw.
+                    tags.remove("+draft/edit");
+                    let root = msg.root_msgid.clone().or_else(|| msg.msgid.clone());
+                    // Newest text under the entry the message already has —
+                    // the same in-place swap the live edit path makes, so a
+                    // restart reproduces the state it left.
+                    if let Some(ref root) = root
+                        && let Some(&idx) = by_root.get(root)
+                        && let Some(existing) = ch.history.get_mut(idx)
+                    {
+                        existing.text = msg.text;
+                        existing.edited = true;
+                        continue;
+                    }
+                    if let Some(ref root) = root {
+                        by_root.insert(root.clone(), ch.history.len());
                     }
                     ch.history.push_back(HistoryMessage {
                         from: msg.sender,
                         text: msg.text,
                         timestamp: msg.timestamp,
                         tags,
-                        msgid: msg.msgid,
+                        // Identity is the root; a revision row's own id is
+                        // audit trail, never the key clients hold.
+                        msgid: root,
+                        edited: msg.replaces_msgid.is_some(),
                     });
                 }
             }
@@ -3187,6 +3219,7 @@ pub(crate) async fn process_s2s_message(
                             timestamp,
                             tags: tags.clone(),
                             msgid: Some(msgid.clone()),
+                            edited: false,
                         });
                         while ch.history.len() > MAX_HISTORY {
                             ch.history.pop_front();
@@ -3389,7 +3422,9 @@ pub(crate) async fn process_s2s_message(
             ..
         } => {
             let channel = sanitize_s2s_str(&channel, 200).to_lowercase();
-            let msgid = sanitize_s2s_str(&msgid, 100);
+            // The peer may name a revision we know under its root.
+            let msgid =
+                crate::connection::helpers::root_msgid(state, &sanitize_s2s_str(&msgid, 100));
             let pinned_by = sanitize_s2s_str(&pinned_by, 64);
 
             let mut channels = state.channels.lock();
@@ -3458,6 +3493,15 @@ pub(crate) async fn process_s2s_message(
                 if let Some(v) = tags.remove(draft) {
                     tags.entry(canonical.to_string()).or_insert(v);
                 }
+            }
+            // …and the message being acted on to its root, so a peer naming a
+            // revision still files and fans out under the one identity our
+            // clients hold the message under.
+            if (tags.contains_key("+react") || tags.contains_key("+freeq.at/unreact"))
+                && let Some(target_msgid) = tags.get("+reply")
+            {
+                let root = crate::connection::helpers::root_msgid(state, target_msgid);
+                tags.insert("+reply".to_string(), root);
             }
 
             // Persist reactions

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -3497,8 +3497,21 @@ pub(crate) async fn process_s2s_message(
                     if let Some(ref acct) = account {
                         tags.insert("account".to_string(), acct.clone());
                     }
-                    state.with_db(|db| {
-                        db.insert_message(
+                    // A DM edit is a revision of a row we already hold, keyed
+                    // by the root — same as the channel path. Storing it as a
+                    // new message would leave the thread showing both versions.
+                    state.with_db(|db| match edit_of {
+                        Some(ref root) => db.insert_edit(
+                            &dm_key,
+                            &from,
+                            &text,
+                            timestamp,
+                            &tags,
+                            &msgid,
+                            root,
+                            sender_did.as_deref(),
+                        ),
+                        None => db.insert_message(
                             &dm_key,
                             &from,
                             &text,
@@ -3506,7 +3519,7 @@ pub(crate) async fn process_s2s_message(
                             &tags,
                             Some(&msgid),
                             sender_did.as_deref(),
-                        )
+                        ),
                     });
                 }
             }
@@ -6026,7 +6039,7 @@ mod s2s_adversarial_tests {
         // way to split it back into BATCH-wrappable chunks. Now the
         // breakdown rides along on the relayed Privmsg event.
         use crate::connection::draft_multiline::BatchLine;
-        use crate::connection::routing::{RouteResult, relay_to_nick};
+        use crate::connection::routing::{RelayIdentity, RouteResult, relay_to_nick};
 
         let state = test_state();
         let (mgr, mut broadcast_rx) = test_manager_with_broadcast_rx();
@@ -6056,11 +6069,11 @@ mod s2s_adversarial_tests {
         let outcome = relay_to_nick(
             &state,
             "sender!u@h",
-            None,
             "ghost",
             "chunk one\nchunk twotail",
             "evt-1".to_string(),
             Some(&lines),
+            RelayIdentity::default(),
         );
         assert!(matches!(outcome, RouteResult::Relayed));
 
@@ -6109,7 +6122,7 @@ mod s2s_adversarial_tests {
         // PRIVMSG path) must still relay with multiline_lines = None
         // so peer servers go through their existing single-PRIVMSG
         // broadcast (no synthetic chunking).
-        use crate::connection::routing::{RouteResult, relay_to_nick};
+        use crate::connection::routing::{RelayIdentity, RouteResult, relay_to_nick};
 
         let state = test_state();
         let (mgr, mut broadcast_rx) = test_manager_with_broadcast_rx();
@@ -6118,11 +6131,11 @@ mod s2s_adversarial_tests {
         let outcome = relay_to_nick(
             &state,
             "sender!u@h",
-            None,
             "ghost",
             "ordinary text",
             "evt-2".to_string(),
             None,
+            RelayIdentity::default(),
         );
         assert!(matches!(outcome, RouteResult::Relayed));
 
@@ -8140,6 +8153,133 @@ mod s2s_adversarial_tests {
             stored.get("id-1").and_then(|v| v.first()).and_then(|r| r.reactor_did.clone()),
             Some(AUTHOR_DID.to_string()),
             "a remote reactor with no local identity was stored nick-only"
+        );
+    }
+
+    /// Relay a DM from the peer, addressed to a local nick.
+    async fn relay_dm(
+        state: &Arc<SharedState>,
+        mgr: &Arc<S2sManager>,
+        to_nick: &str,
+        msgid: &str,
+        text: &str,
+        replaces: Option<&str>,
+    ) {
+        process_s2s_message(
+            state,
+            mgr,
+            PEER,
+            S2sMessage::Privmsg {
+                event_id: format!("{PEER}:dm-{msgid}"),
+                from: "alice!a@remote".to_string(),
+                target: to_nick.to_string(),
+                text: text.to_string(),
+                origin: PEER.to_string(),
+                msgid: Some(msgid.to_string()),
+                sig: None,
+                account: Some(AUTHOR_DID.to_string()),
+                recipient_did: None,
+                replaces_msgid: replaces.map(|r| r.to_string()),
+                tags: HashMap::new(),
+                multiline_lines: None,
+            },
+        )
+        .await;
+    }
+
+    /// Bind a local nick to a DID so a DM addressed to it resolves a recipient
+    /// and therefore persists.
+    fn bind_local_nick(state: &Arc<SharedState>, nick: &str, did: &str) -> String {
+        state
+            .nick_owners
+            .lock()
+            .insert(nick.to_string(), did.to_string());
+        crate::db::canonical_dm_key(AUTHOR_DID, did)
+    }
+
+    fn live_dm_texts(state: &Arc<SharedState>, dm_key: &str) -> Vec<String> {
+        state
+            .with_db(|db| db.get_messages(dm_key, 50, None))
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| r.text)
+            .collect()
+    }
+
+    /// A DM edit crossing the hop revises the thread rather than adding to it.
+    #[tokio::test]
+    async fn s2s_dm_edit_revises_the_thread() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        let dm_key = bind_local_nick(&state, "bob", "did:plc:bobdm");
+
+        relay_dm(&state, &mgr, "bob", "dm-1", "v1", None).await;
+        relay_dm(&state, &mgr, "bob", "dm-2", "v2", Some("dm-1")).await;
+
+        // Both revisions are on file, joined by the root — one logical message
+        // in two rows, not a message plus an unlinked stranger.
+        assert_eq!(
+            live_dm_texts(&state, &dm_key),
+            vec!["v1".to_string(), "v2".to_string()]
+        );
+        assert_eq!(
+            state.with_db(|db| Ok(db.root_of("dm-2"))),
+            Some("dm-1".to_string())
+        );
+        assert_eq!(
+            state
+                .with_db(|db| db.current_revision("dm-1"))
+                .flatten()
+                .map(|r| r.text),
+            Some("v2".to_string())
+        );
+    }
+
+    /// A DM delete has to reach the recipient's server, or the message stays
+    /// in their history forever.
+    #[tokio::test]
+    async fn s2s_dm_delete_applies_to_local_storage() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        let dm_key = bind_local_nick(&state, "bob", "did:plc:bobdel");
+
+        relay_dm(&state, &mgr, "bob", "dm-1", "regrettable", None).await;
+        assert_eq!(live_dm_texts(&state, &dm_key).len(), 1, "dm persisted");
+
+        relay_delete(&state, &mgr, "bob", "dm-1", "alice!a@remote", Some(AUTHOR_DID)).await;
+
+        assert!(
+            live_dm_texts(&state, &dm_key).is_empty(),
+            "the federated DM delete never reached storage"
+        );
+    }
+
+    /// A DM has no roster to appeal to, so authorship is the only way in —
+    /// and a persisted DM row always names its sender's DID.
+    #[tokio::test]
+    async fn s2s_dm_delete_from_a_stranger_is_rejected() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        let dm_key = bind_local_nick(&state, "bob", "did:plc:bobkeep");
+
+        relay_dm(&state, &mgr, "bob", "dm-1", "keep me", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "bob",
+            "dm-1",
+            "alice!a@remote",
+            Some("did:plc:someoneelse"),
+        )
+        .await;
+
+        assert_eq!(
+            live_dm_texts(&state, &dm_key).len(),
+            1,
+            "someone who is not the author deleted a DM"
         );
     }
 

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2687,32 +2687,17 @@ fn sanitize_s2s_str(s: &str, max_len: usize) -> String {
         .collect()
 }
 
-/// May a federated actor delete this message here?
+/// Is a federated actor the author of the message this row records?
 ///
-/// Two ways in, mirroring what a local delete accepts:
-/// - **The author.** DID against the stored row's `sender_did`. A nick match is
-///   accepted only when the row has no DID at all (a guest's message) — for a
-///   row that names a DID, a nick is not evidence, and a peer can assert any
-///   nick it likes.
-/// - **A channel op**, via the same roster check the federated Kick/Mode path
-///   uses. Channels only: a DM has no roster, so authorship is the only route.
-///
-/// A message we hold no row for is nothing to protect — let it through so the
-/// TAGMSG still reaches clients, exactly as an unpersisted local delete does.
-fn federated_delete_authorized(
-    state: &Arc<SharedState>,
-    storage_key: &str,
-    root_msgid: &str,
+/// DID against the stored row's `sender_did`. A nick match is accepted only when
+/// the row has no DID at all (a guest's message) — for a row that names a DID, a
+/// nick is not evidence, and a peer can assert any nick it likes.
+fn federated_actor_is_author(
+    row: &crate::db::MessageAuthorship,
     actor_nick: &str,
     actor_did: Option<&str>,
-    is_channel: bool,
 ) -> bool {
-    let row = state.with_db(|db| db.get_message_by_msgid(storage_key, root_msgid));
-    let Some(Some(row)) = row else {
-        return true;
-    };
-
-    let is_author = match (row.sender_did.as_deref(), actor_did) {
+    match (row.sender_did.as_deref(), actor_did) {
         (Some(row_did), Some(actor)) => row_did == actor,
         (Some(_), None) => false,
         (None, _) => row
@@ -2721,8 +2706,36 @@ fn federated_delete_authorized(
             .next()
             .unwrap_or("")
             .eq_ignore_ascii_case(actor_nick),
+    }
+}
+
+/// May a federated actor delete this message here?
+///
+/// Two ways in, mirroring what a local delete accepts:
+/// - **The author**, per [`federated_actor_is_author`].
+/// - **A channel op**, via the same roster check the federated Kick/Mode path
+///   uses. Channels only: a DM has no roster, so authorship is the only route.
+///
+/// A message we hold no row for is nothing to protect — let it through so the
+/// TAGMSG still reaches clients, exactly as an unpersisted local delete does.
+///
+/// `roster_key` is the lowercase in-memory channel key (the roster map is keyed
+/// that way); the authorship lookup takes no channel at all, so this gate can't
+/// be defeated by the casing a peer happens to send.
+fn federated_delete_authorized(
+    state: &Arc<SharedState>,
+    roster_key: &str,
+    root_msgid: &str,
+    actor_nick: &str,
+    actor_did: Option<&str>,
+    is_channel: bool,
+) -> bool {
+    let row = state.with_db(|db| db.message_authorship(root_msgid));
+    let Some(Some(row)) = row else {
+        return true;
     };
-    if is_author {
+
+    if federated_actor_is_author(&row, actor_nick, actor_did) {
         return true;
     }
     if !is_channel {
@@ -2730,7 +2743,7 @@ fn federated_delete_authorized(
     }
 
     let channels = state.channels.lock();
-    channels.get(storage_key).is_some_and(|ch| {
+    channels.get(roster_key).is_some_and(|ch| {
         ch.remote_member(actor_nick).is_some_and(|rm| {
             rm.is_op
                 || rm.did.as_ref().is_some_and(|d| {
@@ -3684,7 +3697,18 @@ pub(crate) async fn process_s2s_message(
 
                 if federated_delete_authorized(state, &storage_key, &root, &actor_nick, actor_did.as_deref(), is_channel)
                 {
-                    state.with_db(|db| db.soft_delete_message(&storage_key, &root));
+                    // Sweep under the key the row is actually filed beneath. A
+                    // peer sends the channel spelled the way its user typed it
+                    // and that spelling is what got stored, while `storage_key`
+                    // is lowercased for the in-memory map — so a mixed-case
+                    // channel had its history entry dropped here while the row
+                    // survived in the database, and came back on restart.
+                    let db_key = state
+                        .with_db(|db| db.message_authorship(&root))
+                        .flatten()
+                        .map(|a| a.channel)
+                        .unwrap_or_else(|| storage_key.clone());
+                    state.with_db(|db| db.soft_delete_message(&db_key, &root));
                     if is_channel {
                         let mut channels = state.channels.lock();
                         if let Some(ch) = channels.get_mut(&storage_key) {
@@ -8044,6 +8068,64 @@ mod s2s_adversarial_tests {
                 .unwrap_or_default()
                 .is_empty(),
             "a revision survived a delete naming the other one"
+        );
+    }
+
+    /// A peer sends a channel spelled the way its user typed it. Authorization
+    /// must not depend on that casing: scoping the lookup by channel turned a
+    /// miss into "no such message", which is the permissive answer.
+    #[tokio::test]
+    async fn s2s_delete_gate_holds_for_a_mixed_case_channel() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedcase");
+
+        relay_message(&state, &mgr, "#FedCase", "id-1", "keep me", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "#FedCase",
+            "id-1",
+            "stranger!s@remote",
+            Some("did:plc:stranger"),
+        )
+        .await;
+
+        assert_eq!(
+            history_of(&state, "#fedcase").len(),
+            1,
+            "a stranger dropped the message from the live view of a mixed-case channel"
+        );
+    }
+
+    /// …and the author's delete reaches storage there, instead of clearing the
+    /// live view while leaving the row to come back on the next restart.
+    #[tokio::test]
+    async fn s2s_delete_in_a_mixed_case_channel_reaches_storage() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#fedcase2");
+
+        relay_message(&state, &mgr, "#FedCase2", "id-1", "secret", None).await;
+        relay_delete(
+            &state,
+            &mgr,
+            "#FedCase2",
+            "id-1",
+            "alice!a@remote",
+            Some(AUTHOR_DID),
+        )
+        .await;
+
+        assert!(history_of(&state, "#fedcase2").is_empty());
+        assert!(
+            state
+                .with_db(|db| db.get_messages("#FedCase2", 50, None))
+                .unwrap_or_default()
+                .is_empty(),
+            "the row survived the delete and would return on restart"
         );
     }
 

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -1279,6 +1279,7 @@ async fn api_verify_message(
             timestamp: row.timestamp,
             tags: row.tags,
             msgid: row.msgid,
+            edited: row.replaces_msgid.is_some(),
         });
         found_channel = row.channel;
     }
@@ -1980,8 +1981,10 @@ async fn api_channel_pins(
             })
         }
         .or_else(|| {
+            // The pin names the message, not a revision of it: quote the text
+            // the author last wrote, not whichever row carries the pinned id.
             state
-                .with_db(|db| db.find_message_by_msgid(&p.msgid))
+                .with_db(|db| db.current_revision(&p.msgid))
                 .flatten()
                 .map(|row| (row.sender, row.text, row.timestamp))
         })
@@ -4746,6 +4749,7 @@ mod export_tests {
             tags: HashMap::new(),
             msgid: Some(msgid.into()),
             replaces_msgid: None,
+            root_msgid: Some(msgid.into()),
             deleted_at: None,
             sender_did: None,
         }

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -1924,7 +1924,9 @@ async fn api_search(
                 sender: r.sender,
                 text: r.text,
                 timestamp: r.timestamp,
-                msgid: r.msgid,
+                // A hit is addressed by its root — the id clients hold the
+                // message under — not the matching revision's own id.
+                msgid: r.root_msgid.or(r.msgid),
                 tags: r.tags,
             })
             .collect(),

--- a/freeq-server/tests/edit_delete_adversarial.rs
+++ b/freeq-server/tests/edit_delete_adversarial.rs
@@ -1091,3 +1091,479 @@ async fn multi_line_edit_delivers_line1_only_to_non_multiline_receiver() {
     })
     .await;
 }
+
+// ═══════════════════════════════════════════════════════════════
+// MESSAGE IDENTITY ACROSS REVISIONS
+//
+// A message's identity is its original msgid, for life. An edit changes
+// content, never identity: it still travels as a new wire id carrying
+// `+draft/edit=<original>`, but everything the server files and looks up —
+// reactions, pins, deletes, in-memory history — keys on the original.
+//
+// The tests below name operations by BOTH ids on purpose. Clients differ in
+// which one they hold (older builds re-keyed to the newest revision), and a
+// federated peer may relay either, so both must land on the same message.
+// ═══════════════════════════════════════════════════════════════
+
+impl C {
+    fn send_react(&mut self, target: &str, msgid: &str, emoji: &str) {
+        self.tx(&format!("@+react={emoji};+reply={msgid} TAGMSG {target}"));
+    }
+    fn send_unreact(&mut self, target: &str, msgid: &str, emoji: &str) {
+        self.tx(&format!(
+            "@+freeq.at/unreact={emoji};+reply={msgid} TAGMSG {target}"
+        ));
+    }
+    /// Send a message and an edit of it; returns (original id, edit's own id).
+    fn say_then_edit(
+        &mut self,
+        watcher: &mut C,
+        target: &str,
+        v1: &str,
+        v2: &str,
+    ) -> (String, String) {
+        self.tx(&format!("PRIVMSG {target} :{v1}"));
+        let first = watcher.rx(|l| l.contains("PRIVMSG") && l.contains(v1), "v1");
+        let original = C::extract_msgid(&first);
+        self.send_edit(target, &original, v2);
+        let edit = watcher.rx(|l| l.contains("PRIVMSG") && l.contains(v2), "v2");
+        let edit_id = C::extract_msgid(&edit);
+        assert_ne!(original, edit_id, "an edit travels under its own wire id");
+        assert!(
+            edit.contains(&format!("+draft/edit={original}")),
+            "the edit must point at the identity clients hold: {edit}"
+        );
+        (original, edit_id)
+    }
+}
+
+/// Join fresh and return the replayed line for `text`, or None.
+fn replayed_line(addr: SocketAddr, nick: &str, channel: &str, text: &str) -> Option<String> {
+    let mut joiner = C::with_caps(addr, nick);
+    joiner.reg();
+    joiner.drain();
+    joiner.tx(&format!("JOIN {channel}"));
+    joiner.maybe(|l| l.contains("PRIVMSG") && l.contains(text), 1500)
+}
+
+/// React on one revision, un-react on the other: both name the same message,
+/// so the reaction must be gone. A joiner's replay is the honest view — it
+/// reads what the server stored, not what a live client happened to render.
+#[tokio::test]
+async fn unreacting_by_the_original_clears_a_reaction_made_on_the_edit() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "rid_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "rid_b");
+        bob.reg();
+        bob.drain();
+        alice.tx("JOIN #rid1");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #rid1");
+        bob.num("366");
+        bob.drain();
+
+        let (original, edit_id) = alice.say_then_edit(&mut bob, "#rid1", "v1", "v2");
+
+        bob.send_react("#rid1", &edit_id, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+        let with_reaction =
+            replayed_line(addr, "rid_c", "#rid1", "v2").expect("joiner replays the edited message");
+        assert!(
+            with_reaction.contains("+freeq.at/reactions=🔥:rid_b"),
+            "a reaction filed against the edit id must ride the replayed \
+             message, which is keyed by the original: {with_reaction}"
+        );
+
+        bob.send_unreact("#rid1", &original, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+        let after = replayed_line(addr, "rid_d", "#rid1", "v2").expect("still replayed");
+        assert!(
+            !after.contains("+freeq.at/reactions"),
+            "un-reacting by the original id left the reaction behind: {after}"
+        );
+    })
+    .await;
+}
+
+/// …and the same in the other order: reacted before the edit, cleared by the
+/// edit's id afterwards.
+#[tokio::test]
+async fn unreacting_by_the_edit_id_clears_a_reaction_made_on_the_original() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "rid2_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "rid2_b");
+        bob.reg();
+        bob.drain();
+        alice.tx("JOIN #rid2");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #rid2");
+        bob.num("366");
+        bob.drain();
+
+        alice.tx("PRIVMSG #rid2 :v1");
+        let first = bob.rx(|l| l.contains("PRIVMSG") && l.contains("v1"), "v1");
+        let original = C::extract_msgid(&first);
+
+        bob.send_react("#rid2", &original, "🔥");
+        std::thread::sleep(Duration::from_millis(200));
+
+        alice.send_edit("#rid2", &original, "v2");
+        let edit = bob.rx(|l| l.contains("PRIVMSG") && l.contains("v2"), "v2");
+        let edit_id = C::extract_msgid(&edit);
+
+        bob.send_unreact("#rid2", &edit_id, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+
+        let after = replayed_line(addr, "rid2_c", "#rid2", "v2").expect("still replayed");
+        assert!(
+            !after.contains("+freeq.at/reactions"),
+            "un-reacting by the edit id left the reaction behind: {after}"
+        );
+    })
+    .await;
+}
+
+/// One person, one reaction — even when their two clients name two different
+/// revisions of the message.
+#[tokio::test]
+async fn two_ids_never_split_a_reaction_tally() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "tal_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "tal_b");
+        bob.reg();
+        bob.drain();
+        alice.tx("JOIN #tally");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #tally");
+        bob.num("366");
+        bob.drain();
+
+        let (original, edit_id) = alice.say_then_edit(&mut bob, "#tally", "v1", "v2");
+        bob.send_react("#tally", &original, "🔥");
+        bob.send_react("#tally", &edit_id, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+
+        let line = replayed_line(addr, "tal_c", "#tally", "v2").expect("replayed");
+        // Tag order is not stable, so the tally may be the first tag and carry
+        // the leading `@`.
+        let tally = line
+            .split(';')
+            .map(|t| t.trim_start_matches('@'))
+            .find(|t| t.starts_with("+freeq.at/reactions="))
+            .expect("reaction tally present");
+        assert_eq!(
+            tally.matches("tal_b").count(),
+            1,
+            "the same person reacting once must not be counted twice: {tally}"
+        );
+    })
+    .await;
+}
+
+/// A delete naming the edit's id must take the message with it — including out
+/// of the in-memory history a later joiner is replayed from.
+#[tokio::test]
+async fn deleting_by_the_edit_id_does_not_resurrect_for_a_joiner() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "del_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "del_b");
+        bob.reg();
+        bob.drain();
+        alice.tx("JOIN #delrid");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #delrid");
+        bob.num("366");
+        bob.drain();
+
+        let (_original, edit_id) =
+            alice.say_then_edit(&mut bob, "#delrid", "secret v1", "secret v2");
+        alice.send_delete("#delrid", &edit_id);
+        bob.rx(
+            |l| l.contains("TAGMSG") && l.contains("draft/delete"),
+            "delete",
+        );
+        std::thread::sleep(Duration::from_millis(300));
+
+        assert!(
+            replayed_line(addr, "del_c", "#delrid", "secret v2").is_none(),
+            "the deleted message came back for a joiner"
+        );
+        assert!(
+            replayed_line(addr, "del_d", "#delrid", "secret v1").is_none(),
+            "the pre-edit text came back for a joiner"
+        );
+    })
+    .await;
+}
+
+/// Join replay collapses revisions into one message, so nothing in the wire
+/// form says it was ever edited — hence the marker.
+#[tokio::test]
+async fn join_replay_marks_an_edited_message() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "mrk_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "mrk_b");
+        bob.reg();
+        bob.drain();
+        alice.tx("JOIN #marked");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #marked");
+        bob.num("366");
+        bob.drain();
+
+        alice.tx("PRIVMSG #marked :untouched");
+        bob.rx(|l| l.contains("untouched"), "plain message");
+        alice.say_then_edit(&mut bob, "#marked", "v1", "v2");
+        std::thread::sleep(Duration::from_millis(200));
+
+        let edited = replayed_line(addr, "mrk_c", "#marked", "v2").expect("replayed");
+        assert!(
+            edited.contains("+freeq.at/edited=1"),
+            "a late joiner can't tell this text isn't what was sent: {edited}"
+        );
+        let plain = replayed_line(addr, "mrk_d", "#marked", "untouched").expect("replayed");
+        assert!(
+            !plain.contains("+freeq.at/edited"),
+            "an unedited message must not be marked: {plain}"
+        );
+    })
+    .await;
+}
+
+/// Pinning before an edit and after it is one pin, and either id unpins it.
+#[tokio::test]
+async fn a_pin_follows_the_message_across_an_edit() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "pin_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "pin_b");
+        bob.reg();
+        bob.drain();
+        // Alice creates the channel, so she is op and may pin.
+        alice.tx("JOIN #pinrid");
+        alice.num("366");
+        alice.drain();
+        bob.tx("JOIN #pinrid");
+        bob.num("366");
+        bob.drain();
+
+        let (original, edit_id) = alice.say_then_edit(&mut bob, "#pinrid", "v1", "v2");
+        alice.tx(&format!("PIN #pinrid {original}"));
+        alice.drain();
+        alice.tx(&format!("PIN #pinrid {edit_id}"));
+        std::thread::sleep(Duration::from_millis(200));
+
+        alice.drain();
+        alice.tx("PINS #pinrid");
+        let mut pins = Vec::new();
+        while let Some(l) = alice.maybe(|l| l.contains("PIN #pinrid"), 800) {
+            pins.push(l);
+        }
+        assert_eq!(pins.len(), 1, "one message must not pin twice: {pins:?}");
+        assert!(
+            pins[0].contains(&original),
+            "the pin must name the identity clients hold: {}",
+            pins[0]
+        );
+
+        // Unpin naming the revision — the same message, so it must clear.
+        alice.tx(&format!("UNPIN #pinrid {edit_id}"));
+        std::thread::sleep(Duration::from_millis(200));
+        alice.drain();
+        alice.tx("PINS #pinrid");
+        let none = alice.maybe(|l| l.contains("No pinned messages"), 1000);
+        assert!(
+            none.is_some(),
+            "unpinning by the edit's id left the pin in place"
+        );
+    })
+    .await;
+}
+
+/// A DM lives under a canonical `dm:` key rather than the wire target, so
+/// resolving a reaction to its message is a lookup by id, not by channel. Both
+/// ends must still agree.
+#[tokio::test]
+async fn a_dm_reaction_survives_an_edit() {
+    let key_a = PrivateKey::generate_ed25519();
+    let key_b = PrivateKey::generate_ed25519();
+    let resolver = resolver_with(vec![(DID_ALICE, &key_a), (DID_BOB, &key_b)]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, move |addr| {
+        let mut alice = C::with_sasl(addr, "dmrid_a", DID_ALICE, key_a);
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_sasl(addr, "dmrid_b", DID_BOB, key_b);
+        bob.reg();
+        bob.drain();
+
+        alice.tx("PRIVMSG dmrid_b :dm v1");
+        let first = bob.rx(|l| l.contains("PRIVMSG") && l.contains("dm v1"), "dm v1");
+        let original = C::extract_msgid(&first);
+        alice.send_edit("dmrid_b", &original, "dm v2");
+        let edit = bob.rx(|l| l.contains("PRIVMSG") && l.contains("dm v2"), "dm v2");
+        let edit_id = C::extract_msgid(&edit);
+        assert_ne!(original, edit_id);
+
+        bob.send_react("dmrid_a", &edit_id, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+        bob.drain();
+        bob.tx("CHATHISTORY LATEST dmrid_a * 50");
+        let reacted = bob.maybe(|l| l.contains("+freeq.at/reactions"), 1500);
+        assert!(
+            reacted.is_some(),
+            "a DM reaction filed against the edit id vanished from history"
+        );
+
+        bob.send_unreact("dmrid_a", &original, "🔥");
+        std::thread::sleep(Duration::from_millis(300));
+        bob.drain();
+        bob.tx("CHATHISTORY LATEST dmrid_a * 50");
+        let still = bob.maybe(|l| l.contains("+freeq.at/reactions"), 1500);
+        assert!(
+            still.is_none(),
+            "un-reacting by the original id left the DM reaction behind: {still:?}"
+        );
+    })
+    .await;
+}
+
+/// Guest DMs are never persisted, so their ids resolve to no row at all. An
+/// unknown id is its own root: the events must relay exactly as before.
+#[tokio::test]
+async fn unpersisted_guest_dm_ids_pass_through_unchanged() {
+    let resolver = resolver_with(vec![]);
+    let (addr, _h) = start(resolver).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "gst_a");
+        alice.reg();
+        alice.drain();
+        let mut bob = C::with_caps(addr, "gst_b");
+        bob.reg();
+        bob.drain();
+
+        alice.tx("PRIVMSG gst_b :ghost dm");
+        let dm = bob.rx(|l| l.contains("PRIVMSG") && l.contains("ghost dm"), "dm");
+        let msgid = C::extract_msgid(&dm);
+        assert!(!msgid.is_empty());
+
+        bob.send_react("gst_a", &msgid, "🔥");
+        let react = alice.maybe(|l| l.contains("TAGMSG") && l.contains("+react"), 1500);
+        assert!(react.is_some(), "guest DM reaction was not relayed");
+        assert!(
+            react.unwrap().contains(&format!("+reply={msgid}")),
+            "an id with no row must relay untouched"
+        );
+
+        alice.send_delete("gst_b", &msgid);
+        let del = bob.maybe(|l| l.contains("TAGMSG") && l.contains("draft/delete"), 1500);
+        assert!(
+            del.is_some_and(|l| l.contains(&msgid)),
+            "guest DM delete was not relayed with the id it named"
+        );
+    })
+    .await;
+}
+
+/// After a restart, in-memory history is rebuilt from the DB — where an edit is
+/// a separate row. The rebuild has to collapse the revisions the way the live
+/// edit path does, or the next joiner is replayed the same message twice: once
+/// as sent, once as revised.
+#[tokio::test]
+async fn an_edited_message_replays_once_after_a_restart() {
+    use freeq_server::db::Db;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("restart.db");
+    {
+        let db = Db::open(&path).unwrap();
+        db.save_channel("#restart", &freeq_server::server::ChannelState::default())
+            .unwrap();
+        db.insert_message(
+            "#restart",
+            "alice!a@host",
+            "before",
+            100,
+            &HashMap::new(),
+            Some("rst-1"),
+            None,
+        )
+        .unwrap();
+        db.insert_edit(
+            "#restart",
+            "alice!a@host",
+            "after",
+            110,
+            &HashMap::new(),
+            "rst-2",
+            "rst-1",
+            None,
+        )
+        .unwrap();
+    }
+
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        server_name: "test-edit".to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(path.to_str().unwrap().to_string()),
+        ..Default::default()
+    };
+    let (addr, _h) = freeq_server::server::Server::with_resolver(config, resolver_with(vec![]))
+        .start()
+        .await
+        .unwrap();
+
+    run(addr, |addr| {
+        let mut c = C::with_caps(addr, "rst_a");
+        c.reg();
+        c.drain();
+        c.tx("JOIN #restart");
+
+        let replayed = c
+            .maybe(|l| l.contains("PRIVMSG") && l.contains("after"), 2000)
+            .expect("the current text is replayed");
+        assert!(
+            replayed.contains("msgid=rst-1"),
+            "replay must key on the identity clients hold: {replayed}"
+        );
+        assert!(
+            replayed.contains("+freeq.at/edited=1"),
+            "a message revised before the restart is still an edited message: {replayed}"
+        );
+        assert!(
+            c.maybe(|l| l.contains("PRIVMSG") && l.contains("before"), 800)
+                .is_none(),
+            "the pre-edit text was replayed as a second message"
+        );
+    })
+    .await;
+}

--- a/freeq-server/tests/encryption.rs
+++ b/freeq-server/tests/encryption.rs
@@ -242,16 +242,28 @@ mod encryption_at_rest {
             None,
         )
         .unwrap();
-        db.edit_message("msg001", "alice", "edited text", Some("msg002"))
-            .unwrap();
+        // An edit is a new row that revises the original.
+        db.insert_edit(
+            "#test",
+            "alice",
+            "edited text",
+            1001,
+            &HashMap::new(),
+            "msg002",
+            "msg001",
+            None,
+        )
+        .unwrap();
 
-        let msgs = db.get_messages("#test", 10, None).unwrap();
-        // The edited message should show new text
-        let edited = msgs
-            .iter()
-            .find(|m| m.msgid.as_deref() == Some("msg001"))
-            .unwrap();
-        assert_eq!(edited.text, "edited text");
+        // Asked for by the identity the client holds — the original id — the
+        // current text comes back decrypted.
+        let current = db.current_revision("msg001").unwrap().unwrap();
+        assert_eq!(current.text, "edited text");
+        assert!(
+            db.get_raw_message_text("#test", 1001)
+                .unwrap()
+                .starts_with("EAR1:")
+        );
     }
 
     #[test]

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -603,3 +603,183 @@ async fn single_send_delivered_exactly_once() {
     hb.quit(None).await.ok();
     drop((srv_a, srv_b));
 }
+
+// ── federated edits and deletes ──────────────────────────────────
+//
+// A message's identity is its original msgid on BOTH servers. These cover the
+// two halves that used to stop at the origin: an edit arriving as linked
+// revision rather than a second message, and a delete actually deleting.
+
+/// Wait for a channel message whose text matches, returning its `msgid` tag.
+async fn recv_channel_msgid(
+    rx: &mut mpsc::Receiver<Event>,
+    text: &str,
+    dur: Duration,
+) -> Option<String> {
+    timeout(dur, async {
+        loop {
+            match rx.recv().await {
+                Some(Event::Message { text: t, tags, .. }) if t == text => {
+                    return tags.get("msgid").cloned();
+                }
+                Some(_) => continue,
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Rows for `channel` on this server that a delete hasn't struck. Like
+/// `dm_row_count`, this reads the plaintext `channel` column, so it needs no
+/// decryption key.
+fn live_row_count(db_path: &str, channel: &str) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open server db");
+    conn.query_row(
+        "SELECT COUNT(*) FROM messages WHERE channel = ?1 AND deleted_at IS NULL",
+        rusqlite::params![channel],
+        |r| r.get(0),
+    )
+    .expect("count live rows")
+}
+
+/// Wait for a server's stored copy of `channel` to go empty. Poll rather than
+/// sleep: how long a delete takes to cross is exactly what we can't assume.
+async fn wait_rows_cleared(db_path: &str, channel: &str) -> bool {
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    while tokio::time::Instant::now() < deadline {
+        if live_row_count(db_path, channel) == 0 {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    false
+}
+
+/// Everything a fresh joiner on this server is replayed for `channel`.
+async fn replayed_texts(server: &TestServer, id: &TestId, nick: &str, channel: &str) -> Vec<String> {
+    let (h, mut rx) = connect(server, id, nick);
+    wait_auth_and_register(&mut rx).await;
+    h.join(channel).await.unwrap();
+    let mut seen = Vec::new();
+    // Replay arrives before the NAMES reply; collect until it goes quiet.
+    while let Ok(Some(e)) = timeout(Duration::from_secs(2), rx.recv()).await {
+        if let Event::Message { text, target, .. } = e
+            && target.eq_ignore_ascii_case(channel)
+        {
+            seen.push(text);
+        }
+    }
+    h.quit(None).await.ok();
+    seen
+}
+
+/// An edit that crosses the hop must revise the peer's copy, not add a second
+/// message to it.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn channel_edit_crosses_without_duplicating() {
+    let alice = TestId::new("did:plc:aliceedit");
+    let bob = TestId::new("did:plc:bobedit");
+    let carol = TestId::new("did:plc:caroledit");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob, &carol]).await;
+
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    hb.join("#fedit").await.unwrap();
+
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+    warm_link(&ha, &bob.did, &mut rxb).await;
+    ha.join("#fedit").await.unwrap();
+
+    // Send until Bob's server has it, then capture the identity Alice's server
+    // assigned — the id both servers must agree on.
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    let mut msgid = None;
+    while tokio::time::Instant::now() < deadline {
+        ha.privmsg("#fedit", "before").await.ok();
+        if let Some(id) = recv_channel_msgid(&mut rxb, "before", Duration::from_secs(2)).await {
+            msgid = Some(id);
+            break;
+        }
+    }
+    let msgid = msgid.expect("bob's server received the channel message");
+
+    ha.edit_message("#fedit", &msgid, "after").await.unwrap();
+    assert!(
+        try_recv_message(&mut rxb, "after", EVENT_TIMEOUT)
+            .await
+            .is_some(),
+        "the edit never crossed the hop"
+    );
+
+    // The peer holds ONE message, carrying the newest text.
+    let replayed = replayed_texts(&srv_b, &carol, "carol", "#fedit").await;
+    let versions: Vec<&String> = replayed
+        .iter()
+        .filter(|t| *t == "before" || *t == "after")
+        .collect();
+    assert_eq!(
+        versions,
+        vec![&"after".to_string()],
+        "a joiner on the peer must see the edited message once, not both \
+         revisions: {replayed:?}"
+    );
+
+    ha.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}
+
+/// A delete has to cross too — relaying it only to the origin's own clients
+/// left the message readable on every other server, forever.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn channel_delete_crosses_the_hop() {
+    let alice = TestId::new("did:plc:alicedel");
+    let bob = TestId::new("did:plc:bobdel");
+    let carol = TestId::new("did:plc:caroldel");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob, &carol]).await;
+
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    hb.join("#feddel").await.unwrap();
+
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+    warm_link(&ha, &bob.did, &mut rxb).await;
+    ha.join("#feddel").await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    let mut msgid = None;
+    while tokio::time::Instant::now() < deadline {
+        ha.privmsg("#feddel", "regrettable").await.ok();
+        if let Some(id) = recv_channel_msgid(&mut rxb, "regrettable", Duration::from_secs(2)).await
+        {
+            msgid = Some(id);
+            break;
+        }
+    }
+    let msgid = msgid.expect("bob's server received the channel message");
+
+    ha.delete_message("#feddel", &msgid).await.unwrap();
+    assert!(
+        wait_rows_cleared(&srv_b.db_path, "#feddel").await,
+        "the delete never reached the peer's storage — it stays readable there \
+         through CHATHISTORY and every restart"
+    );
+
+    // …and it's out of the memory a joiner is replayed from, too.
+    let replayed = replayed_texts(&srv_b, &carol, "carol", "#feddel").await;
+    assert!(
+        !replayed.iter().any(|t| t == "regrettable"),
+        "the deleted message survived on the peer: {replayed:?}"
+    );
+
+    ha.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -783,3 +783,210 @@ async fn channel_delete_crosses_the_hop() {
     hb.quit(None).await.ok();
     drop((srv_a, srv_b));
 }
+
+/// Every msgid stored under a DM key on this server, oldest first.
+fn dm_msgids(db_path: &str, dm_key: &str) -> Vec<String> {
+    let conn = rusqlite::Connection::open(db_path).expect("open server db");
+    let mut stmt = conn
+        .prepare(
+            "SELECT msgid FROM messages
+             WHERE channel = ?1 AND msgid IS NOT NULL
+             ORDER BY id",
+        )
+        .expect("prepare");
+    let rows = stmt
+        .query_map(rusqlite::params![dm_key], |r| r.get::<_, String>(0))
+        .expect("query");
+    rows.collect::<Result<Vec<_>, _>>().expect("collect msgids")
+}
+
+/// Rows belonging to ONE logical message — every revision shares the root.
+/// Scoped this way because `warm_link` leaves its own probe messages in the
+/// same thread; a thread-wide count would answer a different question.
+fn rows_for_root(db_path: &str, dm_key: &str, root: &str, live_only: bool) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open server db");
+    let sql = if live_only {
+        "SELECT COUNT(*) FROM messages
+         WHERE channel = ?1 AND root_msgid = ?2 AND deleted_at IS NULL"
+    } else {
+        "SELECT COUNT(*) FROM messages WHERE channel = ?1 AND root_msgid = ?2"
+    };
+    conn.query_row(sql, rusqlite::params![dm_key, root], |r| r.get(0))
+        .expect("count rows for root")
+}
+
+/// Rows under a DM key that a delete hasn't struck.
+#[allow(dead_code)]
+fn live_dm_row_count(db_path: &str, dm_key: &str) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open server db");
+    conn.query_row(
+        "SELECT COUNT(*) FROM messages WHERE channel = ?1 AND deleted_at IS NULL",
+        rusqlite::params![dm_key],
+        |r| r.get(0),
+    )
+    .expect("count live dm rows")
+}
+
+/// Poll until both servers have `want` rows under the DM key.
+async fn wait_dm_rows(a: &TestServer, b: &TestServer, dm_key: &str, want: i64) -> bool {
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    while tokio::time::Instant::now() < deadline {
+        if dm_row_count(&a.db_path, dm_key) >= want && dm_row_count(&b.db_path, dm_key) >= want {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    false
+}
+
+/// The same DM must be one message on both servers.
+///
+/// The relay used to send no msgid at all for a recipient who isn't local, so
+/// the receiving server minted its own. Nothing that names a message across
+/// servers — an edit, a delete, a reaction — can work while the two ends
+/// disagree about what the message *is*.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn cross_server_dm_keeps_one_identity() {
+    let alice = TestId::new("did:plc:aliceid");
+    let bob = TestId::new("did:plc:bobid");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob]).await;
+
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+
+    warm_link(&ha, &bob.did, &mut rxb).await;
+    ha.privmsg(&bob.did, "one identity").await.unwrap();
+    assert!(
+        try_recv_message(&mut rxb, "one identity", EVENT_TIMEOUT)
+            .await
+            .is_some(),
+        "bob must receive the DM"
+    );
+
+    let dm_key = freeq_server::db::canonical_dm_key(&alice.did, &bob.did);
+    assert!(
+        wait_dm_rows(&srv_a, &srv_b, &dm_key, 1).await,
+        "both servers must persist the DM"
+    );
+
+    let sender_side = dm_msgids(&srv_a.db_path, &dm_key);
+    let peer_side = dm_msgids(&srv_b.db_path, &dm_key);
+    assert!(
+        peer_side.iter().any(|id| sender_side.contains(id)),
+        "the two servers hold this DM under different ids — sender {sender_side:?}, \
+         peer {peer_side:?}. Every later edit, delete or reaction names an id \
+         the other end cannot resolve."
+    );
+
+    ha.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}
+
+/// A DM edit crossing the hop revises the recipient's copy.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn dm_edit_crosses_with_linkage_intact() {
+    let alice = TestId::new("did:plc:alicedmed");
+    let bob = TestId::new("did:plc:bobdmed");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob]).await;
+
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+
+    warm_link(&ha, &bob.did, &mut rxb).await;
+    ha.privmsg(&bob.did, "dm before").await.unwrap();
+    let msgid = recv_channel_msgid(&mut rxb, "dm before", EVENT_TIMEOUT)
+        .await
+        .expect("bob received the DM with a msgid");
+
+    ha.edit_message(&bob.did, &msgid, "dm after").await.unwrap();
+    let edit_msgid = recv_channel_msgid(&mut rxb, "dm after", EVENT_TIMEOUT)
+        .await
+        .expect("the DM edit never crossed");
+    assert_ne!(edit_msgid, msgid, "an edit travels under its own wire id");
+
+    let dm_key = freeq_server::db::canonical_dm_key(&alice.did, &bob.did);
+    // Two rows under ONE identity: the original and its revision.
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    while tokio::time::Instant::now() < deadline
+        && rows_for_root(&srv_b.db_path, &dm_key, &msgid, false) < 2
+    {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert_eq!(
+        rows_for_root(&srv_b.db_path, &dm_key, &msgid, false),
+        2,
+        "the peer must hold the original and its revision under {msgid}"
+    );
+    assert_eq!(
+        rows_for_root(&srv_b.db_path, &dm_key, &edit_msgid, false),
+        0,
+        "the peer filed the edit as its own message instead of a revision \
+         of {msgid}"
+    );
+
+    ha.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}
+
+/// A DM delete has to cross too, or it only ever hides the message from the
+/// author's own client.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn dm_delete_crosses_the_hop() {
+    let alice = TestId::new("did:plc:alicedmdel");
+    let bob = TestId::new("did:plc:bobdmdel");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob]).await;
+
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+
+    warm_link(&ha, &bob.did, &mut rxb).await;
+    ha.privmsg(&bob.did, "regrettable dm").await.unwrap();
+    let msgid = recv_channel_msgid(&mut rxb, "regrettable dm", EVENT_TIMEOUT)
+        .await
+        .expect("bob received the DM with a msgid");
+
+    let dm_key = freeq_server::db::canonical_dm_key(&alice.did, &bob.did);
+    assert!(
+        wait_dm_rows(&srv_a, &srv_b, &dm_key, 1).await,
+        "both servers must persist the DM first"
+    );
+
+    // The rest of the thread (warm-up probes) must survive — a delete acts on
+    // one message, not on a conversation.
+    let thread_before = dm_msgids(&srv_b.db_path, &dm_key).len();
+    ha.delete_message(&bob.did, &msgid).await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    let mut cleared = false;
+    while tokio::time::Instant::now() < deadline {
+        if rows_for_root(&srv_b.db_path, &dm_key, &msgid, true) == 0 {
+            cleared = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        cleared,
+        "the deleted DM is still readable on the recipient's server"
+    );
+    assert_eq!(
+        dm_msgids(&srv_b.db_path, &dm_key).len(),
+        thread_before,
+        "the delete removed rows other than the message it named"
+    );
+
+    ha.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -20,7 +20,7 @@
 //! - waits are event/DB-driven with a timeout; never a fixed sleep.
 
 use std::process::{Child, Command};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 use freeq_sdk::auth::{ChallengeSigner, KeySigner};
@@ -65,11 +65,19 @@ impl TestId {
 // ── server process management ────────────────────────────────────
 
 /// A running `freeq-server` subprocess. `Drop` kills it and removes its tempdir.
+/// One test at a time: each test boots two servers, and running the file in
+/// parallel (22 servers at once) starves the machine — clients time out before
+/// first auth and the whole batch fails. Taken in `spawn_pair`, which every
+/// test goes through, so they queue regardless of cargo's `--test-threads`.
+static ONE_TEST_AT_A_TIME: Mutex<()> = Mutex::new(());
+
 struct TestServer {
     _dir: tempfile::TempDir,
     child: Child,
     irc_addr: String,
     db_path: String,
+    /// Held by server A for the test's lifetime; see `ONE_TEST_AT_A_TIME`.
+    serial: Option<MutexGuard<'static, ()>>,
 }
 
 impl Drop for TestServer {
@@ -175,12 +183,18 @@ fn spawn_server(plan: ServerPlan, peer: &PeerRef, resolver_entries: &str) -> Tes
         child,
         irc_addr,
         db_path,
+        serial: None,
     }
 }
 
 /// Boot two mutually-peered servers, both resolving every `ids` DID offline.
 /// Blocks until both IRC ports accept connections.
 async fn spawn_pair(ids: &[&TestId]) -> (TestServer, TestServer) {
+    // A failed test poisons the lock; the next test's servers are unaffected,
+    // so take it anyway.
+    let serial = ONE_TEST_AT_A_TIME
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let a_plan = plan_server(0xA1);
     let b_plan = plan_server(0xB2);
     let resolver: String = ids
@@ -193,8 +207,9 @@ async fn spawn_pair(ids: &[&TestId]) -> (TestServer, TestServer) {
     // two can cross-reference for peering.
     let a_ref = PeerRef::of(&a_plan);
     let b_ref = PeerRef::of(&b_plan);
-    let a = spawn_server(a_plan, &b_ref, &resolver);
+    let mut a = spawn_server(a_plan, &b_ref, &resolver);
     let b = spawn_server(b_plan, &a_ref, &resolver);
+    a.serial = Some(serial);
 
     wait_port(&a.irc_addr).await;
     wait_port(&b.irc_addr).await;

--- a/freeq-server/tests/search.rs
+++ b/freeq-server/tests/search.rs
@@ -209,6 +209,52 @@ async fn search_finds_channel_messages_for_member() {
     .await;
 }
 
+/// A hit on an edited message is addressed by the root msgid — the id every
+/// client holds the message under — not the matching revision's own id.
+#[tokio::test]
+async fn search_hit_for_edited_message_carries_the_root_msgid() {
+    let (addr, _h) = start(DidResolver::static_map(HashMap::new())).await;
+    run(addr, |addr| {
+        let mut alice = C::with_caps(addr, "alice");
+        let mut bob = C::with_caps(addr, "bob");
+        alice.reg();
+        bob.reg();
+        alice.tx("JOIN #edits");
+        bob.tx("JOIN #edits");
+        settle();
+        alice.drain();
+        bob.drain();
+
+        alice.tx("PRIVMSG #edits :original wording here");
+        // bob's copy carries the server-assigned msgid — the root.
+        let line = bob.rx(|l| l.contains("original wording here"), "original at bob");
+        let root = line
+            .split("msgid=")
+            .nth(1)
+            .expect("broadcast carries msgid")
+            .split([';', ' '])
+            .next()
+            .unwrap()
+            .to_string();
+
+        alice.tx(&format!("@+draft/edit={root} PRIVMSG #edits :revised wording here"));
+        settle();
+        alice.drain();
+        bob.drain();
+
+        alice.tx("SEARCH #edits :revised");
+        let msgs = alice.collect_batch_messages();
+        assert_eq!(msgs.len(), 1, "one hit for the current text: {msgs:?}");
+        assert!(msgs[0].contains("revised wording here"));
+        assert!(
+            msgs[0].contains(&format!("msgid={root}")),
+            "hit must be addressed by the root id {root}: {}",
+            msgs[0]
+        );
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn search_uses_dedicated_batch_type() {
     let (addr, _h) = start(DidResolver::static_map(HashMap::new())).await;

--- a/freeq-tui/src/app.rs
+++ b/freeq-tui/src/app.rs
@@ -132,10 +132,10 @@ pub struct BufferLine {
     pub is_deleted: bool,
     /// Parent message ID this is a reply to (from IRCv3 `+reply` tag).
     pub reply_to: Option<String>,
-    /// Root msgid of this message's edit chain, once an edit has rewritten
-    /// `msgid`. Deletes name the ORIGINAL msgid, so lookups must be able to
-    /// reach the line by it; `edit_aliases` only records that an id was seen,
-    /// not which line it belongs to.
+    /// Root msgid of this message's edit chain. A message keeps its original
+    /// msgid for life — an edit changes `text`, never `msgid` — so this is
+    /// set purely as a marker that an edit was applied (and it equals
+    /// `msgid` for lines edited in place).
     pub edit_of: Option<String>,
 }
 
@@ -190,12 +190,6 @@ pub struct Buffer {
     /// True once we've seen an empty CHATHISTORY batch — no older messages
     /// exist on the server, so we should stop firing requests.
     pub history_exhausted: bool,
-    /// Original msgids of lines that were rewritten by a `+draft/edit`
-    /// (apply_edit swaps the line's msgid to the EDIT's msgid). A racing
-    /// second CHATHISTORY replay re-sends the original row under the old
-    /// msgid; without this alias set the dedup in `end_batch` misses it and
-    /// the buffer shows both the edited and the pre-edit copy.
-    pub edit_aliases: HashSet<String>,
 }
 
 /// In-progress BATCH buffer (e.g., CHATHISTORY).
@@ -208,10 +202,6 @@ pub struct BatchBuffer {
     /// the buffer's history as exhausted. Without this, an empty batch
     /// of an unrelated type would permanently disable scroll-up fetch.
     pub batch_type: String,
-    /// Original msgids rewritten by an in-batch `+draft/edit` (the line now
-    /// carries the edit's msgid). Merged into the target buffer's
-    /// `edit_aliases` at flush so later replays of the pre-edit row dedup.
-    pub edit_aliases: HashSet<String>,
 }
 
 impl BatchBuffer {
@@ -223,7 +213,7 @@ impl BatchBuffer {
         &mut self,
         editor_nick: &str,
         original_msgid: &str,
-        new_msgid: Option<&str>,
+        _new_msgid: Option<&str>,
         new_text: &str,
     ) -> bool {
         for (_, line) in self.lines.iter_mut() {
@@ -233,10 +223,9 @@ impl BatchBuffer {
                 }
                 line.text = sanitize_text(new_text);
                 line.is_edited = true;
-                if let Some(id) = new_msgid {
-                    line.msgid = Some(id.to_string());
-                }
-                self.edit_aliases.insert(original_msgid.to_string());
+                // The line keeps the msgid it was born with — the identity
+                // the server files reactions, pins and deletes under. The
+                // edit's own wire id is not this message's name.
                 return true;
             }
         }
@@ -274,7 +263,6 @@ impl Buffer {
             pinned: HashSet::new(),
             history_in_flight: false,
             history_exhausted: false,
-            edit_aliases: HashSet::new(),
         }
     }
 
@@ -282,14 +270,12 @@ impl Buffer {
         // Dedup by msgid at the single chokepoint: the server replays
         // history BOTH unbatched on JOIN and via CHATHISTORY batches, and a
         // message can arrive live first. Without this, a rejoin doubles the
-        // buffer. `edit_aliases` covers lines whose msgid was rewritten by a
-        // `+draft/edit` (the pre-edit row replays under the ORIGINAL id).
-        if let Some(ref id) = line.msgid {
-            if self.edit_aliases.contains(id)
-                || self.messages.iter().any(|l| l.msgid.as_deref() == Some(id))
-            {
-                return;
-            }
+        // buffer. A line keeps its msgid across edits, so the id alone is
+        // enough — replayed pre-edit rows carry the same id the line holds.
+        if let Some(ref id) = line.msgid
+            && self.messages.iter().any(|l| l.msgid.as_deref() == Some(id))
+        {
+            return;
         }
         // SECURITY: a hostile peer can put ANSI escapes (cursor moves, color
         // resets, screen clears) into their nick or message body. We render
@@ -415,7 +401,7 @@ impl Buffer {
         &mut self,
         editor_nick: &str,
         original_msgid: &str,
-        new_msgid: Option<&str>,
+        _new_msgid: Option<&str>,
         new_text: &str,
     ) -> bool {
         if let Some(line) = self.find_by_msgid_mut(original_msgid) {
@@ -430,21 +416,11 @@ impl Buffer {
             if line.edit_of.is_none() {
                 line.edit_of = Some(original_msgid.to_string());
             }
-            if let Some(id) = new_msgid {
-                line.msgid = Some(id.to_string());
-            }
-            // Keep the ORIGINAL id recognizable as "already present" so a
-            // later history replay of the pre-edit row dedups instead of
-            // resurrecting the old text alongside the edited line.
-            self.edit_aliases.insert(original_msgid.to_string());
-            // Carry pin through the msgid swap. Without this the
-            // renderer's `msg.msgid in buffer.pinned` check silently
-            // drops the 📌 marker after every edit of a pinned message.
-            if let Some(id) = new_msgid
-                && self.pinned.remove(original_msgid)
-            {
-                self.pinned.insert(id.to_string());
-            }
+            // The line keeps the msgid it was born with. That id is what the
+            // server files reactions, pins and deletes under, what replay
+            // returns the message under, and what every other client holds —
+            // so pins need no re-keying and replayed pre-edit rows dedup on
+            // the id alone. The edit's own wire id is audit trail, not a name.
             true
         } else {
             false
@@ -637,7 +613,11 @@ pub fn shorten_did(s: &str) -> String {
         return s.to_string();
     }
     let mut parts = s.splitn(3, ':');
-    let (_, method, id) = (parts.next(), parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+    let (_, method, id) = (
+        parts.next(),
+        parts.next().unwrap_or(""),
+        parts.next().unwrap_or(""),
+    );
     let chars: Vec<char> = id.chars().collect();
     if chars.len() <= 12 {
         format!("{method}:{id}")
@@ -904,7 +884,6 @@ impl App {
                 target: target.to_string(),
                 lines: Vec::new(),
                 batch_type: batch_type.to_string(),
-                edit_aliases: HashSet::new(),
             },
         );
     }
@@ -929,25 +908,17 @@ impl App {
                 return;
             }
             let buf = self.buffer_mut(&batch.target);
-            // Aliases learned inside the batch (in-batch edit rewrote a
-            // line's msgid) must survive into the buffer, or the NEXT replay
-            // resurrects the pre-edit row.
-            buf.edit_aliases.extend(batch.edit_aliases.drain());
             batch.lines.sort_by_key(|a| a.0);
             let was_empty = batch.lines.is_empty();
             let was_chathistory = batch.batch_type.eq_ignore_ascii_case("chathistory");
             // Skip lines already in the buffer by msgid. A CHATHISTORY LATEST
             // fetch (used to backfill a DM on open) overlaps messages that
             // arrived live, which would otherwise double them.
-            let mut present: HashSet<String> = buf
+            let present: HashSet<String> = buf
                 .messages
                 .iter()
                 .filter_map(|l| l.msgid.clone())
                 .collect();
-            // Edited lines carry the EDIT's msgid; their original ids live in
-            // `edit_aliases`. Both count as present, or a second replay
-            // duplicates every edited message (the pre-edit row sneaks past).
-            present.extend(buf.edit_aliases.iter().cloned());
             // Prepend in order (oldest first)
             for (_, line) in batch.lines.into_iter().rev() {
                 if let Some(ref id) = line.msgid
@@ -1261,11 +1232,12 @@ mod tests {
         let ok = buf.apply_edit("alice", "01ABC", Some("01DEF"), "hello world");
         assert!(ok);
 
-        let edited = buf.find_by_msgid("01DEF").expect("new id should resolve");
+        // The message keeps the id it was born with; the edit's own wire id
+        // never becomes a name anything can be looked up by.
+        let edited = buf.find_by_msgid("01ABC").expect("original id resolves");
         assert_eq!(edited.text, "hello world");
         assert!(edited.is_edited);
-        // Original id no longer points anywhere since the line's msgid swapped.
-        assert!(buf.find_by_msgid("01ABC").is_none());
+        assert!(buf.find_by_msgid("01DEF").is_none());
     }
 
     #[test]
@@ -1456,22 +1428,20 @@ mod tests {
     /// from the pinned message. Fix: when swapping msgid, also move
     /// the pin entry.
     #[test]
-    fn apply_edit_carries_pin_through_msgid_swap() {
+    fn apply_edit_leaves_a_pin_where_it_is() {
+        // Pins key on the message's lifelong id, so an edit needs no pin
+        // bookkeeping at all — the marker survives because nothing moved.
         let mut buf = Buffer::new("#test");
         buf.push(line("important", "alice", Some("01OLD")));
         buf.add_pinned("01OLD");
-        assert!(buf.pinned.contains("01OLD"));
 
         assert!(buf.apply_edit("alice", "01OLD", Some("01NEW"), "important (refined)"));
         assert!(
-            !buf.pinned.contains("01OLD"),
-            "old msgid should be removed from pin set"
-        );
-        assert!(
-            buf.pinned.contains("01NEW"),
-            "new msgid should carry the pin: {:?}",
+            buf.pinned.contains("01OLD"),
+            "the pin stays under the message's id: {:?}",
             buf.pinned
         );
+        assert!(!buf.pinned.contains("01NEW"));
     }
 
     /// CORRECTNESS: `end_batch` set `history_exhausted = true` for
@@ -1855,7 +1825,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_apply_edit_rewrites_within_batch() {
+    fn batch_apply_edit_updates_text_in_place() {
         let mut batch = BatchBuffer {
             target: "#test".into(),
             lines: vec![
@@ -1863,12 +1833,13 @@ mod tests {
                 (2, line_with_msgid("unrelated", Some("01BBB"))),
             ],
             batch_type: "chathistory".into(),
-            edit_aliases: HashSet::new(),
         };
         assert!(batch.apply_edit("alice", "01AAA", Some("01CCC"), "v2"));
         assert_eq!(batch.lines[0].1.text, "v2");
         assert!(batch.lines[0].1.is_edited);
-        assert_eq!(batch.lines[0].1.msgid.as_deref(), Some("01CCC"));
+        // The line keeps the id it was born with; the edit's wire id is
+        // never a message's name.
+        assert_eq!(batch.lines[0].1.msgid.as_deref(), Some("01AAA"));
         // Other line untouched.
         assert_eq!(batch.lines[1].1.text, "unrelated");
         assert!(!batch.lines[1].1.is_edited);
@@ -1880,7 +1851,6 @@ mod tests {
             target: "#test".into(),
             lines: vec![(1, line_with_msgid("secret", Some("01AAA")))],
             batch_type: "chathistory".into(),
-            edit_aliases: HashSet::new(),
         };
         assert!(batch.apply_delete("alice", "01AAA"));
         assert!(batch.lines[0].1.is_deleted);
@@ -1936,7 +1906,8 @@ mod tests {
     #[test]
     fn member_did_rekeys_a_lone_nick_thread() {
         let mut app = App::new("me", false);
-        app.buffer_mut("Alice").push(line("hi", "alice", Some("01A")));
+        app.buffer_mut("Alice")
+            .push(line("hi", "alice", Some("01A")));
         app.active_buffer = "alice".to_string();
 
         app.record_member_did("alice", DID);
@@ -1973,7 +1944,8 @@ mod tests {
     #[test]
     fn member_did_moves_e2ee_key_with_the_thread() {
         let mut app = App::new("me", false);
-        app.buffer_mut("alice").push(line("hi", "alice", Some("01A")));
+        app.buffer_mut("alice")
+            .push(line("hi", "alice", Some("01A")));
         app.channel_keys.insert("alice".to_string(), [7u8; 32]);
 
         app.record_member_did("alice", DID);
@@ -1985,7 +1957,8 @@ mod tests {
     #[test]
     fn member_did_ignores_channels_and_self_bindings() {
         let mut app = App::new("me", false);
-        app.buffer_mut("#general").push(line("hi", "alice", Some("01A")));
+        app.buffer_mut("#general")
+            .push(line("hi", "alice", Some("01A")));
 
         app.record_member_did("#general", DID);
         assert!(app.buffers.contains_key("#general"));
@@ -1996,24 +1969,27 @@ mod tests {
         assert!(!app.did_names.contains_key("not-a-did"));
     }
 
-
     #[test]
     fn push_dedups_unbatched_join_replay() {
         // The server replays history unbatched on JOIN; a line that already
         // arrived (live or via a batch) must not double when pushed again.
         let mut app = App::new("me", false);
-        app.buffer_mut("#ship").push(line("hello", "ana", Some("01A")));
-        app.buffer_mut("#ship").push(line("hello", "ana", Some("01A")));
+        app.buffer_mut("#ship")
+            .push(line("hello", "ana", Some("01A")));
+        app.buffer_mut("#ship")
+            .push(line("hello", "ana", Some("01A")));
         assert_eq!(app.buffers.get("#ship").unwrap().messages.len(), 1);
 
-        // Pre-edit row replayed unbatched after a live edit: alias dedup.
-        app.buffer_mut("#ship").push(line("v1", "chad", Some("01B")));
+        // Pre-edit row replayed unbatched after a live edit: the line kept
+        // its id, so plain msgid dedup covers it.
+        app.buffer_mut("#ship")
+            .push(line("v1", "chad", Some("01B")));
         app.apply_edit("chad", None, "#ship", "01B", Some("01C"), "v2");
-        app.buffer_mut("#ship").push(line("v1", "chad", Some("01B")));
+        app.buffer_mut("#ship")
+            .push(line("v1", "chad", Some("01B")));
         let buf = app.buffers.get("#ship").unwrap();
         assert_eq!(buf.messages.len(), 2, "{:?}", buf.messages);
     }
-
 
     #[test]
     fn edit_in_batch_also_rewrites_live_buffer_row() {
@@ -2021,7 +1997,8 @@ mod tests {
         // arrives inside a CHATHISTORY batch. The edit must rewrite the
         // buffer's copy too, or the flush appends an edited duplicate.
         let mut app = App::new("me", false);
-        app.buffer_mut("#ship").push(line("v1", "chad", Some("01A")));
+        app.buffer_mut("#ship")
+            .push(line("v1", "chad", Some("01A")));
 
         app.start_batch_typed("h1", "#ship", "chathistory");
         app.add_batch_line("h1", 1, line("v1", "chad", Some("01A")));
@@ -2030,14 +2007,18 @@ mod tests {
 
         let buf = app.buffers.get("#ship").unwrap();
         assert_eq!(
-            buf.messages.len(), 1,
+            buf.messages.len(),
+            1,
             "one row after batch edit over join-replayed original: {:?}",
-            buf.messages.iter().map(|l| (&l.text, &l.msgid)).collect::<Vec<_>>()
+            buf.messages
+                .iter()
+                .map(|l| (&l.text, &l.msgid))
+                .collect::<Vec<_>>()
         );
         let row = buf.messages.front().unwrap();
         assert_eq!(row.text, "v2");
         assert!(row.is_edited);
-        assert_eq!(row.msgid.as_deref(), Some("01B"));
+        assert_eq!(row.msgid.as_deref(), Some("01A"));
     }
 
     #[test]
@@ -2052,19 +2033,33 @@ mod tests {
         // Batch 1: original + in-batch edit.
         app.start_batch_typed("h1", "#ship", "chathistory");
         app.add_batch_line("h1", 1, line("shipping it aa", "chad", Some("01A")));
-        app.apply_edit("chad", Some("h1"), "#ship", "01A", Some("01B"), "shipping it 🚀");
+        app.apply_edit(
+            "chad",
+            Some("h1"),
+            "#ship",
+            "01A",
+            Some("01B"),
+            "shipping it 🚀",
+        );
         app.end_batch("h1");
         {
             let buf = app.buffers.get("#ship").unwrap();
             assert_eq!(buf.messages.len(), 1);
-            assert_eq!(buf.messages.front().unwrap().msgid.as_deref(), Some("01B"));
+            assert_eq!(buf.messages.front().unwrap().msgid.as_deref(), Some("01A"));
             assert!(buf.messages.front().unwrap().is_edited);
         }
 
         // Batch 2 (racing duplicate request): same two rows again.
         app.start_batch_typed("h2", "#ship", "chathistory");
         app.add_batch_line("h2", 1, line("shipping it aa", "chad", Some("01A")));
-        app.apply_edit("chad", Some("h2"), "#ship", "01A", Some("01B"), "shipping it 🚀");
+        app.apply_edit(
+            "chad",
+            Some("h2"),
+            "#ship",
+            "01A",
+            Some("01B"),
+            "shipping it 🚀",
+        );
         app.end_batch("h2");
 
         let buf = app.buffers.get("#ship").unwrap();
@@ -2072,7 +2067,10 @@ mod tests {
             buf.messages.len(),
             1,
             "pre-edit row must not resurrect on a second replay: {:?}",
-            buf.messages.iter().map(|l| (&l.text, &l.msgid)).collect::<Vec<_>>()
+            buf.messages
+                .iter()
+                .map(|l| (&l.text, &l.msgid))
+                .collect::<Vec<_>>()
         );
         assert_eq!(buf.messages.front().unwrap().text, "shipping it 🚀");
     }
@@ -2082,7 +2080,8 @@ mod tests {
         // Live path variant: message arrived live (01A), a live edit rewrote
         // it to 01B, then a CHATHISTORY backfill replays the original row.
         let mut app = App::new("me", false);
-        app.buffer_mut("#ship").push(line("v1", "chad", Some("01A")));
+        app.buffer_mut("#ship")
+            .push(line("v1", "chad", Some("01A")));
         app.apply_edit("chad", None, "#ship", "01A", Some("01B"), "v2");
 
         app.start_batch_typed("h1", "#ship", "chathistory");
@@ -2090,7 +2089,11 @@ mod tests {
         app.end_batch("h1");
 
         let buf = app.buffers.get("#ship").unwrap();
-        assert_eq!(buf.messages.len(), 1, "original row must dedup via edit alias");
+        assert_eq!(
+            buf.messages.len(),
+            1,
+            "original row must dedup via edit alias"
+        );
         assert_eq!(buf.messages.front().unwrap().text, "v2");
     }
 
@@ -2099,7 +2102,8 @@ mod tests {
         // A DM's CHATHISTORY LATEST backfill overlaps messages already shown
         // live; the flush must not double them.
         let mut app = App::new("me", false);
-        app.buffer_mut("bob").push(line("live", "bob", Some("01LIVE")));
+        app.buffer_mut("bob")
+            .push(line("live", "bob", Some("01LIVE")));
 
         app.start_batch("h1", "bob");
         // History returns an older message plus the one already present.
@@ -2110,8 +2114,14 @@ mod tests {
         let buf = app.buffers.get("bob").unwrap();
         assert_eq!(buf.messages.len(), 2, "duplicate msgid must be skipped");
         // Older prepended, the live one kept its single copy.
-        assert_eq!(buf.messages.front().unwrap().msgid.as_deref(), Some("01OLD"));
-        assert_eq!(buf.messages.back().unwrap().msgid.as_deref(), Some("01LIVE"));
+        assert_eq!(
+            buf.messages.front().unwrap().msgid.as_deref(),
+            Some("01OLD")
+        );
+        assert_eq!(
+            buf.messages.back().unwrap().msgid.as_deref(),
+            Some("01LIVE")
+        );
     }
 
     #[test]
@@ -2181,12 +2191,10 @@ pub fn evict_image_cache(cache: &ImageCache) {
 mod delete_after_edit_tests {
     //! Deleting an *edited* message must still work.
     //!
-    //! `apply_edit` rewrites `line.msgid` to the edit's msgid (so subsequent
-    //! streaming edits and history dedup line up), recording the original only in
-    //! the buffer-level `edit_aliases` set. Deletes always name the ORIGINAL
-    //! msgid — the identity clients hold, and what the server relays in
-    //! `+draft/delete` — so `apply_delete`'s `find_by_msgid_mut` lookup missed and
-    //! the line stayed on screen after the server had removed it.
+    //! Deletes always name the ORIGINAL msgid — the identity clients hold,
+    //! and what the server relays in `+draft/delete`. A line keeps that id
+    //! across edits, so the delete resolves by plain id lookup; these tests
+    //! pin that an edit never breaks the delete path.
     use super::*;
 
     fn line(msgid: &str, from: &str, text: &str) -> BufferLine {
@@ -2220,12 +2228,21 @@ mod delete_after_edit_tests {
     }
 
     #[test]
-    fn delete_by_edit_msgid_still_works() {
+    fn an_edit_never_changes_the_line_id() {
+        // The invariant everything else here rests on: reactions, pins,
+        // deletes and replay dedup all key on the id the message was born
+        // with, so an edit must leave it alone.
         let mut buf = Buffer::new("#t");
         buf.messages.push_back(line("orig", "alice", "v1"));
-        buf.apply_edit("alice", "orig", Some("edit1"), "v2");
-        assert!(buf.apply_delete("alice", "edit1"));
-        assert!(buf.messages.back().unwrap().is_deleted);
+        assert!(buf.apply_edit("alice", "orig", Some("edit1"), "v2"));
+        let l = buf.messages.back().unwrap();
+        assert_eq!(l.msgid.as_deref(), Some("orig"));
+        assert_eq!(l.text, "v2");
+        assert!(l.is_edited);
+        // A pin on the message needs no re-keying to survive the edit.
+        buf.pinned.insert("orig".into());
+        assert!(buf.apply_edit("alice", "orig", Some("edit2"), "v3"));
+        assert!(buf.pinned.contains("orig"));
     }
 
     #[test]

--- a/freeq-tui/src/main.rs
+++ b/freeq-tui/src/main.rs
@@ -935,7 +935,9 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
             target,
             text,
             tags,
-            dm_key, .. } => {
+            dm_key,
+            ..
+        } => {
             // DID is the identity. Render our own messages under our current
             // nick no matter which client alias sent them — a TUI as `-n nap`,
             // a web session as the handle nick `zapnap` — so one DID reads as
@@ -1012,6 +1014,10 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                 .get("+reply")
                 .filter(|v| crate::app::is_valid_msgid(v))
                 .cloned();
+            // Join replay collapses an edited message into one row with no
+            // `+draft/edit`; the server's `+freeq.at/edited` tag is the only
+            // thing that says the text isn't the original.
+            let replay_edited = tags.get("+freeq.at/edited").is_some_and(|v| v == "1");
 
             // Pin/unpin: server sends a NOTICE CTCP ACTION with a tag. Update
             // the channel's pin set; let the action message itself fall through
@@ -1035,7 +1041,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                 .get("+draft/edit")
                 .filter(|v| crate::app::is_valid_msgid(v))
             {
-                app.apply_edit(
+                let applied = app.apply_edit(
                     &from,
                     batch_id.map(|s| s.as_str()),
                     &buf_name,
@@ -1043,6 +1049,31 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                     msgid.as_deref(),
                     &text,
                 );
+                // Original nowhere on screen (outside the replay window, or
+                // we joined after it was sent): show the current text as its
+                // own line rather than dropping the content — keyed by the
+                // message's identity, the original msgid, never the
+                // revision's wire id.
+                if !applied {
+                    push_line_to_buffer(
+                        app,
+                        batch_id,
+                        &buf_name,
+                        timestamp_ms,
+                        crate::app::BufferLine {
+                            timestamp: timestamp.clone(),
+                            from: from.clone(),
+                            text: text.clone(),
+                            is_system: false,
+                            image_url: None,
+                            msgid: Some(original_msgid.clone()),
+                            is_edited: true,
+                            is_deleted: false,
+                            reply_to: reply_to.clone(),
+                            edit_of: Some(original_msgid.clone()),
+                        },
+                    );
+                }
                 return;
             }
 
@@ -1065,7 +1096,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                             is_system: true,
                             image_url: None,
                             msgid: msgid.clone(),
-                            is_edited: false,
+                            is_edited: replay_edited,
                             is_deleted: false,
                             reply_to: reply_to.clone(),
                             edit_of: None,
@@ -1096,7 +1127,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                         is_system: false,
                         image_url: img_url,
                         msgid: msgid.clone(),
-                        is_edited: false,
+                        is_edited: replay_edited,
                         is_deleted: false,
                         reply_to: reply_to.clone(),
                         edit_of: None,
@@ -1119,7 +1150,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                             is_system: false,
                             image_url: None,
                             msgid: msgid.clone(),
-                            is_edited: false,
+                            is_edited: replay_edited,
                             is_deleted: false,
                             reply_to: reply_to.clone(),
                             edit_of: None,
@@ -1138,7 +1169,7 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                             is_system: false,
                             image_url: None,
                             msgid: msgid.clone(),
-                            is_edited: false,
+                            is_edited: replay_edited,
                             is_deleted: false,
                             reply_to: reply_to.clone(),
                             edit_of: None,
@@ -1162,7 +1193,13 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
         Event::BatchEnd { id } => {
             app.end_batch(&id);
         }
-        Event::TagMsg { from, target, tags, dm_key, .. } => {
+        Event::TagMsg {
+            from,
+            target,
+            tags,
+            dm_key,
+            ..
+        } => {
             // Same conversation keying as Event::Message.
             let buf_name = if target.starts_with('#') || target.starts_with('&') {
                 target.clone()
@@ -1189,7 +1226,11 @@ fn process_irc_event(app: &mut App, event: Event, _handle: &client::ClientHandle
                 let target_msgid = tags.get("+reply").cloned();
                 let target_preview = target_msgid
                     .as_deref()
-                    .and_then(|id| app.buffers.get(&crate::app::buffer_key(&buf_name))?.find_by_msgid(id))
+                    .and_then(|id| {
+                        app.buffers
+                            .get(&crate::app::buffer_key(&buf_name))?
+                            .find_by_msgid(id)
+                    })
                     .map(|line| {
                         let snippet: String = line.text.chars().take(40).collect();
                         if line.text.chars().count() > 40 {

--- a/scripts/run-s2s-tests.sh
+++ b/scripts/run-s2s-tests.sh
@@ -43,6 +43,11 @@ cargo build --release --bin freeq-server 2>&1 | tail -3
 
 BINARY="$(pwd)/target/release/freeq-server"
 
+# Both servers run with a database. Editing or deleting a channel message is
+# authorized against the stored row's author, so a server started without one
+# refuses every edit and delete — a configuration no deployment runs, and one
+# that made the history tests read as product bugs.
+#
 # ── Start Server A (iroh enabled, no peers yet — will accept incoming) ──
 echo ""
 echo "═══ Starting Server A on port $PORT_A ═══"
@@ -50,6 +55,7 @@ RUST_LOG=freeq_server=info "$BINARY" \
     --listen-addr "127.0.0.1:$PORT_A" \
     --server-name "server-a" \
     --data-dir "$DIR_A" \
+    --db-path "$DIR_A/irc.db" \
     --iroh \
     >> "$LOG_A" 2>&1 &
 PID_A=$!
@@ -79,6 +85,7 @@ RUST_LOG=freeq_server=info "$BINARY" \
     --listen-addr "127.0.0.1:$PORT_B" \
     --server-name "server-b" \
     --data-dir "$DIR_B" \
+    --db-path "$DIR_B/irc.db" \
     --iroh \
     --s2s-peers "$IROH_ID_A" \
     --s2s-allowed-peers "$IROH_ID_A" \


### PR DESCRIPTION
## One identity per message, unchanged by edits — server, federation, and all five clients

An edit stores a new row under a new msgid, linked by `replaces_msgid`. Before
this series, each layer had its own answer to "which id is the message":
the database ended at the newest revision, the server's in-memory history kept
the original, live clients re-keyed to the edit id, join replay handed out the
original with no marker, and CHATHISTORY returned both rows. Every consumer
that matched ids exactly — reactions, pins, deletes, replay dedup — missed
whenever two of those disagreed. User-visible results included reactions that
vanished on reload, un-reacts that silently failed, deleted messages that
returned for the next joiner, and federated edits that duplicated on the peer.

This series makes one rule hold everywhere: **a message's identity is its
original msgid, for life.** An edit changes content, never identity. The wire
format is untouched — an edit still travels as a new wire id carrying
`+draft/edit=<original>` — the change is what gets filed and looked up.

### Impact on the revision-family delete work (c8c131b2, ed74fd94, ea648a45)

Stated plainly: this series **replaces the mechanism** those commits
introduced and **preserves the behavior** they established.

- `messages` gains a `root_msgid` column, stamped at insert time (an original
  is its own root; an edit inherits its target's). The delete sweep becomes
  `WHERE root_msgid = ?` instead of re-deriving the family per delete.
- `revision_family()` is removed. The bounded upward walk it introduced
  survives as a private, migration-only helper (`migration_root_of`) that
  runs once per pre-existing database; nothing at runtime re-derives
  families anymore.
- The delete semantics those commits fixed — deleting a message removes every
  revision from messages, FTS, pins, and reactions — are unchanged, and every
  delete-behavior test from them is unmodified and green. The same applies to
  the client-side delete-after-edit tests from the same run (e034cdd6,
  4005179d, 05eca625): behavior assertions kept, only assertions of the
  re-keying mechanism itself updated, since re-keying no longer exists.

### Server

- Migration: `root_msgid` column + index, with an idempotent, upgrade-only
  backfill (walks the existing back-pointers once per pre-existing database;
  a fresh database stamps at insert and never runs the walk). Reactions and
  pins are re-filed under roots, deduplicating rows the old split filed twice
  (earliest wins; `UNIQUE` collisions handled explicitly). Runs automatically
  at startup; verified on an encrypted database.
- Reactions, pins, and deletes normalize to the root at the write boundary
  (inside `db.rs`, so call sites are untouched), and fan-out — local and S2S —
  is rewritten to name roots, so receivers of any age hear one identity.
- In-memory history now collapses revisions on startup rehydration the same
  way the live edit path does, and marks collapsed rows `edited` so join
  replay can emit `+freeq.at/edited=1` — previously a message edited before
  you joined was indistinguishable from its original.
- CHATHISTORY still replays the full revision chain, linked. Search reports
  hits under root ids, and superseded revisions leave the index when an edit
  is made after the upgrade (the backfill does not rewrite existing
  search-index rows, so pre-upgrade revisions remain findable).

### Federation

Previously: a federated edit was persisted by the peer as a brand-new
duplicate message (the linkage tag is stripped by the S2S tag filter), deletes
never left the origin server at all, and a cross-server DM was assigned a
different msgid by each server — so nothing that names a message could work
across the hop.

- `S2sMessage::Privmsg` gains `replaces_msgid` and `S2sMessage::Tagmsg` gains
  `account` (origin-stamped actor DID, same trust shape as `Privmsg.account`).
  Both `serde(default)`: older peers ignore them and behave exactly as today,
  in both directions. No deploy coordination required.
- Edits cross as edits (peer revises its copy via the edit path); deletes are
  relayed and applied to the peer's storage behind authorization — author
  match by DID (nick only for rows with no DID), or the same roster-op check
  Kick/Mode use; DMs are author-only. A nick alone is never sufficient.
- `relay_to_nick` now carries the real msgid, signature, and coordination
  tags for cross-server DMs, so both servers hold the same message under the
  same id. (The relayed signature remains origin-attestation only — the
  signed timestamp still doesn't cross the hop; this brings DMs to parity
  with channel messages, no more.)
- Pre-existing rows don't heal retroactively: duplicates already created by
  federated edits remain as ordinary messages, and pre-existing cross-server
  DMs keep their split ids. Only new traffic gets the guarantees.

### Clients

web, macOS, iOS, and the TUI stop re-keying on edit — a message keeps the id
it was born with, which is the id the server files everything under. That
deletes the compensation machinery each client had grown (the TUI's
`edit_aliases` set, iOS's dictionary re-key bookkeeping, macOS pin
re-keying); transition arms that still match a superseded id are kept where
old cached rows can exist, commented with their removal condition. Android
never re-keyed — it already held the invariant — but its reaction handling
had two real defects fixed here: `+freeq.at/unreact` was not handled at all,
and un-reacting updated the screen without transmitting anything — its
reaction handling is now the same explicit, idempotent add/remove the other
clients use. All five
clients render the replay `edited` marker (natively via a new `edited` field
on the FFI message type).

Fixed in passing: macOS never requested DM history on opening a thread (DM
content and reactions were session-only there), and the tracked Kotlin FFI
bindings were stale by ~90 lines (missing `CoordinationEvent` entirely).

### Verification

- freeq-server: 1226 passed / 0 failed (default suite), federation e2e 11/11,
  including new adversarial cases: react→edit→un-react across both id
  directions, in channels and DMs; delete-by-edit-id no longer resurrects for
  a fresh joiner; forged federated deletes rejected (stranger, missing DID);
  cross-server DM identity equality; old-peer downgrade simulations.
- The three federation e2e tests for edit/delete/DM-identity were each proven
  non-vacuous by disabling their fix and reproducing the original failure.
- Clients: freeq-app 798, freeq-sdk-js 219, sdk-ffi 19, freeq-tui 90, Android
  unit suite — all green. Each native client verified on-device; web and TUI
  verified against a live deployed server (the TUI via a scripted terminal
  session with a wire-side observer).
- Deployed to irc.zerosum.org through the series; the migration ran on its
  production database, and the full matrix was re-verified live after each
  deploy stage.
