### PR TITLE
Fix the red tests — including two federation bugs they were hiding

### DIFF
--- a/freeq-server/src/s2s.rs
+++ b/freeq-server/src/s2s.rs
@@ -1223,6 +1223,31 @@ async fn handle_s2s_connection_from_manager(
     .await;
 }
 
+/// Which of two simultaneous links between the same pair of servers survives.
+///
+/// When both servers list each other in `--s2s-peers` — the natural
+/// configuration — each dials the other and the pair ends up holding two QUIC
+/// connections. Both must independently pick the *same* one to keep, or each
+/// keeps the one the other is tearing down: the loser's link task ends, its
+/// retry loop dials again, that new connection displaces the peer's entry, and
+/// the two servers trade teardowns forever. (Observed: 39 connection
+/// generations in 20 seconds, with no link stable long enough to carry a
+/// message.)
+///
+/// The rule is a total order on the pair, so it needs no negotiation: **the
+/// server with the lower endpoint ID keeps its outgoing connection**, and the
+/// one with the higher ID keeps its incoming. Both sides evaluate this and
+/// arrive at the same surviving connection.
+///
+/// Applied only when a duplicate actually exists. A server that is dialed but
+/// does not dial back has exactly one link, and must keep it whichever side of
+/// the ID comparison it falls on.
+fn duplicate_link_wins(my_id: &str, peer_id: &str, incoming: bool) -> bool {
+    // Lower ID keeps outgoing → for that side, an incoming duplicate loses.
+    // Higher ID keeps incoming → for that side, an outgoing duplicate loses.
+    incoming != (my_id < peer_id)
+}
+
 /// Handle an S2S connection (both incoming and outgoing).
 async fn handle_s2s_connection(
     conn: iroh::endpoint::Connection,
@@ -1257,17 +1282,25 @@ async fn handle_s2s_connection(
         }
     };
 
-    // Write channel — with duplicate connection tie-breaking.
-    // When both servers have each other in --s2s-peers, we get two QUIC
-    // connections (one outgoing, one incoming).  Deterministic rule:
-    //   The peer with the LOWER endpoint ID keeps its OUTGOING connection.
-    //   The peer with the HIGHER endpoint ID keeps the INCOMING connection.
-    // This means: drop if `incoming == (our_id < peer_id)`.
+    // Write channel — with duplicate connection tie-breaking. See
+    // `duplicate_link_wins`: both servers apply the same total order, so they
+    // keep the same connection instead of tearing down each other's.
     let (write_tx, mut write_rx) = mpsc::channel::<S2sMessage>(256);
     let my_gen = conn_gen.fetch_add(1, Ordering::Relaxed);
     {
         let mut peers_guard = peers.lock().await;
         if peers_guard.contains_key(&peer_id) {
+            if !duplicate_link_wins(&server_id, &peer_id, incoming) {
+                tracing::info!(
+                    peer = %peer_id, incoming, gen = my_gen,
+                    "S2S duplicate connection — yielding to the link both sides keep"
+                );
+                // Leave the map untouched: the surviving entry is the peer's,
+                // and the retry loop skips reconnecting while it is there.
+                drop(peers_guard);
+                conn.close(0u32.into(), b"duplicate link");
+                return;
+            }
             tracing::info!(
                 peer = %peer_id, incoming, gen = my_gen,
                 "S2S duplicate connection — replacing existing (generation-safe cleanup)"
@@ -1500,6 +1533,38 @@ async fn handle_s2s_connection(
 
 #[cfg(test)]
 mod tests {
+    /// Both sides of a duplicate must choose the same surviving link, or they
+    /// trade teardowns until one of them is restarted.
+    #[test]
+    fn duplicate_links_are_resolved_the_same_way_by_both_servers() {
+        let low = "aaaa";
+        let high = "bbbb";
+
+        // The low-ID server keeps its outgoing; the high-ID server keeps its
+        // incoming. Those are the same connection, seen from the two ends.
+        assert!(duplicate_link_wins(low, high, false), "low keeps outgoing");
+        assert!(duplicate_link_wins(high, low, true), "high keeps incoming");
+
+        // And each discards the other one — again, one connection, two ends.
+        assert!(!duplicate_link_wins(low, high, true), "low drops incoming");
+        assert!(!duplicate_link_wins(high, low, false), "high drops outgoing");
+    }
+
+    /// Exactly one of the two ends survives, for any pair of ids in any order.
+    #[test]
+    fn exactly_one_end_of_a_duplicate_survives() {
+        for (a, b) in [("aaa", "bbb"), ("bbb", "aaa"), ("a", "ab"), ("zz", "zza")] {
+            // The connection a→b: outgoing at `a`, incoming at `b`.
+            let a_to_b = duplicate_link_wins(a, b, false) && duplicate_link_wins(b, a, true);
+            // The connection b→a: outgoing at `b`, incoming at `a`.
+            let b_to_a = duplicate_link_wins(b, a, false) && duplicate_link_wins(a, b, true);
+            assert!(
+                a_to_b ^ b_to_a,
+                "({a}, {b}): exactly one direction must survive, got a→b={a_to_b} b→a={b_to_a}"
+            );
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2805,6 +2805,32 @@ fn federated_edit_authorized(
         .eq_ignore_ascii_case(actor_nick)
 }
 
+/// The channel entry for an S2S-learned channel, created with the mode set a
+/// channel is born with everywhere else (+nt: no external messages, topic
+/// locked to ops) if this is the first we have heard of it.
+///
+/// Four S2S handlers can bring a channel into existence — `Join`, `Topic`,
+/// `ChannelCreated`, `SyncResponse` — and only the last two applied the
+/// defaults. Worse, the origin sends `Join` *before* `ChannelCreated`, so by the
+/// time the explicit defaults arrived the channel already existed and they were
+/// skipped: in practice a peer-learned channel had no +n and no +t at all.
+/// A channel's protections must not depend on which event won a race, so every
+/// creation path goes through here.
+///
+/// Existing channels are returned untouched: a mode deliberately turned off
+/// stays off.
+fn s2s_channel_entry<'a>(
+    channels: &'a mut HashMap<String, ChannelState>,
+    channel: &str,
+) -> &'a mut ChannelState {
+    let is_new = !channels.contains_key(channel);
+    let ch = channels.entry(channel.to_string()).or_default();
+    if is_new {
+        ch.no_ext_msg = true;
+        ch.topic_locked = true;
+    }
+    ch}
+
 /// Process an incoming S2S message. Exposed as pub(crate) for adversarial testing.
 pub(crate) async fn process_s2s_message(
     state: &Arc<SharedState>,
@@ -3917,7 +3943,7 @@ pub(crate) async fn process_s2s_message(
             // Idempotent: set-based, don't assume not present
             {
                 let mut channels = state.channels.lock();
-                let ch = channels.entry(channel.clone()).or_default();
+                let ch = s2s_channel_entry(&mut channels, &channel);
                 // Consume invite (all forms: DID, nick)
                 if let Some(ref d) = did {
                     ch.invites.remove(d);
@@ -4035,7 +4061,7 @@ pub(crate) async fn process_s2s_message(
             // Apply locally for immediate UX (CRDT is authoritative if they diverge)
             {
                 let mut channels = state.channels.lock();
-                let ch = channels.entry(channel.clone()).or_default();
+                let ch = s2s_channel_entry(&mut channels, &channel);
                 ch.topic = Some(TopicInfo::new(topic.clone(), set_by.clone()));
             }
 
@@ -4054,13 +4080,7 @@ pub(crate) async fn process_s2s_message(
             let has_local_members;
             {
                 let mut channels = state.channels.lock();
-                let is_new = !channels.contains_key(&channel);
-                let ch = channels.entry(channel.clone()).or_default();
-                // New channels get +nt defaults
-                if is_new {
-                    ch.no_ext_msg = true;
-                    ch.topic_locked = true;
-                }
+                let ch = s2s_channel_entry(&mut channels, &channel);
 
                 // ── Authority gating ───────────────────────────────────
                 // Founder: only adopt if we have no local founder.
@@ -4261,13 +4281,7 @@ pub(crate) async fn process_s2s_message(
                 }
 
                 for info in remote_channels {
-                    let is_new = !channels.contains_key(&info.name);
-                    let ch = channels.entry(info.name.clone()).or_default();
-                    // New channels created via sync get +nt by default
-                    if is_new {
-                        ch.no_ext_msg = true;
-                        ch.topic_locked = true;
-                    }
+                    let ch = s2s_channel_entry(&mut channels, &info.name);
 
                     // ── Authority gating on sync ──────────────────────
                     // Merge founder: only adopt if we don't have one AND it's a valid DID
@@ -6529,6 +6543,141 @@ mod s2s_adversarial_tests {
     // ═══════════════════════════════════════════════════════════
     // S2S CHANNEL LENGTH LIMIT
     // ═══════════════════════════════════════════════════════════
+
+    // ── Channel defaults on S2S-learned channels ───────────────────
+    //
+    // A channel comes into existence with +nt everywhere. `ChannelCreated` and
+    // `SyncResponse` say so explicitly; `Join` and `Topic` can create a channel
+    // too, and left it with `ChannelState::default()` — no +n, no +t. Which
+    // meant the modes a channel had on a peer depended on which event happened
+    // to arrive first, and on the peer's copy anyone could set the topic and a
+    // non-member could talk.
+
+    /// The mode set a channel is born with, on any server that learns of it.
+    fn modes_of(state: &Arc<SharedState>, channel: &str) -> (bool, bool) {
+        let channels = state.channels.lock();
+        let ch = channels.get(channel).expect("channel exists");
+        (ch.no_ext_msg, ch.topic_locked)
+    }
+
+    async fn relay_join(state: &Arc<SharedState>, mgr: &Arc<S2sManager>, channel: &str, nick: &str) {
+        process_s2s_message(
+            state,
+            mgr,
+            PEER,
+            S2sMessage::Join {
+                event_id: format!("{PEER}:join-{channel}-{nick}"),
+                nick: nick.to_string(),
+                channel: channel.to_string(),
+                did: None,
+                handle: None,
+                is_op: false,
+                actor_class: None,
+                origin: PEER.to_string(),
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn s2s_join_creating_a_channel_applies_default_modes() {
+        let state = test_state();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+
+        relay_join(&state, &mgr, "#fedjoinmodes", "alice").await;
+
+        assert_eq!(
+            modes_of(&state, "#fedjoinmodes"),
+            (true, true),
+            "a channel learned from a peer's JOIN must be +nt, like one created here"
+        );
+    }
+
+    /// The order the origin actually sends in: `Join` first, then
+    /// `ChannelCreated`. So `ChannelCreated`'s own defaults never applied — by
+    /// the time it arrived the channel existed, and `is_new` was false.
+    #[tokio::test]
+    async fn s2s_join_before_channel_created_still_locks_the_topic() {
+        let state = test_state();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+
+        relay_join(&state, &mgr, "#fedorder", "alice").await;
+        process_s2s_message(
+            &state,
+            &mgr,
+            PEER,
+            S2sMessage::ChannelCreated {
+                event_id: format!("{PEER}:created"),
+                channel: "#fedorder".to_string(),
+                founder_did: None,
+                did_ops: vec![],
+                created_at: 0,
+                origin: PEER.to_string(),
+            },
+        )
+        .await;
+
+        assert_eq!(
+            modes_of(&state, "#fedorder"),
+            (true, true),
+            "the JOIN-then-ChannelCreated order left the channel with no protections"
+        );
+    }
+
+    /// A `Topic` for a channel we have never seen creates it too. Same rule.
+    #[tokio::test]
+    async fn s2s_topic_creating_a_channel_applies_default_modes() {
+        let state = test_state();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+
+        process_s2s_message(
+            &state,
+            &mgr,
+            PEER,
+            S2sMessage::Topic {
+                event_id: format!("{PEER}:topic"),
+                channel: "#fedtopicmodes".to_string(),
+                topic: "hello".to_string(),
+                set_by: "alice".to_string(),
+                origin: PEER.to_string(),
+            },
+        )
+        .await;
+
+        assert_eq!(
+            modes_of(&state, "#fedtopicmodes"),
+            (true, true),
+            "a channel learned from a peer's TOPIC must be +nt"
+        );
+    }
+
+    /// The defaults are for *new* channels only — a channel we already hold
+    /// keeps the modes it has, including ones deliberately turned off.
+    #[tokio::test]
+    async fn s2s_join_does_not_reimpose_defaults_on_an_existing_channel() {
+        let state = test_state();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+
+        setup_channel(&state, "#fedexisting");
+        {
+            let mut channels = state.channels.lock();
+            let ch = channels.get_mut("#fedexisting").unwrap();
+            ch.no_ext_msg = false;
+            ch.topic_locked = false;
+        }
+
+        relay_join(&state, &mgr, "#fedexisting", "alice").await;
+
+        assert_eq!(
+            modes_of(&state, "#fedexisting"),
+            (false, false),
+            "an existing channel's modes must not be reset by a peer's JOIN"
+        );
+    }
 
     #[tokio::test]
     async fn s2s_join_long_channel_name_truncated() {

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -195,8 +195,15 @@ async fn spawn_pair(ids: &[&TestId]) -> (TestServer, TestServer) {
     let serial = ONE_TEST_AT_A_TIME
         .lock()
         .unwrap_or_else(PoisonError::into_inner);
-    let a_plan = plan_server(0xA1);
-    let b_plan = plan_server(0xB2);
+    // A fresh iroh identity per pair. Every pair used to boot as the same two
+    // node IDs, so two pairs alive at once — the previous test's servers still
+    // exiting, or anything that runs this file without the lock above — were, to
+    // iroh, the same two nodes reachable at two addresses. The lock makes that
+    // rare rather than impossible; distinct identities make it harmless.
+    static NEXT_SEED: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(1);
+    let n = NEXT_SEED.fetch_add(2, std::sync::atomic::Ordering::Relaxed);
+    let a_plan = plan_server(n);
+    let b_plan = plan_server(n.wrapping_add(1));
     let resolver: String = ids
         .iter()
         .map(|i| i.resolver_entry())

--- a/freeq-server/tests/oauth_ssrf.rs
+++ b/freeq-server/tests/oauth_ssrf.rs
@@ -122,6 +122,27 @@ async fn ctf_07_step_up_refuses_loopback_pds_url() {
     // internal address back to the attacker.
     let (http, _state, _h) = start_server_with_malicious_pds("http://127.0.0.1:1/").await;
 
+    // Warm the process first. The refusal itself takes well under a
+    // millisecond, but the *first* outbound-client construction in a process
+    // pays a one-time cost (on macOS, loading the system TLS trust store) of
+    // seconds. Measuring that made this assertion a coin flip against its own 3s
+    // budget — it failed under load while the code under test was doing exactly
+    // the right thing, sub-millisecond. Warmed, the same request is ~0.5ms, so
+    // the budget below can be tight enough to actually catch a connect-then-fail.
+    let warm = reqwest::Client::new()
+        .get(url(
+            http,
+            &format!("/auth/step-up?purpose=blob_upload&did={VICTIM_DID}"),
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        warm.status().is_client_error(),
+        "warm-up request should already be refused: {}",
+        warm.status()
+    );
+
     let started = Instant::now();
     let resp = reqwest::Client::new()
         .get(url(
@@ -141,7 +162,7 @@ async fn ctf_07_step_up_refuses_loopback_pds_url() {
         "step-up to a loopback PDS must be refused with a 4xx; got {status}: {body}"
     );
     assert!(
-        elapsed < Duration::from_secs(3),
+        elapsed < Duration::from_millis(500),
         "step-up to a loopback PDS must fail fast (URL validation, not connect-then-fail); \
          elapsed = {elapsed:?}"
     );

--- a/freeq-server/tests/s2s_acceptance.rs
+++ b/freeq-server/tests/s2s_acceptance.rs
@@ -18,11 +18,14 @@
 //! Channel names use `#_zqtest_` prefix + timestamp to avoid collisions
 //! with real channels on live servers.
 
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
+use freeq_sdk::auth::{ChallengeSigner, KeySigner};
 use freeq_sdk::client::{self, ClientHandle, ConnectConfig};
+use freeq_sdk::crypto::PrivateKey;
 use freeq_sdk::event::Event;
 
 /// How long to wait for an event before considering it failed.
@@ -34,7 +37,139 @@ const S2S_TIMEOUT: Duration = Duration::from_secs(30);
 /// Time to let S2S state propagate after a JOIN/PART/etc.
 const S2S_SETTLE: Duration = Duration::from_secs(3);
 
+// ── Test identities ──────────────────────────────────────────────
+//
+// Channel authority in freeq is DID-anchored. A peer's `is_op` claim is never
+// trusted across a hop (C-2 in docs/SECURITY-AUDIT-2026-03-29.md: "Never trust
+// `is_op` from peers … derive op status from local channel state"), and the
+// state that *does* cross is `founder_did` / `did_ops`. A guest has no DID, so a
+// guest cannot hold authority anywhere but on the server they are connected to.
+//
+// Every test whose subject is an op action crossing a hop — topic on +t, MODE,
+// invites — therefore has to authenticate. `connect_guest` is still right for
+// tests about plain messaging, presence, and history.
+
+/// One authenticated identity per test that needs one, keyed by the test's own
+/// tag. Fixed ed25519 seeds, so the DIDs and their public keys are reproducible
+/// and can be handed to the servers on the command line before the tests start.
+///
+/// One per test, not a shared pool: two sessions on the same DID are *one*
+/// identity with two devices, which is correct behavior and exactly wrong for a
+/// test. Sharing a DID made a test see the previous test's nick in NAMES, and
+/// only when the suite ran in order — the kind of failure that looks like
+/// flakiness.
+///
+/// `(tag, seed, publicKeyMultibase)`. The multibase is duplicated in
+/// `scripts/run-s2s-tests.sh`, which has to pass these to the servers before any
+/// test runs; `static_identities_match_the_harness` fails if they drift.
+const TEST_IDS: [(&str, u8, &str); 12] = [
+    ("tsync", 0x51, "z6MksPykuQeYh4zgthFRFBExrgo1dwFWWenY2TEJ9SvT9jn1"),
+    ("rtop", 0x52, "z6MkgcTiPMbTofzVghWywkKDM7SeNYnG4jPbFxerG2rVnV8A"),
+    ("toppers", 0x53, "z6Mkw9YUWaWMuG7ZMhwtpfEytLaMZjiaxYnXe9SxDQHN64sy"),
+    ("top1", 0x54, "z6MkqB3fVxzXFbVUK2q1GPrLQzaxgwDGGVuxkDzaf5tsLnpo"),
+    ("top3", 0x55, "z6Mksp9sfVKVpWAi43niHLXfGQ5NdCTEoiycLmrLPehquVqK"),
+    ("sy2", 0x56, "z6MkofZ1WuSJkd6UMyevdzsBVrhCtmpcq53cWATRc3jRYAxJ"),
+    ("sy3", 0x57, "z6MksvxZ2oR6ogBgsCwsDSiPi3F84SDNn1yCQdVDHf5zKtKp"),
+    ("inv2", 0x58, "z6MkuBDVJTuuJUJSC4XSVeHU6ZgTqcUZM6CkCYxSJ2jNRFSr"),
+    ("inv3", 0x59, "z6MkqzWvFQiKjiXi57aaSdAkYE7WbxVw8ymXA4BMshHYghPh"),
+    ("inv7", 0x5a, "z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD"),
+    ("inv10", 0x5b, "z6MkmghdggH9iwAwmMypZmN9EsfPGwsbvmum2HkFWXVzrAeE"),
+    ("sinv", 0x5c, "z6MkvS2fUtMaVsmMNMMgGzvgSCu7j11e1cvvykBcEvyvz3xW"),
+];
+
+/// One of the fixed test identities. `did:key:<multibase>` — self-certifying, so
+/// the static resolver entry is just the key repeated.
+struct TestId {
+    did: String,
+    seed: u8,
+}
+
+impl TestId {
+    /// The identity belonging to `tag` — use the test's own channel tag, so each
+    /// test has its own user and no two tests can collide on one DID.
+    fn for_test(tag: &str) -> Self {
+        let (_, seed, multibase) = TEST_IDS
+            .iter()
+            .find(|(t, _, _)| *t == tag)
+            .unwrap_or_else(|| panic!("no test identity registered for {tag:?}; add one to TEST_IDS and to scripts/run-s2s-tests.sh"));
+        TestId {
+            did: format!("did:key:{multibase}"),
+            seed: *seed,
+        }
+    }
+
+    /// A fresh signer over the same key (`KeySigner` consumes the key).
+    fn signer(&self) -> Arc<dyn ChallengeSigner> {
+        let key = PrivateKey::ed25519_from_bytes(&[self.seed; 32]).unwrap();
+        Arc::new(KeySigner::new(self.did.clone(), key))
+    }
+}
+
+/// The identities above are duplicated in `scripts/run-s2s-tests.sh`, which has
+/// to pass them to the servers before any test runs. Nothing prevents the two
+/// from drifting except this.
+#[test]
+fn static_identities_match_the_harness() {
+    let script = include_str!("../../scripts/run-s2s-tests.sh");
+    for (tag, seed, multibase) in TEST_IDS {
+        let key = PrivateKey::ed25519_from_bytes(&[seed; 32]).unwrap();
+        assert_eq!(
+            &key.public_key_multibase(),
+            multibase,
+            "TEST_IDS[{tag}] no longer matches seed {seed:#04x}; update scripts/run-s2s-tests.sh too"
+        );
+        assert!(
+            script.contains(multibase),
+            "scripts/run-s2s-tests.sh does not pass {tag}'s key ({multibase}) to the servers"
+        );
+    }
+
+    let mut seeds: Vec<u8> = TEST_IDS.iter().map(|(_, s, _)| *s).collect();
+    seeds.sort_unstable();
+    let before = seeds.len();
+    seeds.dedup();
+    assert_eq!(
+        seeds.len(), before,
+        "two tests share a seed, so they share a DID, so they are one identity with two devices"
+    );
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
+
+/// Connect a DID-authenticated user, returning handle + event receiver.
+/// Waits for SASL success, so the caller knows authority is in place.
+async fn connect_authed(
+    addr: &str,
+    nick: &str,
+    id: &TestId,
+) -> (ClientHandle, mpsc::Receiver<Event>) {
+    let config = ConnectConfig {
+        server_addr: addr.to_string(),
+        nick: nick.to_string(),
+        user: nick.to_string(),
+        realname: format!("S2S Test ({nick})"),
+        tls: false,
+        tls_insecure: false,
+        ..Default::default()
+    };
+    let (h, mut rx) = client::connect(config, Some(id.signer()));
+    // SASL completes during registration, so `Authenticated` precedes
+    // `Registered`. Wait for both: authority is in place at the first, and the
+    // session accepts commands at the second.
+    let authed = maybe_wait(
+        &mut rx,
+        |e| matches!(e, Event::Authenticated { .. }),
+        Duration::from_secs(20),
+    )
+    .await;
+    assert!(
+        authed.is_some(),
+        "{nick} never authenticated as {} — is --did-resolver-static set on this server?",
+        id.did
+    );
+    wait_registered(&mut rx).await;
+    (h, rx)
+}
 
 /// Connect a guest user to a server, returning handle + event receiver.
 async fn connect_guest(addr: &str, nick: &str) -> (ClientHandle, mpsc::Receiver<Event>) {
@@ -1165,10 +1300,11 @@ async fn s2s_topic_syncs() {
     let nick_a = test_nick("tsync", "a");
     let nick_b = test_nick("tsync", "b");
 
-    let (h1, mut e1) = connect_guest(&local, &nick_a).await;
+    // A authenticates: the topic is being set on a +t channel and has to be
+    // honoured on the far side, which only a DID-anchored op can do (C-2).
+    let (h1, mut e1) = connect_authed(&local, &nick_a, &TestId::for_test("tsync")).await;
     let (h2, mut e2) = connect_guest(&remote, &nick_b).await;
 
-    wait_registered(&mut e1).await;
     wait_registered(&mut e2).await;
 
     h1.join(&channel).await.unwrap();
@@ -1632,9 +1768,9 @@ async fn s2s_topic_persists_across_reconnect() {
     let nick_b = test_nick("tp", "b");
     let nick_c = test_nick("tp", "c");
 
-    let (ha, mut ea) = connect_guest(&local, &nick_a).await;
+    // A sets the topic, so A authenticates (see C-2).
+    let (ha, mut ea) = connect_authed(&local, &nick_a, &TestId::for_test("toppers")).await;
     let (hb, mut eb) = connect_guest(&remote, &nick_b).await;
-    wait_registered(&mut ea).await;
     wait_registered(&mut eb).await;
 
     ha.join(&channel).await.unwrap();
@@ -1786,10 +1922,11 @@ async fn s2s_topic_set_from_remote() {
     let nick_a = test_nick("rtop", "a");
     let nick_b = test_nick("rtop", "b");
 
+    // B sets the topic on a +t channel, so B needs a DID: op authority is
+    // DID-anchored and does not cross a hop for a guest (C-2).
     let (ha, mut ea) = connect_guest(&local, &nick_a).await;
-    let (hb, mut eb) = connect_guest(&remote, &nick_b).await;
+    let (hb, mut eb) = connect_authed(&remote, &nick_b, &TestId::for_test("rtop")).await;
     wait_registered(&mut ea).await;
-    wait_registered(&mut eb).await;
 
     ha.join(&channel).await.unwrap();
     hb.join(&channel).await.unwrap();
@@ -2264,9 +2401,12 @@ async fn s2s_inv3_creator_is_op_everywhere() {
     let nick_a = test_nick("inv3", "a");
     let nick_b = test_nick("inv3", "b");
 
-    // A creates channel on local
-    let (ha, mut ea) = connect_guest(&local, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A creates the channel on local, authenticated: a creator is op on the
+    // *other* server only through their DID. `ChannelCreated` carries
+    // `founder_did`, and the peer derives op from it; a guest creator has no DID
+    // to carry, and a peer-asserted `is_op` is never trusted (C-2). So this
+    // test is only meaningful for an authenticated creator.
+    let (ha, mut ea) = connect_authed(&local, &nick_a, &TestId::for_test("inv3")).await;
     ha.join(&channel).await.unwrap();
     wait_joined(&mut ea, &channel).await;
 
@@ -2470,8 +2610,9 @@ async fn s2s_inv7_mode_propagates() {
     let nick_a = test_nick("inv7", "a");
     let nick_b = test_nick("inv7", "b");
 
-    let (ha, mut ea) = connect_guest(&local, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A sets a mode, so A authenticates: a MODE from a guest "op" is refused on
+    // the far server (C-2).
+    let (ha, mut ea) = connect_authed(&local, &nick_a, &TestId::for_test("inv7")).await;
     ha.join(&channel).await.unwrap();
     wait_joined(&mut ea, &channel).await;
 
@@ -2615,9 +2756,11 @@ async fn s2s_inv10_remote_creator_sole_op_local_joiner_no_ops() {
     let nick_a = test_nick("inv10", "a");
     let nick_b = test_nick("inv10", "b");
 
-    // A creates channel on REMOTE server (A is founder/op)
-    let (ha, mut ea) = connect_guest(&remote, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A creates the channel on REMOTE (A is founder/op) and authenticates: the
+    // assertion below is that A's op status is visible on the *local* server,
+    // which travels as `founder_did`. A guest founder has no DID to travel, and
+    // a peer's `is_op` claim is never trusted (C-2).
+    let (ha, mut ea) = connect_authed(&remote, &nick_a, &TestId::for_test("top1")).await;
     ha.join(&channel).await.unwrap();
     wait_joined(&mut ea, &channel).await;
 
@@ -3514,7 +3657,9 @@ async fn s2s_sync2_remote_topic_visible_locally() {
     // B sets the topic — A should see it.
     //
     // Note: B must be an op to set topic (channels default to +t).
-    // We make B the creator so B is op on their home server.
+    // We make B the creator so B is op on their home server — and B
+    // authenticates, because an op's authority reaches the other server only
+    // through their DID (C-2).
     let Some((local, remote)) = get_servers() else {
         return;
     };
@@ -3523,8 +3668,7 @@ async fn s2s_sync2_remote_topic_visible_locally() {
     let nick_b = test_nick("sy2", "b");
 
     // B creates channel on remote (B is op)
-    let (hb, mut eb) = connect_guest(&remote, &nick_b).await;
-    wait_registered(&mut eb).await;
+    let (hb, mut eb) = connect_authed(&remote, &nick_b, &TestId::for_test("sy2")).await;
     hb.join(&channel).await.unwrap();
     wait_joined(&mut eb, &channel).await;
 
@@ -3571,9 +3715,9 @@ async fn s2s_sync3_remote_mode_propagates() {
     let nick_a = test_nick("sy3", "a");
     let nick_b = test_nick("sy3", "b");
 
-    // B creates channel on remote (gets ops)
-    let (hb, mut eb) = connect_guest(&remote, &nick_b).await;
-    wait_registered(&mut eb).await;
+    // B creates the channel on remote and sets a mode on it, so B needs a DID:
+    // a MODE from a guest "op" is refused on the far server (C-2).
+    let (hb, mut eb) = connect_authed(&remote, &nick_b, &TestId::for_test("sy3")).await;
     hb.join(&channel).await.unwrap();
     wait_joined(&mut eb, &channel).await;
 
@@ -4610,9 +4754,10 @@ async fn s2s_topic1_remote_op_sets_topic_on_plus_t() {
     let nick_a = test_nick("top1", "a");
     let nick_b = test_nick("top1", "b");
 
-    // A creates channel on remote (gets ops, channel defaults to +t)
-    let (ha, mut ea) = connect_guest(&remote, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A creates channel on remote (gets ops, channel defaults to +t) and
+    // authenticates — the topic has to be honoured on the *other* server, and
+    // only a DID-anchored op carries authority across a hop (C-2).
+    let (ha, mut ea) = connect_authed(&remote, &nick_a, &TestId::for_test("inv10")).await;
     ha.join(&channel).await.unwrap();
     wait_joined(&mut ea, &channel).await;
 
@@ -4721,8 +4866,8 @@ async fn s2s_topic3_topic_visible_to_late_joiner() {
     let nick_a = test_nick("top3", "a");
     let nick_b = test_nick("top3", "b");
 
-    let (ha, mut ea) = connect_guest(&local, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A sets the topic, so A authenticates (see C-2).
+    let (ha, mut ea) = connect_authed(&local, &nick_a, &TestId::for_test("top3")).await;
     ha.join(&channel).await.unwrap();
     wait_joined(&mut ea, &channel).await;
 
@@ -5332,9 +5477,11 @@ async fn s2s_inv2_remote_guest_blocked_from_invite_only_without_invite() {
     let nick_b = format!("InvD{ts}");
     let channel = format!("#inv2{ts}");
 
-    // A creates +i channel on local
-    let (ha, mut ea) = connect_guest(&local, &nick_a).await;
-    wait_registered(&mut ea).await;
+    // A creates the +i channel on local, authenticated: +i only protects the
+    // channel on the *other* server if the MODE crosses, and a mode set by a
+    // guest "op" is refused there (C-2). Unauthenticated, this test asserts a
+    // block that cannot happen.
+    let (ha, mut ea) = connect_authed(&local, &nick_a, &TestId::for_test("inv2")).await;
     ha.join(&channel).await.unwrap();
     wait_for(&mut ea, |evt| matches!(evt, Event::Joined { .. }), "A join").await;
     drain(&mut ea).await;
@@ -7546,11 +7693,25 @@ async fn s2s_invite_syncs_across_servers() {
     let nick_op = test_nick("sinv", "op");
     let nick_guest = test_nick("sinv", "g");
 
-    // Op connects to local server, guest to remote
-    let (h_op, mut e_op) = connect_guest(&local, &nick_op).await;
+    // Op connects to local server, guest to remote. The op authenticates: both
+    // halves of this test cross a hop (the +i mode, then the invite), and
+    // neither is honoured on the far side for a guest "op" (C-2).
+    let (h_op, mut e_op) = connect_authed(&local, &nick_op, &TestId::for_test("sinv")).await;
     let (h_g, mut e_g) = connect_guest(&remote, &nick_guest).await;
-    wait_registered(&mut e_op).await;
     wait_registered(&mut e_g).await;
+
+    // A server can only invite a nick it has heard of: `resolve_network_target`
+    // knows local sessions and the remote members of channels it holds, and
+    // nothing else — there is no network-wide nick directory to consult. A
+    // remote user who has never shared a channel is `Unknown`, and INVITE
+    // answers 401. So give the two a shared channel first, which is also how
+    // this happens in practice: you invite someone you have seen.
+    let lobby = test_channel("sinvlobby");
+    h_op.join(&lobby).await.unwrap();
+    wait_joined(&mut e_op, &lobby).await;
+    h_g.join(&lobby).await.unwrap();
+    wait_joined(&mut e_g, &lobby).await;
+    tokio::time::sleep(S2S_SETTLE).await;
 
     // Op creates channel and sets +i
     h_op.join(&channel).await.unwrap();

--- a/freeq-server/tests/s2s_acceptance.rs
+++ b/freeq-server/tests/s2s_acceptance.rs
@@ -63,6 +63,35 @@ async fn connect_guest(addr: &str, nick: &str) -> (ClientHandle, mpsc::Receiver<
     client::connect_with_stream(conn, config, None)
 }
 
+/// Drain every `Message` whose text starts with `prefix`, pushing each one's
+/// `msgid` tag onto `out`. Stops when the stream goes quiet.
+async fn collect_msgids(rx: &mut mpsc::Receiver<Event>, prefix: &str, out: &mut Vec<String>) {
+    let p = prefix.to_string();
+    while let Some(Event::Message { tags, .. }) = maybe_wait(
+        rx,
+        |e| matches!(e, Event::Message { text, .. } if text.starts_with(&p)),
+        Duration::from_secs(3),
+    )
+    .await
+    {
+        match tags.get("msgid") {
+            Some(mid) => out.push(mid.clone()),
+            None => panic!("delivered message carried no msgid tag"),
+        }
+    }
+}
+
+/// Prove the session still works after something odd was sent on it: join a
+/// fresh channel and see the JOIN come back. Used by the tests whose subject is
+/// "this input must not take the connection down" — without it they assert only
+/// that no error arrived, which an already-dead session also satisfies.
+async fn assert_session_alive(h: &ClientHandle, rx: &mut mpsc::Receiver<Event>, tag: &str) {
+    let probe = test_channel(&format!("{tag}alive"));
+    h.join(&probe).await.expect("session accepted a JOIN");
+    wait_joined(rx, &probe).await;
+    let _ = h.raw(&format!("PART {probe}")).await;
+}
+
 /// Wait for a specific event, ignoring others.
 async fn wait_for<F: Fn(&Event) -> bool>(
     rx: &mut mpsc::Receiver<Event>,
@@ -6631,18 +6660,39 @@ async fn single_server_dm2_dm_to_offline_user() {
     // Send DM to non-existent nick
     ha.privmsg(&nick_offline, "hello?").await.unwrap();
 
-    // Should get ERR_NOSUCHNICK (401) as a ServerNotice or similar
+    // Two outcomes are correct, and which one you get depends on the topology,
+    // not on this code path being right:
+    //   - No S2S peers: ERR_NOSUCHNICK (401).
+    //   - With S2S peers: relayed, because this server cannot know whether the
+    //     nick exists on a peer. Same rule PM-2 and ROUTE-2 document.
+    // This harness peers LOCAL_SERVER with a second server, so the relay is the
+    // expected path here. What must hold either way is that the session
+    // survives — that is the test's subject ("don't crash").
+    //
+    // A 401 surfaces as `WhoisReply`, not `ServerNotice`: the SDK gives numeric
+    // 401 its own arm for WHOIS failures, so it never reaches the generic
+    // 4xx→ServerNotice fallback. Accept either, since a 401 answering a PRIVMSG
+    // and a 401 answering a WHOIS are indistinguishable on the wire.
     let got_error = maybe_wait(
         &mut ea,
-        |e| matches!(e, Event::ServerNotice { text } if text.contains("No such nick") || text.contains(&nick_offline)),
+        |e| match e {
+            Event::ServerNotice { text } => {
+                text.contains("No such nick") || text.contains(&nick_offline)
+            }
+            Event::WhoisReply { info, .. } => info.contains("No such nick"),
+            _ => false,
+        },
         Duration::from_secs(3),
     )
     .await;
-    assert!(
-        got_error.is_some(),
-        "Should receive error for DM to offline user"
-    );
-    eprintln!("  ✓ DM to offline user returns error without crash");
+    if got_error.is_some() {
+        eprintln!("  ✓ DM to offline user returned ERR_NOSUCHNICK");
+    } else {
+        eprintln!("  ✓ DM to offline user relayed to peers (federation active)");
+    }
+
+    assert_session_alive(&ha, &mut ea, "dm2").await;
+    eprintln!("  ✓ DM to offline user left the session usable");
 
     let _ = ha.quit(Some("done")).await;
 }
@@ -6799,36 +6849,54 @@ async fn single_server_edge14_rapid_messages_unique_msgids() {
     drain(&mut ea).await;
     drain(&mut eb).await;
 
-    // Send 20 rapid messages
-    for i in 0..20 {
-        ha.privmsg(&ch, &format!("rapid-{i}")).await.unwrap();
-    }
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
-    // Collect msgids from B's perspective
+    // Flood protection is 5 messages per 2 seconds per session, and it is not
+    // incidental — it is the defense against a single connection saturating a
+    // channel. A 20-message burst therefore *must* be clipped: expecting most of
+    // it through (the old ">= 10") asserted the absence of the protection.
+    //
+    // Two things are worth pinning here, so do both: the burst is refused rather
+    // than silently swallowed, and every message that is accepted — burst or not
+    // — carries its own msgid.
     let mut msgids = Vec::new();
-    loop {
-        match maybe_wait(
-            &mut eb,
-            |e| matches!(e, Event::Message { text, .. } if text.starts_with("rapid-")),
-            Duration::from_secs(3),
-        )
-        .await
-        {
-            Some(Event::Message { tags, .. }) => {
-                if let Some(mid) = tags.get("msgid") {
-                    msgids.push(mid.clone());
-                }
-            }
-            _ => break,
-        }
-    }
 
+    for i in 0..20 {
+        ha.privmsg(&ch, &format!("burst-{i}")).await.unwrap();
+    }
+    let flood_reply = maybe_wait(
+        &mut ea,
+        |e| matches!(e, Event::ServerNotice { text } if text.contains("Flood protection")),
+        Duration::from_secs(3),
+    )
+    .await;
     assert!(
-        msgids.len() >= 10,
-        "Should receive at least 10 rapid messages, got {}",
-        msgids.len()
+        flood_reply.is_some(),
+        "a 20-message burst must draw the flood-protection reply"
     );
+    collect_msgids(&mut eb, "burst-", &mut msgids).await;
+    let from_burst = msgids.len();
+    assert!(
+        (1..=10).contains(&from_burst),
+        "the burst should be clipped to roughly the 5/2s allowance, got {from_burst} of 20"
+    );
+    eprintln!("  ✓ 20-message burst clipped to {from_burst} by flood protection");
+
+    // Now the same volume inside the allowance: 4 per 2s window. Every one of
+    // these must arrive — that is the half of the original intent worth keeping.
+    let paced = 12;
+    for i in 0..paced {
+        if i > 0 && i % 4 == 0 {
+            tokio::time::sleep(Duration::from_millis(2100)).await;
+        }
+        ha.privmsg(&ch, &format!("paced-{i}")).await.unwrap();
+    }
+    let mut paced_ids = Vec::new();
+    collect_msgids(&mut eb, "paced-", &mut paced_ids).await;
+    assert_eq!(
+        paced_ids.len(),
+        paced,
+        "every message sent inside the flood allowance must be delivered"
+    );
+    msgids.extend(paced_ids);
 
     // All msgids should be unique
     let unique: std::collections::HashSet<&str> = msgids.iter().map(|s| s.as_str()).collect();
@@ -6925,9 +6993,17 @@ async fn single_server_edge16_nick_change_mid_conversation() {
 
     // A sends message with new nick
     ha.privmsg(&ch, "after-change").await.unwrap();
-    let (from, text) = wait_message_from(&mut eb, &nick_a2).await;
+    // `wait_message_from` already asserts the sender (it waits for a Message
+    // whose `from` is `nick_a2`) and returns `(target, text)`. The old binding
+    // named the target `from` and then compared it to the nick, so the assert
+    // read "the channel equals the new nick" and failed on every run.
+    let (target, text) = wait_message_from(&mut eb, &nick_a2).await;
     assert_eq!(text, "after-change");
-    assert_eq!(from, nick_a2);
+    assert_eq!(
+        target.to_lowercase(),
+        ch.to_lowercase(),
+        "post-rename message must still land in the channel"
+    );
     eprintln!("  ✓ Messages delivered correctly after nick change");
 
     let _ = ha.quit(Some("done")).await;
@@ -7103,14 +7179,21 @@ async fn single_server_edge20_message_to_long_nick() {
     let long_nick = "x".repeat(100);
     ha.privmsg(&long_nick, "hello").await.unwrap();
 
-    // Should get ERR_NOSUCHNICK or similar, not crash
+    // An error is welcome but not guaranteed: with an S2S peer attached the
+    // server relays an unknown DM target rather than answering 401 (see DM-2),
+    // and a 100-character nick is just an unknown target. "Handled gracefully"
+    // is therefore about the session, not about a reply arriving — so check the
+    // session, which is what the test is named for.
     let result = maybe_wait(
         &mut ea,
-        |e| matches!(e, Event::ServerNotice { .. }),
+        |e| matches!(e, Event::ServerNotice { .. } | Event::WhoisReply { .. }),
         Duration::from_secs(3),
     )
     .await;
-    assert!(result.is_some(), "Should get error for invalid nick");
+    if result.is_some() {
+        eprintln!("  ✓ absurdly long nick drew an error reply");
+    }
+    assert_session_alive(&ha, &mut ea, "edge20").await;
     eprintln!("  ✓ DM to absurdly long nick handled gracefully");
 
     let _ = ha.quit(Some("done")).await;

--- a/scripts/run-s2s-tests.sh
+++ b/scripts/run-s2s-tests.sh
@@ -17,6 +17,18 @@ set -euo pipefail
 
 PORT_A=16667
 PORT_B=16668
+
+# Test identities, resolvable offline so the suite can authenticate without the
+# network. Channel authority in freeq is DID-anchored (see C-2 in
+# docs/SECURITY-AUDIT-2026-03-29.md: a peer's `is_op` claim is never trusted, op
+# status is derived from founder_did / did_ops), so any test about ops, modes,
+# topics or invites crossing a hop has to log in as a DID, not as a guest.
+#
+# Each entry is `did=<publicKeyMultibase>` for an ed25519 key seeded with a fixed
+# byte, so the values are reproducible. They are duplicated in
+# freeq-server/tests/s2s_acceptance.rs (`TEST_IDS`, one identity per test), and
+# `static_identities_match_the_harness` fails if the two ever drift.
+STATIC_DIDS="did:key:z6MksPykuQeYh4zgthFRFBExrgo1dwFWWenY2TEJ9SvT9jn1=z6MksPykuQeYh4zgthFRFBExrgo1dwFWWenY2TEJ9SvT9jn1,did:key:z6MkgcTiPMbTofzVghWywkKDM7SeNYnG4jPbFxerG2rVnV8A=z6MkgcTiPMbTofzVghWywkKDM7SeNYnG4jPbFxerG2rVnV8A,did:key:z6Mkw9YUWaWMuG7ZMhwtpfEytLaMZjiaxYnXe9SxDQHN64sy=z6Mkw9YUWaWMuG7ZMhwtpfEytLaMZjiaxYnXe9SxDQHN64sy,did:key:z6MkqB3fVxzXFbVUK2q1GPrLQzaxgwDGGVuxkDzaf5tsLnpo=z6MkqB3fVxzXFbVUK2q1GPrLQzaxgwDGGVuxkDzaf5tsLnpo,did:key:z6Mksp9sfVKVpWAi43niHLXfGQ5NdCTEoiycLmrLPehquVqK=z6Mksp9sfVKVpWAi43niHLXfGQ5NdCTEoiycLmrLPehquVqK,did:key:z6MkofZ1WuSJkd6UMyevdzsBVrhCtmpcq53cWATRc3jRYAxJ=z6MkofZ1WuSJkd6UMyevdzsBVrhCtmpcq53cWATRc3jRYAxJ,did:key:z6MksvxZ2oR6ogBgsCwsDSiPi3F84SDNn1yCQdVDHf5zKtKp=z6MksvxZ2oR6ogBgsCwsDSiPi3F84SDNn1yCQdVDHf5zKtKp,did:key:z6MkuBDVJTuuJUJSC4XSVeHU6ZgTqcUZM6CkCYxSJ2jNRFSr=z6MkuBDVJTuuJUJSC4XSVeHU6ZgTqcUZM6CkCYxSJ2jNRFSr,did:key:z6MkqzWvFQiKjiXi57aaSdAkYE7WbxVw8ymXA4BMshHYghPh=z6MkqzWvFQiKjiXi57aaSdAkYE7WbxVw8ymXA4BMshHYghPh,did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD=z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD,did:key:z6MkmghdggH9iwAwmMypZmN9EsfPGwsbvmum2HkFWXVzrAeE=z6MkmghdggH9iwAwmMypZmN9EsfPGwsbvmum2HkFWXVzrAeE,did:key:z6MkvS2fUtMaVsmMNMMgGzvgSCu7j11e1cvvykBcEvyvz3xW=z6MkvS2fUtMaVsmMNMMgGzvgSCu7j11e1cvvykBcEvyvz3xW"
 DIR_A=$(mktemp -d)
 DIR_B=$(mktemp -d)
 LOG_A="$DIR_A/server.log"
@@ -56,6 +68,7 @@ RUST_LOG=freeq_server=info "$BINARY" \
     --server-name "server-a" \
     --data-dir "$DIR_A" \
     --db-path "$DIR_A/irc.db" \
+    --did-resolver-static "$STATIC_DIDS" \
     --iroh \
     >> "$LOG_A" 2>&1 &
 PID_A=$!
@@ -86,6 +99,7 @@ RUST_LOG=freeq_server=info "$BINARY" \
     --server-name "server-b" \
     --data-dir "$DIR_B" \
     --db-path "$DIR_B/irc.db" \
+    --did-resolver-static "$STATIC_DIDS" \
     --iroh \
     --s2s-peers "$IROH_ID_A" \
     --s2s-allowed-peers "$IROH_ID_A" \


### PR DESCRIPTION
The suite had 16 failing acceptance tests, 5 of 11 federation e2e tests failing at random, and one flaky OAuth test. Two of those were real product bugs; the rest were tests asserting things the server never promised.

## Product bugs

**`62d5a945` — the S2S duplicate-link tie-break was documented but never implemented.** The rule was written down in `s2s.rs`:

> The peer with the LOWER endpoint ID keeps its OUTGOING connection. The peer with the HIGHER endpoint ID keeps the INCOMING. This means: drop if `incoming == (our_id < peer_id)`.

No code applied it. Both connections registered, each overwriting the other's peer-map entry; the displaced link's task ended, which the retry loop reads as "link dropped, will reconnect" — so it dialed again and displaced the peer's entry, forever. Measured on a two-server pair: **39 connection generations in 20 seconds**, no link alive long enough to carry a message. Federation between two mutually-peered servers — the natural configuration, and what `tests/federation.rs` sets up — did not work; it only looked *intermittent* because a message occasionally landed inside a generation's lifetime.

The rule is now `duplicate_link_wins`, a total order on the pair, so both ends pick the same survivor with no negotiation. Applied only when a duplicate is actually present, so a server that is dialed but does not dial back keeps its single link either way. Two unit tests, including one asserting exactly one end of the pair survives for arbitrary id orderings.

**`efb1cc9e` — a channel learned from a peer wasn't born with +nt.** Four S2S handlers can create a channel; only `ChannelCreated` and `SyncResponse` applied the defaults — and since the origin broadcasts `Join` *first*, even those were dead code in the common path. On the peer's copy anyone could set the topic and a non-member could talk into the channel, and which behavior you got depended on which event won a race. It also explains why `s2s_topic1` passed while `s2s_topic_syncs` failed on identical logic. All four paths now go through one `s2s_channel_entry`; four unit tests.

## Tests that were wrong

**`35c5918e`** — 12 acceptance tests asserted op actions (topic on +t, MODE, invites, being op) taking effect across a hop *as guests*. That has been impossible since audit fix **C-2** ("never trust `is_op` from peers … derive op status from local channel state"): authority travels as `founder_did`/`did_ops`, and a guest has no DID. They were exercising the wrong user class, so they now authenticate — one DID per test, because two sessions on one DID are one identity with two devices (sharing a DID made a test read the *previous* test's nick out of NAMES, and only when the suite ran in order). Adds `--did-resolver-static` to the harness plus a drift guard between the script and the constants. One test also invited a remote user the local server had never heard of — INVITE resolves nicks through local sessions and remote members of channels it holds, so the reply was 401, never 341; the two users now share a channel first.

**`592f95a4`** — four single-server tests. `wait_message_from` returns `(target, text)` and one destructured it as `(from, …)`, so it compared a channel name to a nick and could never pass. Another required 10 of a 20-message burst through when flood protection deliberately clips at 5 — that bound asserted the *absence* of the protection. Two required an error for a DM to an unknown nick, which a peered server relays instead (as PM-2 and ROUTE-2 already document); both are named for not crashing, so they now prove the session still works, which "no error arrived" did not.

**`1708bd05`** — CTF-07's `elapsed < 3s` "fail fast" check was measuring the process's first TLS-trust-store load, not the SSRF refusal:

```
PROBE 0: 3.475s status=400
PROBE 1: 537µs  status=400
PROBE 2: 923µs  status=400
```

It failed under load while the code did exactly the right thing. Warmed, the budget tightens to 500ms — now able to catch a connect-then-fail, which 3s was not.

**`5f22730a`** — every federation pair booted as the same two iroh node IDs. The serialization lock from #57 stays deliberately: with it, 11/11 in ~60s repeatably; without it the file finishes in 8s but boots 22 iroh servers at once and lost a probe in 2 of 8 runs. Determinism is worth the 50 seconds.

## Verification

- `cargo test --workspace` clean; `freeq-server` lib **449 passed**
- `scripts/run-s2s-tests.sh`: **141 passed, 0 failed** (was 124 passed, 16 failed)
- `tests/federation.rs`: **11/11**, repeatable (was 4–8 of 11, varying per run)
- `scripts/lint-federation.sh` clean; one *fewer* clippy warning than `main`
- Every new test verified non-vacuous by reverting its fix and reproducing the original failure

## Note for a follow-up

A 401 answering a PRIVMSG surfaces as `Event::WhoisReply`, not `ServerNotice` — the SDK gives numeric 401 its own arm for WHOIS failures, so it never reaches the generic 4xx→ServerNotice fallback. `freeq-windows-core` therefore renders a failed DM as "WHOIS x: No such nick". Left alone here; it changes event semantics across five clients.
