### PR TITLE
Require signatures for changing messages (enforcement switchover)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The web client at `irc.freeq.at` provides:
 - **Moderator appointments** — ops issue signed credentials for halfop (+h)
 - **Automatic role escalation** — credentials auto-grant IRC modes (op, halfop, voice)
 - **Shareable invite links** — `https://irc.freeq.at/join/#channel`
-- **Message editing, deletion, reactions, threads**
+- **Message editing, deletion, reactions, threads** — changing a message requires the sender's signature; current clients sign automatically
 - **End-to-end encrypted channels**
 
 ### Demo Channels

--- a/docs/BOT-QUICKSTART.md
+++ b/docs/BOT-QUICKSTART.md
@@ -121,6 +121,8 @@ const taskId = bot.client.emitEvent('#chan', 'task_request', { … });
 bot.client.spawnAgent('#chan', 'worker-bot', ['url_fetch']);
 ```
 
+Note on `sendEdit` / `sendDelete` / `sendReaction`: changing a message requires a valid signature from a logged-in sender — unsigned changes are refused with a visible error. Bots on bot-kit/SDK defaults sign automatically; a bot that explicitly disabled signing will have these actions refused. In a DM, signing needs the peer's identity known — resolve the peer (WHOIS) before changing messages in a fresh DM thread.
+
 ### Examples
 
 Runnable bots under [`@freeq/bot-kit`'s `examples/`](../freeq-bot-kit-js/examples/):

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -160,6 +160,12 @@ The IRC convention that nothing auto-replies to a notice still holds and is a re
 
 Nearly every notice on a freeq server is the server's own — command results, errors, the `API-BEARER` handshake, the approval notification above — and those are exactly the ephemeral case.
 
+### Changing messages requires a signature
+
+A logged-in sender's edit, delete, react, and unreact must carry a valid signature; unsigned ones are refused with a visible error. Current clients and SDKs sign automatically, and bots on bot-kit/SDK defaults are unaffected — but a bot that explicitly disabled signing will have these actions refused. Plain messages are unchanged. Guest behavior is unchanged, including DMs with a guest, which can never be signed and keep the old rules.
+
+In a DM, signing needs the peer's identity known — resolve the peer (WHOIS) before changing messages in a fresh DM thread.
+
 ### Commit-Reveal
 
 A convention layered on signed PRIVMSGs for sealed-then-revealed messages. Participants commit to an answer before anyone reveals theirs, so nobody can be influenced by others' early posts. The hash binds the future reveal to its earlier commit cryptographically.

--- a/freeq-sdk-js/README.md
+++ b/freeq-sdk-js/README.md
@@ -48,7 +48,7 @@ Building a bot? See **[`@freeq/bot-kit`](../freeq-bot-kit-js/)** for higher-leve
 - **E2EE** — Double Ratchet for DMs, AES-256-GCM for channels
 - **IRCv3** — message-tags, echo-message, CHATHISTORY, batch, away-notify
 - **Auto-reconnect** — exponential backoff with automatic channel rejoin
-- **Message signing** — Ed25519 per-session signing for non-repudiation
+- **Message signing** — Ed25519 per-session signing for non-repudiation; edits, deletes, and reactions are signed, and servers refuse unsigned changes from logged-in senders
 - **Profiles** — AT Protocol profile fetching with TTL cache
 
 ### Agent protocol (Phases 1–5)

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -854,7 +854,7 @@ describe('coordination event methods', () => {
     client.updateTask('#foo', 'task-abc', 'reviewing', 'looking');
     await flushAsync();
     const line = ws.sent.find((l) => l.includes('TAGMSG'));
-    expect(line).toContain('+freeq.at/task-id=task-abc');
+    expect(line).toContain('+freeq.at/ref=task-abc');
   });
 
   it('completeTask() emits task_complete', async () => {
@@ -2316,7 +2316,7 @@ describe('signed mutations', () => {
       tags: {
         '+freeq.at/event': 'evidence_attach',
         '+freeq.at/payload': payload,
-        '+freeq.at/task-id': '01KYVT1W2P0000000000000000',
+        '+freeq.at/ref': '01KYVT1W2P0000000000000000',
         '+freeq.at/evidence-type': 'code_review',
       },
     });
@@ -2412,7 +2412,11 @@ describe('signed mutations', () => {
     expect(noMime).toContain('"media-url"');
   });
 
-  it('an emitted event against a legacy server is byte-identical to before', async () => {
+  // A server that never offered the signing cap gets exactly the shape it
+  // always got — legacy id in `msgid`, the pair of frames, no signature. The
+  // one field that moved is the reference, which both spellings have always
+  // meant and which readers still accept under either.
+  it('an emitted event against a legacy server keeps its unsigned shape', async () => {
     const { client, ws } = await makeRegistered();
     client.signing.setSigningDid('did:plc:mutator');
     await client.signing.generateSigningKey();
@@ -2424,7 +2428,7 @@ describe('signed mutations', () => {
     expect(eventId, 'the legacy id format is what a legacy server files').toMatch(/^[0-9a-f]+$/);
     const tags =
       `msgid=${eventId};+freeq.at/event=task_request;` +
-      '+freeq.at/payload={"description":"ship%20it"};+freeq.at/task-id=task-abc';
+      '+freeq.at/payload={"description":"ship%20it"};+freeq.at/ref=task-abc';
     expect(ws.sent).toEqual([
       `@${tags} TAGMSG #room`,
       `@${tags} PRIVMSG #room :📋 New task: ship it`,

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -1127,7 +1127,7 @@ export class FreeqClient extends EventEmitter {
       }
     }
     const did = this.getDidForNick(from);
-    const taskId = tags['+freeq.at/task-id'] || tags['+freeq.at/ref'];
+    const taskId = tags['+freeq.at/ref'] || tags['+freeq.at/task-id'];
     const evidenceType = tags['+freeq.at/evidence-type'];
     const eventPayload: CoordinationEventPayload = {
       channel,
@@ -3165,7 +3165,7 @@ export class FreeqClient extends EventEmitter {
       '+freeq.at/event': eventType,
       '+freeq.at/payload': encoded,
     };
-    if (opts.refId) tags['+freeq.at/task-id'] = opts.refId;
+    if (opts.refId) tags['+freeq.at/ref'] = opts.refId;
     if (opts.extraTags) Object.assign(tags, opts.extraTags);
     const humanText = opts.humanText ?? `${eventType}`;
     if (!signable) {

--- a/freeq-sdk-js/src/signing.vectors.test.ts
+++ b/freeq-sdk-js/src/signing.vectors.test.ts
@@ -53,7 +53,7 @@ interface Negative {
 
 const spec = JSON.parse(
   readFileSync(join(__dirname, '../../spec/chat-signing-vectors.json'), 'utf8'),
-) as { vectors: Vector[]; negatives: Negative[] };
+) as { vectors: Vector[]; negatives: Negative[]; coordRule: string };
 
 beforeAll(() => {
   Object.defineProperty(globalThis, 'crypto', {
@@ -185,6 +185,44 @@ describe('chat signing vectors', () => {
     const [a, b] = dm.input.dmParticipants!;
     expect(signing.dmVenue(a!, b!)).toBe(dm.input.target);
     expect(signing.dmVenue(b!, a!)).toBe(dm.input.target);
+  });
+
+  // The covered list, named one by one, on this side of the contract too.
+  // The set is append-only forever in both languages at once: a document
+  // canonicalizes the tags it carries *from this list*, so dropping a name
+  // changes the bytes of every signature already made over a message that
+  // carried it. Comparing the constant to itself, or counting it, would pass
+  // through the one edit that matters — hence the literal names, which must
+  // equal the Rust list in `chatsig.rs`.
+  it('covers exactly these tag names', () => {
+    expect([...signing.COVERED_COORD_TAGS]).toEqual([
+      'event',
+      'evidence-type',
+      'link-desc',
+      'link-image',
+      'link-title',
+      'link-url',
+      'media-alt',
+      'media-blurhash',
+      'media-duration',
+      'media-filename',
+      'media-h',
+      'media-mime',
+      'media-size',
+      'media-url',
+      'media-w',
+      'payload',
+      'ref',
+      'task-id',
+    ]);
+  });
+
+  // …and the fixture states the same set in prose, so a reader of the spec
+  // and a reader of the code cannot be told different things.
+  it('states the same set in the fixture rule text', () => {
+    for (const name of signing.COVERED_COORD_TAGS) {
+      expect(spec.coordRule).toContain(name);
+    }
   });
 
   it('mints event ids a server will accept: ULID shape, current time', () => {

--- a/freeq-sdk/src/chatsig.rs
+++ b/freeq-sdk/src/chatsig.rs
@@ -1502,7 +1502,19 @@ mod tests {
             "bodyRule": "body = \"sha256:\" + lowercase hex of SHA-256 over the UTF-8 wire body — ciphertext under E2EE, and the assembled body (real newlines) for a draft/multiline batch.",
             "payloadRule": "payload = \"sha256:\" + lowercase hex of SHA-256 over the UTF-8 wire value of +freeq.at/payload, IRC-unescaped and otherwise verbatim — any app-level encoding inside it is opaque bytes to the signature.",
             "venueRule": "target is the normalized venue, never the wire target: a channel lowercased, or `dm:<did_a>,<did_b>` with the two DIDs sorted ascending.",
-            "coordRule": "coord covers exactly the client-authored coordination and attachment tags event, evidence-type, link-desc, link-image, link-title, link-url, media-alt, media-blurhash, media-duration, media-filename, media-h, media-mime, media-size, media-url, media-w, payload, ref, task-id (canonical keys; wire names carry a +freeq.at/ prefix), IRC-unescaped, verbatim. An event is its TAGMSG, which carries its id in +freeq.at/eventid under its own signature; a message carrying event tags is a rendering of the event, never a carrier of its id. Every other tag — server stamps, tallies, verdicts, provenance, ephemera, framing — is excluded.",
+            // The names come from the constant rather than a copy of it: a
+            // hand-written list in the spec is a second source of truth for
+            // the one set both implementations must agree on, and the copy is
+            // the one that goes stale.
+            "coordRule": format!(
+                "coord covers exactly the client-authored coordination and attachment tags {} \
+                 (canonical keys; wire names carry a +freeq.at/ prefix), IRC-unescaped, verbatim. \
+                 An event is its TAGMSG, which carries its id in +freeq.at/eventid under its own \
+                 signature; a message carrying event tags is a rendering of the event, never a \
+                 carrier of its id. Every other tag — server stamps, tallies, verdicts, \
+                 provenance, ephemera, framing — is excluded.",
+                COVERED_COORD_TAGS.join(", "),
+            ),
             "referenceRule": "edit, reply and subject always name root msgids. A signed event naming a revision is refused, never rewritten.",
             "kidRule": "base64url-nopad(sha256(raw 32-byte ed25519 public key)[0..16])",
             "sigTagFormat": "ed25519:<kid>:<base64url-nopad signature over the UTF-8 canonical bytes>",
@@ -1530,6 +1542,46 @@ mod tests {
             .expect("spec/chat-signing-vectors.json missing — run generate_chat_signing_vectors");
         let on_disk: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
         assert_eq!(on_disk, build_fixtures_json());
+    }
+
+    /// The covered list, named one by one.
+    ///
+    /// This set is append-only forever, in both languages at once: a document
+    /// canonicalizes the tags it carries *from this list*, so removing a name
+    /// changes the bytes of every signature already made over a message that
+    /// carried it — retroactively, and only for the readers who updated.
+    /// Adding one costs nothing, because a document without the tag
+    /// canonicalizes exactly as it did before.
+    ///
+    /// Spelling them out is the point. A test that compared the constant to
+    /// itself, or counted it, would pass through the one edit that matters.
+    #[test]
+    fn the_covered_tag_list_is_exactly_these_names() {
+        assert_eq!(
+            COVERED_COORD_TAGS,
+            [
+                "event",
+                "evidence-type",
+                "link-desc",
+                "link-image",
+                "link-title",
+                "link-url",
+                "media-alt",
+                "media-blurhash",
+                "media-duration",
+                "media-filename",
+                "media-h",
+                "media-mime",
+                "media-size",
+                "media-url",
+                "media-w",
+                "payload",
+                "ref",
+                "task-id",
+            ],
+            "the covered list is append-only, and the TypeScript one must match \
+             it name for name (see signing.ts)"
+        );
     }
 
     #[test]

--- a/freeq-sdk/src/media.rs
+++ b/freeq-sdk/src/media.rs
@@ -34,16 +34,14 @@ pub struct MediaAttachment {
     pub filename: Option<String>,
 }
 
-/// A tag value under either spelling: the vendor-prefixed name a client tag
-/// must use to cross a federation link, or the bare name this SDK wrote
-/// before it did.
+/// A client tag's value, under the vendor-prefixed name every writer uses.
 ///
-/// Both are read because the writers moved and the wire did not: a message
-/// composed by an older build, or replayed out of history, still carries the
-/// bare form. The prefixed one wins where both appear.
+/// Only the prefixed spelling is read. A bare name never crossed a federation
+/// link — the relay carries vendor-prefixed client tags and drops the rest —
+/// so a bare field only ever reached readers on the sender's own server, and
+/// no writer has produced one since the writers moved.
 fn tag<'a>(tags: &'a HashMap<String, String>, name: &str) -> Option<&'a String> {
     tags.get(&format!("+freeq.at/{name}"))
-        .or_else(|| tags.get(name))
 }
 
 impl MediaAttachment {
@@ -51,9 +49,10 @@ impl MediaAttachment {
     ///
     /// Vendor-prefixed throughout: the S2S relay carries client tags and
     /// drops everything else, so a bare name is a field that reaches nobody
-    /// on a peer server. `media-mime` rather than `content-type` because the
-    /// latter is an HTTP header name and arrives carrying the header's
-    /// semantics, parameters included.
+    /// on a peer server — which is why the bare spelling is not read either.
+    /// `media-mime` rather than `content-type` because the latter is an HTTP
+    /// header name and arrives carrying the header's semantics, parameters
+    /// included.
     pub fn to_tags(&self) -> HashMap<String, String> {
         let mut tags = HashMap::new();
         tags.insert(
@@ -82,7 +81,7 @@ impl MediaAttachment {
         tags
     }
 
-    /// Parse from IRCv3 message tags, in either spelling.
+    /// Parse from IRCv3 message tags.
     ///
     /// `None` for a link preview: it carries a URL and a type like any
     /// attachment, so a reader that runs first would claim it and render it
@@ -96,7 +95,6 @@ impl MediaAttachment {
         // that names none is still an attachment — a file rather than an
         // image — and declining it would hide exactly what this reads for.
         let content_type = tag(tags, "media-mime")
-            .or_else(|| tag(tags, "content-type"))
             .cloned()
             .unwrap_or_else(|| UNDECLARED_TYPE.to_string());
         Some(Self {
@@ -178,12 +176,11 @@ fn url_looks_like_image(url: &str) -> bool {
 
 /// Whether these tags describe a link preview rather than an attachment.
 ///
-/// Either the explicit URL field or the discriminator the older shape used.
+/// The explicit URL field, which is the only thing that says so on the wire.
 /// One question, asked in one place, so the two readers cannot disagree about
 /// which of them owns a message.
 fn is_link_preview(tags: &HashMap<String, String>) -> bool {
     tag(tags, "link-url").is_some()
-        || tag(tags, "content-type").map(String::as_str) == Some("text/x-link-preview")
 }
 
 impl LinkPreview {
@@ -209,24 +206,21 @@ impl LinkPreview {
         tags
     }
 
-    /// Parse from IRCv3 message tags, in either spelling.
+    /// Parse from IRCv3 message tags.
     ///
-    /// A preview announces itself two ways: an explicit `link-url`, or the
-    /// `content-type` discriminator this SDK used to write. The discriminator
-    /// cannot federate — it is a bare tag, and the relay carries only
-    /// prefixed ones — so the explicit field is the shape that survives, and
-    /// the old one is read for what is already on the wire.
+    /// A preview announces itself with an explicit `link-url`. The
+    /// `content-type` discriminator this SDK once wrote could not federate —
+    /// it was a bare tag, and the relay carries only prefixed ones — so it
+    /// described a preview to nobody but its own server.
     pub fn from_tags(tags: &HashMap<String, String>) -> Option<Self> {
         if !is_link_preview(tags) {
             return None;
         }
         Some(Self {
-            url: tag(tags, "link-url").or_else(|| tag(tags, "media-url"))?.clone(),
+            url: tag(tags, "link-url")?.clone(),
             title: tag(tags, "link-title").cloned(),
             description: tag(tags, "link-desc").cloned(),
-            thumb_url: tag(tags, "link-image")
-                .or_else(|| tag(tags, "link-thumb"))
-                .cloned(),
+            thumb_url: tag(tags, "link-image").cloned(),
         })
     }
 }
@@ -774,14 +768,14 @@ mod tests {
         assert!(allowed.contains(&"application/pdf"));
     }
 
-    // ── Reading both attachment shapes ──────────────────────────────
+    // ── Reading an attachment ───────────────────────────────────────
     //
-    // Two SDKs described an attachment differently at the field level: this
-    // one wrote bare names and worked out a link preview from a
-    // `content-type` discriminator, the TypeScript one writes vendor-prefixed
-    // names with an explicit `link-url`. Only the prefixed spelling crosses a
-    // federation link, so that shape wins — but a reader has to understand
-    // both, or moving the writers breaks everything already on the wire.
+    // Two SDKs once described an attachment differently at the field level:
+    // this one wrote bare names and worked out a link preview from a
+    // `content-type` discriminator, the TypeScript one vendor-prefixed names
+    // with an explicit `link-url`. Only the prefixed spelling crosses a
+    // federation link, so it is the only shape any reader ever received from
+    // elsewhere — and now the only one read.
 
     fn ts_media_tags() -> HashMap<String, String> {
         HashMap::from([
@@ -794,15 +788,20 @@ mod tests {
         ])
     }
 
+    /// The same attachment as [`ts_media_tags`], written field-for-field the
+    /// way this SDK writes one.
     fn rust_media_tags() -> HashMap<String, String> {
-        HashMap::from([
-            ("media-url".to_string(), "https://cdn/cat.png".to_string()),
-            ("content-type".to_string(), "image/png".to_string()),
-            ("media-alt".to_string(), "a cat".to_string()),
-            ("media-w".to_string(), "640".to_string()),
-            ("media-h".to_string(), "480".to_string()),
-            ("media-size".to_string(), "1024".to_string()),
-        ])
+        MediaAttachment {
+            content_type: "image/png".to_string(),
+            url: "https://cdn/cat.png".to_string(),
+            alt: Some("a cat".to_string()),
+            width: Some(640),
+            height: Some(480),
+            blurhash: None,
+            size: Some(1024),
+            filename: None,
+        }
+        .to_tags()
     }
 
     /// Every tag this SDK writes has to survive a federation hop, and the
@@ -862,7 +861,7 @@ mod tests {
     }
 
     #[test]
-    fn the_two_attachment_shapes_read_as_the_same_media() {
+    fn both_sdks_attachments_read_as_the_same_media() {
         let from_ts = MediaAttachment::from_tags(&ts_media_tags())
             .expect("a TypeScript attachment must parse — nothing rendered them before");
         let from_rust = MediaAttachment::from_tags(&rust_media_tags()).expect("and this one still");
@@ -922,20 +921,20 @@ mod tests {
     }
 
     #[test]
-    fn the_two_link_preview_shapes_read_as_the_same_preview() {
+    fn both_sdks_link_previews_read_as_the_same_preview() {
         let ts = HashMap::from([
             ("+freeq.at/link-url".to_string(), "https://example.com/post".to_string()),
             ("+freeq.at/link-title".to_string(), "A post".to_string()),
             ("+freeq.at/link-desc".to_string(), "about things".to_string()),
             ("+freeq.at/link-image".to_string(), "https://cdn/thumb.png".to_string()),
         ]);
-        let rust = HashMap::from([
-            ("content-type".to_string(), "text/x-link-preview".to_string()),
-            ("media-url".to_string(), "https://example.com/post".to_string()),
-            ("link-title".to_string(), "A post".to_string()),
-            ("link-desc".to_string(), "about things".to_string()),
-            ("link-thumb".to_string(), "https://cdn/thumb.png".to_string()),
-        ]);
+        let rust = LinkPreview {
+            url: "https://example.com/post".to_string(),
+            title: Some("A post".to_string()),
+            description: Some("about things".to_string()),
+            thumb_url: Some("https://cdn/thumb.png".to_string()),
+        }
+        .to_tags();
         let from_ts = LinkPreview::from_tags(&ts).expect("a TypeScript preview must parse");
         let from_rust = LinkPreview::from_tags(&rust).expect("and this one still");
         assert_eq!(from_ts.url, from_rust.url);
@@ -951,11 +950,13 @@ mod tests {
     /// never reached.
     #[test]
     fn a_link_preview_does_not_read_as_media() {
-        let rust_preview = HashMap::from([
-            ("content-type".to_string(), "text/x-link-preview".to_string()),
-            ("media-url".to_string(), "https://example.com/post".to_string()),
-            ("link-title".to_string(), "A post".to_string()),
-        ]);
+        let rust_preview = LinkPreview {
+            url: "https://example.com/post".to_string(),
+            title: Some("A post".to_string()),
+            description: None,
+            thumb_url: None,
+        }
+        .to_tags();
         assert!(MediaAttachment::from_tags(&rust_preview).is_none());
 
         let ts_preview = HashMap::from([

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -202,21 +202,25 @@ fn resolve_signature(
     tags: &HashMap<String, String>,
     client_sig: Option<&str>,
     state: &Arc<SharedState>,
-) -> Option<String> {
-    let did = conn.authenticated_did.as_ref()?;
+) -> SettledSignature {
+    let Some(did) = conn.authenticated_did.as_ref() else {
+        return SettledSignature::Attach(None);
+    };
     let venue = signing_venue(state, did, target);
 
     if let (Some(sig_tag), Some(venue)) = (client_sig, venue.as_deref()) {
         let doc = message_document(did, venue, fields, tags);
         match verify_client_signature(&doc, sig_tag, did, Some(&conn.id), state) {
-            ClientSigOutcome::Verified => return Some(sig_tag.to_string()),
+            ClientSigOutcome::Verified => {
+                return SettledSignature::Attach(Some(sig_tag.to_string()));
+            }
             ClientSigOutcome::Failed => {
                 tracing::warn!(
                     session = %conn.id, did = %did, msgid = %fields.msgid,
                     "Client signature did not verify against the key it names — \
-                     relaying the message unsigned rather than substituting ours"
+                     refusing the message"
                 );
-                return None;
+                return SettledSignature::Failed;
             }
             ClientSigOutcome::Unverifiable(why) => {
                 tracing::debug!(
@@ -235,9 +239,42 @@ fn resolve_signature(
     // Server signature over the same document. Without a venue there is no
     // document to sign, and inventing one would produce a signature nobody
     // could rebuild — the exact failure this canonical exists to end.
-    let venue = venue?;
+    let Some(venue) = venue else {
+        return SettledSignature::Attach(None);
+    };
     let doc = message_document(did, &venue, fields, tags);
-    Some(doc.sign(&state.msg_signing_key))
+    SettledSignature::Attach(Some(doc.sign(&state.msg_signing_key)))
+}
+
+/// Tell the sender their message carried a signature that did not verify.
+///
+/// `command` is the command being refused, per the standard-replies shape.
+fn send_signature_invalid(conn: &Connection, command: &str, state: &Arc<SharedState>) {
+    let reply = Message::from_server(
+        &state.server_name,
+        "FAIL",
+        vec![
+            command,
+            "SIGNATURE_INVALID",
+            "That signature does not verify against the key it names",
+        ],
+    );
+    if let Some(tx) = state.connections.lock().get(&conn.id) {
+        let _ = tx.try_send(format!("{reply}\r\n"));
+    }
+}
+
+/// What a message's signature settled to at ingress.
+pub(crate) enum SettledSignature {
+    /// Relay it, carrying this signature: the sender's own where it verified,
+    /// this server's vouch where there was nothing to check, and none at all
+    /// for a guest or a venue that does not resolve.
+    Attach(Option<String>),
+    /// The signature named a key this server holds and did not verify against
+    /// it. The bytes and the proof disagree, which is a fact about the
+    /// message — so it is refused rather than relayed with the disagreement
+    /// quietly dropped.
+    Failed,
 }
 
 /// What happened when we checked a client's signature — three outcomes, not
@@ -1769,10 +1806,13 @@ pub(super) fn handle_privmsg_with_multiline(
             reply: reply_reference(tags),
             edit: None,
         };
-        set_signature(
-            &mut full_tags,
-            resolve_signature(conn, target, &signed, tags, client_sig, state),
-        );
+        match resolve_signature(conn, target, &signed, tags, client_sig, state) {
+            SettledSignature::Attach(sig) => set_signature(&mut full_tags, sig),
+            SettledSignature::Failed => {
+                send_signature_invalid(conn, command, state);
+                return;
+            }
+        }
 
         // If this PRIVMSG is a commit-reveal `reveal` event, verify the
         // binding against the prior commit and stamp the outcome onto
@@ -2054,10 +2094,13 @@ pub(super) fn handle_privmsg_with_multiline(
             reply: reply_reference(tags),
             edit: None,
         };
-        set_signature(
-            &mut pm_tags,
-            resolve_signature(conn, target, &signed, tags, client_sig, state),
-        );
+        match resolve_signature(conn, target, &signed, tags, client_sig, state) {
+            SettledSignature::Attach(sig) => set_signature(&mut pm_tags, sig),
+            SettledSignature::Failed => {
+                send_signature_invalid(conn, command, state);
+                return;
+            }
+        }
 
         let mut pm_tags_with_time = pm_tags.clone();
         pm_tags_with_time.insert("time".to_string(), time_tag.clone());
@@ -3235,10 +3278,15 @@ fn handle_edit(
         }
     }
 
-    set_signature(
-        &mut full_tags,
-        resolve_signature(conn, target, &signed, tags, client_sig, state),
-    );
+    match resolve_signature(conn, target, &signed, tags, client_sig, state) {
+        SettledSignature::Attach(sig) => set_signature(&mut full_tags, sig),
+        // Unreachable: an edit whose signature failed was refused above, with
+        // the code that names an edit. Refuse again rather than file it.
+        SettledSignature::Failed => {
+            send_signature_invalid(conn, "EDIT", state);
+            return;
+        }
+    }
 
     // Multi-line breakdown for BATCH-wrapped outbound. Two sources, in
     // priority order:

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -896,6 +896,50 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Whether a channel will take a TAGMSG from this sender: `+n` (members only)
+/// and `+m` (voiced or better), the same two gates a PRIVMSG passes.
+///
+/// Sends the refusal itself, so a caller only has to stop.
+fn channel_accepts_tagmsg(conn: &Connection, target: &str, state: &Arc<SharedState>) -> bool {
+    // Resolve sender DID once, before taking the channels lock.
+    let sender_did = state.session_dids.lock().get(&conn.id).cloned();
+    let refusal = {
+        let channels = state.channels.lock();
+        let Some(ch) = channels.get(target) else {
+            return true;
+        };
+        // Founder + persistent DID-ops bypass +m. (+n is membership-based;
+        // a non-member can't be founder anyway, so no bypass needed there.)
+        let is_did_authority = sender_did
+            .as_deref()
+            .is_some_and(|d| ch.founder_did.as_deref() == Some(d) || ch.did_ops.contains(d));
+        if ch.no_ext_msg && !ch.members.contains(&conn.id) {
+            Some("Cannot send to channel (+n)")
+        } else if ch.moderated
+            && !is_did_authority
+            && !ch.ops.contains(&conn.id)
+            && !ch.halfops.contains(&conn.id)
+            && !ch.voiced.contains(&conn.id)
+        {
+            Some("Cannot send to channel (+m)")
+        } else {
+            None
+        }
+    };
+    let Some(reason) = refusal else {
+        return true;
+    };
+    let reply = Message::from_server(
+        &state.server_name,
+        irc::ERR_CANNOTSENDTOCHAN,
+        vec![conn.nick_or_star(), target, reason],
+    );
+    if let Some(tx) = state.connections.lock().get(&conn.id) {
+        let _ = tx.try_send(format!("{reply}\r\n"));
+    }
+    false
+}
+
 pub(super) fn handle_tagmsg(
     conn: &Connection,
     target: &str,
@@ -1322,6 +1366,17 @@ pub(super) fn handle_tagmsg(
         .as_deref()
         .and_then(|did| signing_venue(state, did, target));
 
+    // The channel's own gates run before anything is filed. A reaction from
+    // outside a `+n` channel, or from an unvoiced sender in a `+m` one,
+    // reaches nobody — and filing it first left a row for a reaction no
+    // member ever received, which then surfaced for everyone on the next
+    // join.
+    if (target.starts_with('#') || target.starts_with('&'))
+        && !channel_accepts_tagmsg(conn, target, state)
+    {
+        return;
+    }
+
     // ── Persist reactions (+react with +reply) ──
     if let (Some(emoji), Some(target_msgid)) = (tags.get("+react"), tags.get("+reply")) {
         let nick = conn.nick_or_star().to_string();
@@ -1414,51 +1469,6 @@ pub(super) fn handle_tagmsg(
 
     // Rich clients get TAGMSG, plain clients get fallback PRIVMSG (if any)
     if target.starts_with('#') || target.starts_with('&') {
-        // Channel TAGMSG — enforce +n (no external messages) and +m (moderated)
-        // Resolve sender DID once, before taking the channels lock.
-        let sender_did = state.session_dids.lock().get(&conn.id).cloned();
-        {
-            let channels = state.channels.lock();
-            if let Some(ch) = channels.get(target) {
-                // Founder + persistent DID-ops bypass +m. (+n is membership-based;
-                // a non-member can't be founder anyway, so no bypass needed there.)
-                let is_did_authority = sender_did.as_deref().is_some_and(|d| {
-                    ch.founder_did.as_deref() == Some(d) || ch.did_ops.contains(d)
-                });
-                // +n: must be a member to send
-                if ch.no_ext_msg && !ch.members.contains(&conn.id) {
-                    let nick = conn.nick_or_star();
-                    let reply = Message::from_server(
-                        &state.server_name,
-                        irc::ERR_CANNOTSENDTOCHAN,
-                        vec![nick, target, "Cannot send to channel (+n)"],
-                    );
-                    if let Some(tx) = state.connections.lock().get(&conn.id) {
-                        let _ = tx.try_send(format!("{reply}\r\n"));
-                    }
-                    return;
-                }
-                // +m: must be voiced or op to send
-                if ch.moderated
-                    && !is_did_authority
-                    && !ch.ops.contains(&conn.id)
-                    && !ch.halfops.contains(&conn.id)
-                    && !ch.voiced.contains(&conn.id)
-                {
-                    let nick = conn.nick_or_star();
-                    let reply = Message::from_server(
-                        &state.server_name,
-                        irc::ERR_CANNOTSENDTOCHAN,
-                        vec![nick, target, "Cannot send to channel (+m)"],
-                    );
-                    if let Some(tx) = state.connections.lock().get(&conn.id) {
-                        let _ = tx.try_send(format!("{reply}\r\n"));
-                    }
-                    return;
-                }
-            }
-        }
-
         let members: Vec<String> = state
             .channels
             .lock()

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -3179,31 +3179,45 @@ fn handle_edit(
         edit: Some(original_msgid),
     };
 
-    // Refuse an edit whose signature fails to verify — the same tamper rule
-    // delete/react/unreact already enforce. An edit changes an existing record,
-    // so a signature that fails against the key it names is evidence of
-    // tampering and must not apply. Absent and unverifiable signatures still
-    // fall through to the server vouch below; only a *failed* check is refused.
+    // An edit takes the editor's own proof, the same as a delete or a
+    // reaction: it rewrites a record that already exists, and a note saying
+    // this server believed them is not evidence of what they wrote.
+    //
+    // Two refusals, one rule, kept apart because they are different problems
+    // for the sender to fix. A signature that fails against the key it names
+    // is evidence the bytes moved. One this server cannot check at all —
+    // absent, or naming a key nobody registered — is a request nobody proved.
+    //
+    // A venue that does not resolve exempts the edit, as it does every other
+    // mutation: a DM with a guest has no document for anyone to sign, so
+    // requiring one would end editing in those threads and end nothing else.
     if let Some(did) = conn.authenticated_did.as_deref()
-        && let (Some(sig_tag), Some(venue)) = (client_sig, signing_venue(state, did, target))
+        && let Some(venue) = signing_venue(state, did, target)
     {
-        let doc = message_document(did, &venue, &signed, tags);
-        if verify_client_signature(&doc, sig_tag, did, Some(&conn.id), state)
-            == ClientSigOutcome::Failed
-        {
-            tracing::warn!(
-                session = %conn.id, did = %did, target = %target,
-                "Edit signature did not verify against the key it names — refusing the edit"
-            );
-            let reply = Message::from_server(
-                &state.server_name,
-                "FAIL",
-                vec![
-                    "EDIT",
+        let outcome = match client_sig {
+            Some(sig_tag) => {
+                let doc = message_document(did, &venue, &signed, tags);
+                verify_client_signature(&doc, sig_tag, did, Some(&conn.id), state)
+            }
+            None => ClientSigOutcome::Unverifiable("edit carries no signature"),
+        };
+        if outcome != ClientSigOutcome::Verified {
+            let (code, description) = match outcome {
+                ClientSigOutcome::Failed => (
                     "SIGNATURE_INVALID",
                     "That signature does not verify against the key it names",
-                ],
+                ),
+                _ => (
+                    "SIGNATURE_REQUIRED",
+                    "A signed request is required to modify messages on this server",
+                ),
+            };
+            tracing::warn!(
+                session = %conn.id, did = %did, target = %target, outcome = ?outcome,
+                "Edit refused: {code}"
             );
+            let reply =
+                Message::from_server(&state.server_name, "FAIL", vec!["EDIT", code, description]);
             if let Some(tx) = state.connections.lock().get(&conn.id) {
                 let _ = tx.try_send(format!("{reply}\r\n"));
             }

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -820,76 +820,42 @@ fn keep_signature(checked: Option<&CheckedMutation>, tidied: &HashMap<String, St
 /// event is filed under, and the signature that goes with it.
 pub(crate) struct VouchedMutation {
     pub event_id: String,
-    /// The sender's own signature, or this server's over the same document.
-    /// `None` only for a guest — no identity, nothing to vouch for.
+    /// The sender's own signature. Never this server's: a mutation nobody
+    /// proved is refused rather than vouched for.
     pub signature: Option<String>,
 }
 
-/// Settle a mutation's signature the way a message's is settled.
+/// Settle a mutation's signature: the sender's own, or nothing.
 ///
-/// A note under a user's name means the same thing whether it is a sentence or
-/// a delete: *this server saw this authenticated account do this*. So the
-/// rules are the message rules, with no special case:
+/// A mutation changes a record that already exists, so the only thing worth
+/// attaching is proof from the key the actor registered. This server used to
+/// sign an unsigned one on the sender's behalf, which made the actor of a
+/// delete this server's word — indistinguishable, from the act alone, from
+/// the sender's own. Those events are now refused at ingress instead
+/// (`handle_tagmsg`), leaving this with one job: carry the sender's signature
+/// onward while it still covers what is on the wire.
 ///
-/// - the sender's signature, when it verifies and still covers what is on the
-///   wire — the only outcome with real non-repudiation;
-/// - **this server's signature** over the same document otherwise, which says
-///   only what it means. A reader tells the two apart by the key each names,
-///   which is what `verified_by` reports;
-/// - nothing at all for a guest, who has no identity to bind.
-///
-/// A signature that *failed* never reaches here: the caller refuses the event.
+/// `None` for a guest, who has no identity to bind, and for a verified
+/// signature whose subject this server has since re-rooted — the document a
+/// reader would rebuild is no longer the one the sender signed.
 fn vouch_mutation(
-    conn: &Connection,
-    target: &str,
     tidied: &HashMap<String, String>,
     checked: Option<&CheckedMutation>,
-    state: &Arc<SharedState>,
 ) -> Option<VouchedMutation> {
-    let (kind, subject, emoji) = mutation_in(tidied)?;
+    if !keep_signature(checked, tidied) {
+        return None;
+    }
     let event_id = tidied
         .get(freeq_sdk::chatsig::EVENT_ID_TAG)
         .or_else(|| tidied.get(freeq_sdk::chatsig::EVENT_ID_TAG_BARE))
-        .cloned();
-
-    // The sender's own, when it verified and nothing since has moved out from
-    // under it.
-    if keep_signature(checked, tidied)
-        && let (Some(event_id), Some(sig)) = (
-            event_id.clone(),
-            tidied
-                .get("+freeq.at/sig")
-                .or_else(|| tidied.get("freeq.at/sig"))
-                .cloned(),
-        )
-    {
-        return Some(VouchedMutation {
-            event_id,
-            signature: Some(sig),
-        });
-    }
-
-    let did = conn.authenticated_did.as_deref()?;
-    // Without a venue there is no document, and inventing one would produce a
-    // signature nobody could rebuild — the exact failure the canonical exists
-    // to end. The act still happens; it just isn't vouched for.
-    let venue = signing_venue(state, did, target)?;
-    // The sender's id is kept when it holds up, so the event this server
-    // vouches for and the one the sender named are the same event. Otherwise
-    // the act still needs an identity, and this server mints it.
-    let event_id = event_id
-        .filter(|id| crate::msgid::check_client_minted(id, now_ms()).is_ok())
-        .unwrap_or_else(crate::msgid::generate);
-
-    let mut doc =
-        freeq_sdk::chatsig::ChatDoc::mutation(kind, did, &event_id, &venue, &subject);
-    if let Some(ref emoji) = emoji {
-        doc = doc.with_emoji(emoji);
-    }
-    let signature = doc.sign(&state.msg_signing_key);
+        .cloned()?;
+    let sig = tidied
+        .get("+freeq.at/sig")
+        .or_else(|| tidied.get("freeq.at/sig"))
+        .cloned()?;
     Some(VouchedMutation {
         event_id,
-        signature: Some(signature),
+        signature: Some(sig),
     })
 }
 
@@ -990,6 +956,50 @@ pub(super) fn handle_tagmsg(
         return;
     }
 
+    // ── An identity's mutation must carry that identity's own proof ──
+    //
+    // A signature this server made over someone else's delete says only that
+    // this server believed them, and nothing downstream can tell the two
+    // apart from the act alone. So an authenticated sender whose mutation
+    // arrives unsigned — or with a signature no key here can check — is
+    // refused, and nothing is filed. `SIGNATURE_REQUIRED` stays distinct from
+    // `SIGNATURE_INVALID` above: one is a client that did not sign, the other
+    // is bytes that do not match, and they are different problems to fix.
+    //
+    // Two exemptions, both cases where the proof could not have existed:
+    // a guest, who has no identity to bind, and a thread with no venue — a
+    // DM with a guest, whose document names a DID the recipient does not
+    // have. Demanding a signature there would end deletes in those threads
+    // forever, and would end nothing else: no signature was ever attached to
+    // them, by the sender or by this server. A peer DID the *client* has not
+    // learned yet is not this case — that venue resolves here, and the client
+    // closes the gap by asking who the peer is before it acts.
+    if is_mutation
+        && let Some(did) = conn.authenticated_did.as_deref()
+        && signing_venue(state, did, target).is_some()
+        && arrived.as_ref().map(|c| c.outcome) != Some(ClientSigOutcome::Verified)
+    {
+        tracing::info!(
+            session = %conn.id, did = ?conn.authenticated_did, target = %target,
+            outcome = ?arrived.as_ref().map(|c| c.outcome),
+            "Mutation from an authenticated sender carries no signature this server can \
+             check — refusing the event"
+        );
+        let reply = Message::from_server(
+            &state.server_name,
+            "FAIL",
+            vec![
+                "TAGMSG",
+                "SIGNATURE_REQUIRED",
+                "A signed request is required to modify messages on this server",
+            ],
+        );
+        if let Some(tx) = state.connections.lock().get(&conn.id) {
+            let _ = tx.try_send(format!("{reply}\r\n"));
+        }
+        return;
+    }
+
     // Normalize IRCv3 draft tags to their canonical forms so all downstream
     // code (persistence, relay, fallback) only needs to check one name.
     let mut tags = tags.clone();
@@ -1016,14 +1026,13 @@ pub(super) fn handle_tagmsg(
             tags.insert("+draft/delete".to_string(), root);
         }
     }
-    // Settle what this server stands behind. The sender's signature when it
-    // verified and still covers what is on the wire; this server's over the
-    // same document otherwise; nothing at all for a guest. A signature the
+    // Settle what this server stands behind: the sender's signature while it
+    // still covers what is on the wire, and nothing otherwise. A signature the
     // server did not make and cannot vouch for never leaves the server — the
     // never-launder rule, which is also what stops a guest inventing a lock
     // badge for free.
     let vouched = if is_mutation {
-        vouch_mutation(conn, target, &tags, arrived.as_ref(), state)
+        vouch_mutation(&tags, arrived.as_ref())
     } else {
         None
     };

--- a/freeq-server/src/connection/routing.rs
+++ b/freeq-server/src/connection/routing.rs
@@ -247,6 +247,13 @@ pub(crate) fn reconcile_recipient_did(stamp: Option<&str>, local: Option<&str>) 
 /// `account` is looked up strictly as an identity in `did_sessions`, never
 /// resolved as a nick. The value is peer-asserted: routing a nick-shaped one
 /// through the nick map would let a peer address whoever holds that nick here.
+///
+/// **Callers pass `None` unless the event's signature verified.** Everywhere
+/// else a stamped DID only labels an event; here it decides delivery *into
+/// that identity's own client*, where the event reads as something they sent.
+/// A peer naming a local user could otherwise put a line in their outbox, or
+/// a delete in their history, that they never issued — the claim has to be
+/// one this server checked, not one it was told.
 pub(crate) fn sender_sessions_for_account(
     state: &SharedState,
     account: Option<&str>,

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -2306,9 +2306,22 @@ impl Db {
     }
 
     /// The DID's most-recently-registered signing key (raw 32-byte ed25519
-    /// public key), or None. Used by the existing verify path, which wants the
-    /// current key; a specific historical key is fetched via
-    /// [`Db::get_signing_key_by_kid`].
+    /// public key), or None.
+    ///
+    /// **Not a verification lookup.** This answers "what key is this identity
+    /// using now", which the public key endpoint publishes and the provenance
+    /// check needs — not "what key made this signature", which is the only
+    /// question chat verification asks. Every chat path resolves the key by
+    /// the `kid` the signature names ([`Db::get_signing_key_by_kid`]), so a
+    /// signature stays checkable after the session that made it ends and a
+    /// key rotation does not turn a body of honest history invalid.
+    ///
+    /// The retired signature format — a bare base64 blob over
+    /// `did\0target\0text\0timestamp`, naming no kid — is what a "latest key"
+    /// lookup existed for. It folded a client-minted wall clock that never
+    /// crossed the wire, so nothing could rebuild its bytes: it is
+    /// uncheckable on every path, classified `unverifiable-legacy-format`,
+    /// and never evidence of forgery.
     pub fn get_signing_key(&self, did: &str) -> SqlResult<Option<[u8; 32]>> {
         // rowid DESC breaks ties: registered_at is second-granularity, so two
         // keys registered in the same second must fall back to insertion order.

--- a/freeq-server/src/peer_keys.rs
+++ b/freeq-server/src/peer_keys.rs
@@ -91,6 +91,18 @@ fn base_for_origin(state: &Arc<SharedState>, origin: &str) -> Option<String> {
         .cloned()
 }
 
+/// Whether this peer has a key server at all (`--s2s-peer-api`).
+///
+/// A peer with none can never have its signatures checked here, which is
+/// honest for a message — it is labeled and delivered — but decides the fate
+/// of a mutation, which is refused when it cannot be checked. The refusal is
+/// worth naming the reason for: without this, an operator sees mutations from
+/// one peer quietly doing nothing and has no way to tell a forgery from a
+/// line missing from the command line.
+pub fn has_key_source(state: &Arc<SharedState>, origin: &str) -> bool {
+    base_for_origin(state, origin).is_some()
+}
+
 /// Look up the key a relayed signature names, without holding anything up.
 ///
 /// Call when a relayed event was uncheckable for want of a key. Returns

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -4144,11 +4144,20 @@ pub(crate) async fn process_s2s_message(
                 // …and the sender's own sessions here, if they have any. The
                 // origin fanned this out to their other devices on its send
                 // path; that code never runs on this side of the link.
+                //
+                // Only on a signature this server checked. This delivery is
+                // the one place a stamped DID does more than label a message:
+                // it routes the message into that identity's own client, in
+                // the position of something they sent. A peer that names a
+                // local user could put a line in their outbox for free.
                 crate::connection::routing::merge_sessions(
                     &mut sids,
                     crate::connection::routing::sender_sessions_for_account(
                         state,
-                        account.as_deref(),
+                        account.as_deref().filter(|_| {
+                            sig_verdict
+                                == Some(crate::connection::messaging::ClientSigOutcome::Verified)
+                        }),
                     ),
                 );
                 let tag_caps = state.cap_message_tags.lock();
@@ -4587,13 +4596,19 @@ pub(crate) async fn process_s2s_message(
             } else {
                 // Plus the sender's own sessions here — a reaction or delete
                 // they made from another server has to reach their other
-                // devices, the same as the DM PRIVMSG path.
+                // devices, the same as the DM PRIVMSG path, and on the same
+                // condition: a signature this server checked, because this
+                // delivery puts the event in the named identity's own client
+                // as something they did.
                 let mut sids = crate::connection::routing::local_sessions_for_target(state, &target);
                 crate::connection::routing::merge_sessions(
                     &mut sids,
                     crate::connection::routing::sender_sessions_for_account(
                         state,
-                        peer_account.as_deref(),
+                        peer_account.as_deref().filter(|_| {
+                            sig_verdict
+                                == Some(crate::connection::messaging::ClientSigOutcome::Verified)
+                        }),
                     ),
                 );
                 sids

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -3654,7 +3654,7 @@ pub(crate) async fn process_s2s_message(
                         peer = %authenticated_peer_id, target = %target, from = %from,
                         account = ?account, msgid = ?msgid,
                         "Relayed message signature did not verify against the key it names — \
-                         stripping it before relay"
+                         dropping the message"
                     ),
                     ClientSigOutcome::Unverifiable(why) => tracing::debug!(
                         peer = %authenticated_peer_id, target = %target, why = %why,
@@ -3662,15 +3662,15 @@ pub(crate) async fn process_s2s_message(
                     ),
                 }
             }
-            // A signature that did not check out is evidence about the bytes,
-            // and it must not travel any further under it: no local client
-            // sees it, nothing files it. The same never-launder rule the
-            // origin follows — a signature this server cannot stand behind
-            // does not leave this server.
-            let sig = match sig_verdict {
-                Some(crate::connection::messaging::ClientSigOutcome::Failed) => None,
-                _ => sig,
-            };
+            // A signature that did not check out is evidence about the bytes:
+            // the words and the proof arrived together and disagree. The
+            // message is dropped rather than relayed without the half that
+            // disagreed — passing on the words alone would put text under the
+            // sender's name that the evidence on the wire says is not theirs,
+            // and would hide the one fact worth knowing about it.
+            if sig_verdict == Some(crate::connection::messaging::ClientSigOutcome::Failed) {
+                return;
+            }
 
             // Generate a local msgid if the remote didn't send one
             let msgid = msgid.unwrap_or_else(crate::msgid::generate);
@@ -6785,11 +6785,58 @@ mod s2s_adversarial_tests {
         rx.try_recv().expect("the message reached the member")
     }
 
-    /// A signature that does not check out is evidence of tampering, so it
-    /// must not travel any further: no local client sees it, and nothing
-    /// downstream can mistake it for a signature this server stood behind.
+    /// The same, for a relay that may legitimately deliver nothing.
+    #[allow(clippy::too_many_arguments)]
+    async fn relay_to_member_maybe(
+        state: &Arc<SharedState>,
+        mgr: &Arc<S2sManager>,
+        envelope: &str,
+        did: Option<&str>,
+        msgid: &str,
+        text: &str,
+        sig: Option<String>,
+    ) -> Option<String> {
+        let (tx, mut rx) = mpsc::channel(16);
+        let session = format!("w-{envelope}");
+        state.connections.lock().insert(session.clone(), tx);
+        state.cap_message_tags.lock().insert(session.clone());
+        state
+            .channels
+            .lock()
+            .get_mut("#chat")
+            .unwrap()
+            .members
+            .insert(session.clone());
+
+        process_s2s_message(
+            state,
+            mgr,
+            PEER,
+            S2sMessage::Privmsg {
+                event_id: format!("{PEER}:{envelope}"),
+                from: "remote!u@s2s".to_string(),
+                target: "#chat".to_string(),
+                text: text.to_string(),
+                origin: PEER.to_string(),
+                msgid: Some(msgid.to_string()),
+                sig,
+                account: did.map(str::to_string),
+                recipient_did: None,
+                replaces_msgid: None,
+                tags: HashMap::new(),
+                multiline_lines: None,
+            },
+        )
+        .await;
+
+        rx.try_recv().ok()
+    }
+
+    /// A signature that does not check out is evidence about the bytes, so
+    /// the message does not travel: no local client sees it, and nothing is
+    /// filed for a reader of history to find.
     #[tokio::test]
-    async fn a_relayed_message_whose_signature_fails_is_relayed_without_it() {
+    async fn a_relayed_message_whose_signature_fails_is_dropped() {
         let state = test_state_with_db();
         let mgr = test_manager();
         setup_authenticated_peer(&state, &mgr).await;
@@ -6798,7 +6845,7 @@ mod s2s_adversarial_tests {
 
         // Signed over one body, relayed with another.
         let sig = sign_channel_message(&key, SIGNER, "01TAMPERED", "#chat", "what was said");
-        let frame = relay_to_member(
+        let delivered = relay_to_member_maybe(
             &state,
             &mgr,
             "tampered",
@@ -6808,17 +6855,24 @@ mod s2s_adversarial_tests {
             Some(sig),
         )
         .await;
-
         assert!(
-            !frame.contains("+freeq.at/sig"),
-            "a signature that failed must not reach local clients: {frame}"
+            delivered.is_none(),
+            "a message whose signature failed must not reach local clients: {delivered:?}"
+        );
+        assert!(
+            state
+                .with_db(|db| db.find_message_by_msgid("01TAMPERED"))
+                .flatten()
+                .is_none(),
+            "nor may it be filed for a reader of history to find"
         );
 
         // The same rule for a signed event replayed somewhere it was never
         // sent: the venue is inside the document, so the signature does not
-        // survive the move and must not travel with it.
+        // survive the move — which reads as a failure, and the replay is
+        // refused rather than delivered shorn of its proof.
         let elsewhere = sign_channel_message(&key, SIGNER, "01REPLAYED", "#private", "for us only");
-        let frame = relay_to_member(
+        let delivered = relay_to_member_maybe(
             &state,
             &mgr,
             "replayed",
@@ -6829,19 +6883,9 @@ mod s2s_adversarial_tests {
         )
         .await;
         assert!(
-            !frame.contains("+freeq.at/sig"),
-            "a signed event replayed into another channel must lose its signature: {frame}"
+            delivered.is_none(),
+            "a signed event replayed into another channel must not arrive: {delivered:?}"
         );
-        // Nor is it filed — a reader of history must not find it either.
-        let row = state
-            .with_db(|db| db.find_message_by_msgid("01TAMPERED"))
-            .flatten()
-            .expect("the message itself is still stored");
-        assert!(
-            !row.tags.contains_key("+freeq.at/sig"),
-            "a signature that failed must not be stored"
-        );
-        assert_eq!(row.text, "what a liar substituted");
     }
 
     /// The other side of the same rule: a signature that checks out is

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2917,15 +2917,37 @@ fn verify_relayed_privmsg(
     ))
 }
 
+/// The mutation a relayed TAGMSG's tags describe, if any — read before the
+/// draft names are canonicalized, like every other reader of the wire.
+///
+/// Separate from the signature check because the two questions are asked
+/// separately: *is this a mutation at all* decides whether the proof rule
+/// applies, and an unsigned mutation has no signature to check.
+fn relayed_mutation_in<'a>(
+    tags: &'a HashMap<String, String>,
+) -> Option<(freeq_sdk::chatsig::Mutation, Option<&'a str>, Option<&'a str>)> {
+    use freeq_sdk::chatsig::Mutation;
+    let get = |a: &str, b: &str| tags.get(a).or_else(|| tags.get(b)).map(String::as_str);
+    let subject = || get("+reply", "+draft/reply");
+    if let Some(subject) = get("+draft/delete", "+delete") {
+        return Some((Mutation::Delete, Some(subject), None));
+    }
+    if let Some(emoji) = get("+react", "+draft/react") {
+        return Some((Mutation::React, subject(), Some(emoji)));
+    }
+    if let Some(emoji) = tags.get("+freeq.at/unreact").map(String::as_str) {
+        return Some((Mutation::Unreact, subject(), Some(emoji)));
+    }
+    None
+}
+
 /// Check a relayed mutation's signature against the event as transmitted.
 ///
 /// `None` when the event carries no signature, or carries no mutation at all
 /// (a typing notification is not a signed event).
 ///
 /// Read before the receive path renames draft tags and resolves the subject to
-/// a local root: both rewrite values the signature covers. A sender that mints
-/// no event id leaves nothing to rebuild, which reads unverifiable — the state
-/// of every mutation on the wire until senders sign them.
+/// a local root: both rewrite values the signature covers.
 fn verify_relayed_mutation_tags(
     state: &Arc<SharedState>,
     account: Option<&str>,
@@ -2933,19 +2955,9 @@ fn verify_relayed_mutation_tags(
     tags: &HashMap<String, String>,
 ) -> Option<crate::connection::messaging::ClientSigOutcome> {
     use crate::connection::messaging::{ClientSigOutcome, verify_relayed_mutation};
-    use freeq_sdk::chatsig::Mutation;
 
     let get = |a: &str, b: &str| tags.get(a).or_else(|| tags.get(b)).map(String::as_str);
-    let subject = || get("+reply", "+draft/reply");
-    let (kind, subject, emoji) = if let Some(subject) = get("+draft/delete", "+delete") {
-        (Mutation::Delete, Some(subject), None)
-    } else if let Some(emoji) = get("+react", "+draft/react") {
-        (Mutation::React, subject(), Some(emoji))
-    } else if let Some(emoji) = tags.get("+freeq.at/unreact").map(String::as_str) {
-        (Mutation::Unreact, subject(), Some(emoji))
-    } else {
-        return None;
-    };
+    let (kind, subject, emoji) = relayed_mutation_in(tags)?;
 
     let sig = tags.get("+freeq.at/sig").map(String::as_str)?;
     let Some(did) = account else {
@@ -3713,6 +3725,23 @@ pub(crate) async fn process_s2s_message(
             // it as new text would put words in the channel that the origin's
             // user never asked to send as a new message.
             let actor_nick = from.split('!').next().unwrap_or(&from).to_string();
+            // An edit rewrites a record, so it answers to the mutation rule
+            // rather than the message one: the actor's own proof, or nothing
+            // happens. Same two exemptions — no account is a guest's edit, and
+            // a venue that does not resolve had no document to sign.
+            if edit_of.is_some()
+                && let Some(actor) = account.as_deref()
+                && crate::connection::messaging::signing_venue(state, actor, &target).is_some()
+                && sig_verdict != Some(crate::connection::messaging::ClientSigOutcome::Verified)
+            {
+                tracing::warn!(
+                    peer = %authenticated_peer_id, origin = %origin, target = %target,
+                    account = %actor, verdict = ?sig_verdict,
+                    key_source = crate::peer_keys::has_key_source(state, &origin),
+                    "Relayed edit carries no signature this server can check — dropping it"
+                );
+                return;
+            }
             if let Some(ref root) = edit_of {
                 let history_key = (target.starts_with('#') || target.starts_with('&'))
                     .then(|| target.to_lowercase());
@@ -4296,6 +4325,38 @@ pub(crate) async fn process_s2s_message(
                 }
             }
 
+            // ── A relayed mutation takes the actor's own proof ──────────
+            //
+            // The peer names who acted; only a signature from that account's
+            // key makes the claim something this server can check rather than
+            // something it is told. Without one the event is dropped here —
+            // not applied on the peer's word, and not shown to anyone.
+            //
+            // Two exemptions, the same two as local ingress, both cases where
+            // no proof could exist: an event naming no account is a guest's
+            // and keeps the nick rules, and a venue that does not resolve (a
+            // DM with a guest here) has no document for anyone to sign.
+            //
+            // A signature this server cannot check *yet* is dropped like any
+            // other: the key lookup runs off this path and never holds an
+            // event back, so the first mutation from a signer whose key is not
+            // cached is lost, and every mutation from a peer with no key
+            // server configured is. That is worth an operator seeing, hence
+            // the log naming both.
+            if let Some(actor) = peer_account.as_deref()
+                && relayed_mutation_in(&tags).is_some()
+                && crate::connection::messaging::signing_venue(state, actor, &target).is_some()
+                && sig_verdict != Some(crate::connection::messaging::ClientSigOutcome::Verified)
+            {
+                tracing::warn!(
+                    peer = %authenticated_peer_id, origin = %origin, target = %target,
+                    account = %actor, verdict = ?sig_verdict,
+                    key_source = crate::peer_keys::has_key_source(state, &origin),
+                    "Relayed mutation carries no signature this server can check — dropping it"
+                );
+                return;
+            }
+
             // The subject as it arrived, before the re-rooting below rewrites
             // it. The signature covers this value, so a filed document may only
             // claim the signature when the two still agree.
@@ -4308,13 +4369,6 @@ pub(crate) async fn process_s2s_message(
 
             // Normalize draft tags
             let mut tags = tags.clone();
-            // A mutation signature that did not check out does not travel
-            // under it — the same rule the relayed-PRIVMSG path follows. The
-            // mutation itself still applies: authorization is a separate
-            // question, answered by the checks further down.
-            if sig_verdict == Some(crate::connection::messaging::ClientSigOutcome::Failed) {
-                tags.remove("+freeq.at/sig");
-            }
             for (draft, canonical) in [("+draft/react", "+react"), ("+draft/reply", "+reply")] {
                 if let Some(v) = tags.remove(draft) {
                     tags.entry(canonical.to_string()).or_insert(v);
@@ -6273,6 +6327,18 @@ mod s2s_adversarial_tests {
     const SIGNER: &str = "did:plc:relayedsigner";
 
     /// A signer whose key is on file here, as a key lookup would leave it.
+    /// [`signer_on_file`] where a database may be absent. A server without one
+    /// resolves no keys, so there is nothing a signature could be checked
+    /// against and nothing to register.
+    fn signer_on_file_opt(
+        state: &Arc<SharedState>,
+        did: &str,
+    ) -> Option<ed25519_dalek::SigningKey> {
+        let key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        state.with_db(|db| db.save_signing_key(did, key.verifying_key().as_bytes()))?;
+        Some(key)
+    }
+
     fn signer_on_file(state: &Arc<SharedState>, did: &str) -> ed25519_dalek::SigningKey {
         let key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
         state
@@ -6937,11 +7003,13 @@ mod s2s_adversarial_tests {
         ));
     }
 
-    /// The mutation half of the never-launder rule: a reaction whose subject
-    /// was swapped in flight is relayed without the signature that no longer
-    /// covers it.
+    /// A reaction whose subject was swapped in flight is not relayed at all.
+    /// The signature stopped covering the event, and a mutation this server
+    /// cannot stand behind does not get applied on the peer's word — the
+    /// swapped-onto message is someone else's, and moving a reaction onto it
+    /// is the whole attack.
     #[tokio::test]
-    async fn a_relayed_mutation_whose_signature_fails_is_relayed_without_it() {
+    async fn a_relayed_mutation_whose_signature_fails_is_dropped() {
         let state = test_state_with_db();
         let mgr = test_manager();
         setup_authenticated_peer(&state, &mgr).await;
@@ -6993,15 +7061,108 @@ mod s2s_adversarial_tests {
         )
         .await;
 
-        let frame = rx.try_recv().expect("the reaction reached the member");
         assert!(
-            !frame.contains("+freeq.at/sig"),
-            "a mutation signature that failed must not reach local clients: {frame}"
+            rx.try_recv().is_err(),
+            "a mutation whose signature failed must not reach local clients at all"
         );
-        assert!(
-            frame.contains("+react"),
-            "the reaction itself still relays: {frame}"
-        );
+        let filed = state
+            .with_db(|db| db.get_reactions_for_messages(&["01SOMEONEELSESMESSAGE"]))
+            .expect("test state has a database");
+        assert!(filed.is_empty(), "and must not be on file either: {filed:?}");
+    }
+
+    /// The unsigned case, which is what an older peer sends: the actor is
+    /// named, nothing proves it, and the event does not apply.
+    #[tokio::test]
+    async fn a_relayed_mutation_with_no_signature_is_dropped() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#chat");
+
+        let (tx, mut rx) = mpsc::channel(16);
+        state.connections.lock().insert("m".to_string(), tx);
+        state.cap_message_tags.lock().insert("m".to_string());
+        state
+            .channels
+            .lock()
+            .get_mut("#chat")
+            .unwrap()
+            .members
+            .insert("m".to_string());
+
+        for tags in [
+            HashMap::from([("+draft/delete".to_string(), "01SUBJECTMSGID".to_string())]),
+            HashMap::from([
+                ("+react".to_string(), "👍".to_string()),
+                ("+reply".to_string(), "01SUBJECTMSGID".to_string()),
+            ]),
+            HashMap::from([
+                ("+freeq.at/unreact".to_string(), "👍".to_string()),
+                ("+reply".to_string(), "01SUBJECTMSGID".to_string()),
+            ]),
+        ] {
+            process_s2s_message(
+                &state,
+                &mgr,
+                PEER,
+                S2sMessage::Tagmsg {
+                    event_id: format!("{PEER}:unsigned"),
+                    from: "remote!u@s2s".to_string(),
+                    target: "#chat".to_string(),
+                    tags: tags.clone(),
+                    origin: PEER.to_string(),
+                    account: Some(SIGNER.to_string()),
+                },
+            )
+            .await;
+            assert!(
+                rx.try_recv().is_err(),
+                "an unsigned relayed mutation must not reach local clients: {tags:?}"
+            );
+        }
+    }
+
+    /// A mutation naming no account is a guest's, and a guest's mutations
+    /// have never been signed by anyone. They keep the rules they had.
+    #[tokio::test]
+    async fn a_relayed_guest_mutation_still_applies() {
+        let state = test_state_with_db();
+        let mgr = test_manager();
+        setup_authenticated_peer(&state, &mgr).await;
+        setup_channel(&state, "#chat");
+
+        let (tx, mut rx) = mpsc::channel(16);
+        state.connections.lock().insert("m".to_string(), tx);
+        state.cap_message_tags.lock().insert("m".to_string());
+        state
+            .channels
+            .lock()
+            .get_mut("#chat")
+            .unwrap()
+            .members
+            .insert("m".to_string());
+
+        process_s2s_message(
+            &state,
+            &mgr,
+            PEER,
+            S2sMessage::Tagmsg {
+                event_id: format!("{PEER}:guestreact"),
+                from: "guest!u@s2s".to_string(),
+                target: "#chat".to_string(),
+                tags: HashMap::from([
+                    ("+react".to_string(), "👍".to_string()),
+                    ("+reply".to_string(), "01SUBJECTMSGID".to_string()),
+                ]),
+                origin: PEER.to_string(),
+                account: None,
+            },
+        )
+        .await;
+
+        let frame = rx.try_recv().expect("a guest's reaction still relays");
+        assert!(frame.contains("+react"), "{frame}");
     }
 
     /// A DM mutation that crossed the hop verifies here against the venue its
@@ -8933,7 +9094,9 @@ mod s2s_adversarial_tests {
     #[tokio::test]
     async fn s2s_tagmsg_carries_the_origin_stamped_account() {
         const REMOTE_DID: &str = "did:plc:remoteactor";
-        let state = test_state();
+        // A database, because the reaction now has to carry a signature and a
+        // signature is checked against a key this server holds.
+        let state = test_state_with_db();
         let mgr = test_manager();
         setup_authenticated_peer(&state, &mgr).await;
         setup_channel(&state, "#acct-test");
@@ -8962,6 +9125,15 @@ mod s2s_adversarial_tests {
         let mut tags = HashMap::new();
         tags.insert("+react".to_string(), "👍".to_string());
         tags.insert("+reply".to_string(), "msg001".to_string());
+        sign_relayed_mutation(
+            &state,
+            Some(REMOTE_DID),
+            "#acct-test",
+            freeq_sdk::chatsig::Mutation::React,
+            "msg001",
+            Some("👍"),
+            &mut tags,
+        );
 
         process_s2s_message(
             &state,
@@ -10242,6 +10414,18 @@ mod s2s_adversarial_tests {
         from: &str,
         account: Option<&str>,
     ) {
+        // An edit is a mutation, so it crosses the hop with the editor's own
+        // signature or not at all. A plain message needs none.
+        let sig = replaces.and_then(|root| {
+            let did = account?;
+            let venue = crate::connection::messaging::signing_venue(state, did, channel)?;
+            let key = signer_on_file_opt(state, did)?;
+            Some(
+                freeq_sdk::chatsig::ChatDoc::message(did, msgid, &venue, text)
+                    .with_edit(root)
+                    .sign(&key),
+            )
+        });
         process_s2s_message(
             state,
             mgr,
@@ -10253,7 +10437,7 @@ mod s2s_adversarial_tests {
                 text: text.to_string(),
                 origin: PEER.to_string(),
                 msgid: Some(msgid.to_string()),
-                sig: None,
+                sig,
                 account: account.map(|a| a.to_string()),
                 recipient_did: None,
                 replaces_msgid: replaces.map(|r| r.to_string()),
@@ -10262,6 +10446,38 @@ mod s2s_adversarial_tests {
             },
         )
         .await;
+    }
+
+    /// Sign a relayed mutation the way a current peer's client does: the
+    /// actor's own key, over the venue the receiving server rebuilds.
+    ///
+    /// Registers the key as the peer's key server would have supplied it. A
+    /// venue that does not resolve leaves the event unsigned, because nothing
+    /// could have signed it — the exemption, reproduced rather than
+    /// worked around.
+    fn sign_relayed_mutation(
+        state: &Arc<SharedState>,
+        account: Option<&str>,
+        target: &str,
+        kind: freeq_sdk::chatsig::Mutation,
+        subject: &str,
+        emoji: Option<&str>,
+        tags: &mut HashMap<String, String>,
+    ) {
+        let Some(did) = account else { return };
+        let Some(venue) = crate::connection::messaging::signing_venue(state, did, target) else {
+            return;
+        };
+        let Some(key) = signer_on_file_opt(state, did) else {
+            return;
+        };
+        let event_id = crate::msgid::generate();
+        let mut doc = freeq_sdk::chatsig::ChatDoc::mutation(kind, did, &event_id, &venue, subject);
+        if let Some(emoji) = emoji {
+            doc = doc.with_emoji(emoji);
+        }
+        tags.insert("+freeq.at/sig".to_string(), doc.sign(&key));
+        tags.insert(freeq_sdk::chatsig::EVENT_ID_TAG.to_string(), event_id);
     }
 
     async fn relay_delete(
@@ -10274,6 +10490,15 @@ mod s2s_adversarial_tests {
     ) {
         let mut tags = HashMap::new();
         tags.insert("+draft/delete".to_string(), msgid.to_string());
+        sign_relayed_mutation(
+            state,
+            account,
+            channel,
+            freeq_sdk::chatsig::Mutation::Delete,
+            msgid,
+            None,
+            &mut tags,
+        );
         process_s2s_message(
             state,
             mgr,
@@ -10776,6 +11001,15 @@ mod s2s_adversarial_tests {
         let mut tags = HashMap::new();
         tags.insert("+react".to_string(), "🔥".to_string());
         tags.insert("+reply".to_string(), "id-1".to_string());
+        sign_relayed_mutation(
+            &state,
+            Some(AUTHOR_DID),
+            "#fedreact",
+            freeq_sdk::chatsig::Mutation::React,
+            "id-1",
+            Some("🔥"),
+            &mut tags,
+        );
         process_s2s_message(
             &state,
             &mgr,
@@ -10821,7 +11055,17 @@ mod s2s_adversarial_tests {
                 text: text.to_string(),
                 origin: PEER.to_string(),
                 msgid: Some(msgid.to_string()),
-                sig: None,
+                sig: replaces.and_then(|root| {
+                    let venue = crate::connection::messaging::signing_venue(
+                        state, AUTHOR_DID, to_nick,
+                    )?;
+                    let key = signer_on_file_opt(state, AUTHOR_DID)?;
+                    Some(
+                        freeq_sdk::chatsig::ChatDoc::message(AUTHOR_DID, msgid, &venue, text)
+                            .with_edit(root)
+                            .sign(&key),
+                    )
+                }),
                 account: Some(AUTHOR_DID.to_string()),
                 recipient_did: None,
                 replaces_msgid: replaces.map(|r| r.to_string()),

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -7197,6 +7197,67 @@ mod s2s_adversarial_tests {
         assert!(frame.contains("+react"), "{frame}");
     }
 
+    /// Every chat path resolves a key by the `kid` its signature names, never
+    /// by "the identity's current key". A device that rotates keys — or a
+    /// second device signing in — would otherwise invalidate every signature
+    /// the earlier key made, turning honest history into a wall of forgery
+    /// verdicts the moment someone reconnects.
+    ///
+    /// Two of the three paths are here: a relayed message, and a replayed
+    /// event checked against the bytes it travelled with. The third, the
+    /// verify endpoint's classifier, is pinned in `web.rs`.
+    #[tokio::test]
+    async fn chat_paths_resolve_a_key_by_kid_not_by_latest() {
+        let state = test_state_with_db();
+        // The key that signs, registered first…
+        let old = signer_on_file(&state, SIGNER);
+        // …and a newer one, which is what "the identity's current key" means.
+        let _new = signer_on_file(&state, SIGNER);
+
+        let sig = sign_channel_message(&old, SIGNER, "01OLDKEY", "#chat", "signed before rotating");
+        assert_eq!(
+            check_relayed(
+                &state,
+                Some(SIGNER),
+                "#chat",
+                Some("01OLDKEY"),
+                "signed before rotating",
+                &HashMap::new(),
+                Some(&sig),
+            ),
+            Some(crate::connection::messaging::ClientSigOutcome::Verified),
+            "a relayed message signed with a retired key must still verify"
+        );
+
+        // The replay path checks the bytes it was handed, by the same rule.
+        let canonical = freeq_sdk::chatsig::ChatDoc::mutation(
+            freeq_sdk::chatsig::Mutation::Delete,
+            SIGNER,
+            "01OLDKEYDELETE",
+            &freeq_sdk::chatsig::channel_venue("#chat"),
+            "01SUBJECTMSGID",
+        )
+        .canonical();
+        let mutation_sig = freeq_sdk::chatsig::ChatDoc::mutation(
+            freeq_sdk::chatsig::Mutation::Delete,
+            SIGNER,
+            "01OLDKEYDELETE",
+            &freeq_sdk::chatsig::channel_venue("#chat"),
+            "01SUBJECTMSGID",
+        )
+        .sign(&old);
+        assert_eq!(
+            crate::connection::messaging::verify_canonical_bytes(
+                &state,
+                SIGNER,
+                &canonical,
+                &mutation_sig,
+            ),
+            crate::connection::messaging::ClientSigOutcome::Verified,
+            "a replayed event signed with a retired key must still verify"
+        );
+    }
+
     /// A DM mutation that crossed the hop verifies here against the venue its
     /// signature covers.
     ///

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -4341,7 +4341,11 @@ pub(crate) async fn process_s2s_message(
             // server configured is. That is worth an operator seeing, hence
             // the log naming both.
             if let Some(actor) = peer_account.as_deref()
-                && relayed_mutation_in(&tags).is_some()
+                // A mutation names the message it acts on. One that names none
+                // is not something a signer signs — the sender side reads the
+                // same tags and declines — so demanding proof for it would
+                // refuse an event nothing could ever have proven.
+                && relayed_mutation_in(&tags).is_some_and(|(.., subject, _)| subject.is_some())
                 && crate::connection::messaging::signing_venue(state, actor, &target).is_some()
                 && sig_verdict != Some(crate::connection::messaging::ClientSigOutcome::Verified)
             {

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -3883,12 +3883,11 @@ pub(crate) async fn process_s2s_message(
                     if let Some(ref acct) = account {
                         tags.insert("account".to_string(), acct.clone());
                     }
-                    // Prefer the DID carried from the origin; fall back to a
-                    // local nick_owners lookup for peers that didn't send one.
-                    let sender_nick = from.split('!').next().unwrap_or(&from);
-                    let s2s_sender_did = account
-                        .clone()
-                        .or_else(|| state.nick_owners.lock().get(sender_nick).cloned());
+                    // Who sent this is the origin's to state, and only the
+                    // origin's: a nick is something a peer chooses, so
+                    // resolving one against our own records answered "who is
+                    // this" with the name of whoever holds that nick here.
+                    let s2s_sender_did = account.clone();
                     // File it before showing it. Persists the coordination
                     // tags (incl. +freeq.at/origin) so CHATHISTORY replay
                     // carries them, like the DM persist path — and if the
@@ -4071,14 +4070,11 @@ pub(crate) async fn process_s2s_message(
                 }
             } else {
                 // Persist first — a DM the store refuses (spent msgid) must
-                // not be delivered either. A durable row needs both DIDs:
-                // prefer the sender DID carried from the origin (a remote
-                // sender is not in our nick_owners); fall back to the local
-                // lookup.
-                let sender_nick = from.split('!').next().unwrap_or(&from);
-                let sender_did = account
-                    .clone()
-                    .or_else(|| state.nick_owners.lock().get(sender_nick).cloned());
+                // not be delivered either. A durable row needs both DIDs, and
+                // the sender's is the one the origin stamped or none: filing a
+                // DM under a DID resolved from a peer-chosen nick wrote one
+                // person's thread into another's.
+                let sender_did = account.clone();
                 // Recipient: honor the origin's stamp, cross-checked against our
                 // own resolution. On a mismatch we fall back (no durable row)
                 // rather than persist under a possibly-wrong identity.
@@ -4277,21 +4273,13 @@ pub(crate) async fn process_s2s_message(
         } => {
             let from = sanitize_s2s_str(&from, 512);
             let target = sanitize_s2s_str(&target, 200);
-            // Actor DID, origin-stamped. Older peers send none, so keep the
-            // nick lookup as the fallback — it resolves for anyone who has
-            // authenticated here, which is what we relied on before.
+            // Actor DID, origin-stamped or none. A peer chooses the nick it
+            // sends, so looking that nick up here answered "who is acting"
+            // with whoever holds it on this server — which is what let a peer
+            // delete a local user's message by wearing their name.
             let actor_nick = from.split('!').next().unwrap_or(&from).to_string();
-            // The DID the peer stamped, kept separate from `actor_did` below:
-            // this one the origin asserts about its own authenticated session,
-            // the other may have come from our nick map instead.
             let peer_account = account.map(|a| sanitize_s2s_str(&a, 512));
-            let actor_did = peer_account.clone().or_else(|| {
-                state
-                    .nick_owners
-                    .lock()
-                    .get(&actor_nick.to_lowercase())
-                    .cloned()
-            });
+            let actor_did = peer_account.clone();
 
             // ── verify before tidying ────────────────────────────────
             // Same rule the relayed-PRIVMSG path follows: the renames and the

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -1493,17 +1493,13 @@ async fn api_verify_message(
     let sig_tag = msg.tags.get(freeq_sdk::sigtag::SIG_TAG).cloned();
 
     // The `account` tag is the origin's own statement of who sent this, which
-    // is what the document binds; the nick map is a last resort for rows
-    // predating it.
-    let sender_nick = msg.from.split('!').next().unwrap_or(&msg.from).to_string();
+    // is what the document binds. A row that carries neither it nor a stored
+    // sender names nobody, and this endpoint says so — `unverifiable-unknown-
+    // sender` below. Resolving the nick against our own records instead
+    // rebuilt the document around whoever holds that nick *here*, which is a
+    // verdict about a message the named identity may never have sent.
     if sender_did.is_none() {
-        sender_did = msg.tags.get("account").cloned().or_else(|| {
-            state
-                .nick_owners
-                .lock()
-                .get(&sender_nick.to_lowercase())
-                .cloned()
-        });
+        sender_did = msg.tags.get("account").cloned();
     }
 
     // Rebuild the exact document the signer signed, through the one builder
@@ -5206,6 +5202,64 @@ mod signature_verdict_tests {
         assert_eq!(out.0["verification"]["verdict"], "valid");
         assert_eq!(out.0["verification"]["verified_by"], "client-session-key");
         assert_eq!(out.0["sender_did"], did);
+    }
+
+    /// A row that names no sender is answered as one, not guessed at. The
+    /// endpoint used to fall back to whoever holds the sender's nick on this
+    /// server, which rebuilt a document around a DID the signer never signed
+    /// — and then reported the mismatch as a verdict about the message.
+    #[tokio::test]
+    async fn a_row_with_no_sender_did_is_unverifiable_not_attributed_by_nick() {
+        let state = test_state_with_db();
+        let key = SigningKey::from_bytes(&[13u8; 32]);
+        let local = "did:plc:holdsthenick";
+        let msgid = "01KYVT5Z8Q00000000NONAME00";
+        state
+            .with_db(|db| db.save_signing_key(local, key.verifying_key().as_bytes()))
+            .expect("test state has a database");
+        // The nick belongs to a local identity here…
+        state
+            .nick_owners
+            .lock()
+            .insert("stranger".to_string(), local.to_string());
+
+        // …but the row names no sender, and carries a signature by whoever
+        // did write it. Nothing here can say who that was.
+        let sig = ChatDoc::message(
+            local,
+            msgid,
+            &freeq_sdk::chatsig::channel_venue("#nameless"),
+            "who wrote this",
+        )
+        .sign(&key);
+        let tags = std::collections::HashMap::from([(freeq_sdk::sigtag::SIG_TAG.to_string(), sig)]);
+        state
+            .with_db(|db| {
+                db.insert_message(
+                    "#nameless",
+                    "stranger!u@s2s",
+                    "who wrote this",
+                    0,
+                    &tags,
+                    Some(msgid),
+                    None,
+                )
+            })
+            .expect("test state has a database");
+
+        let out = api_verify_message(
+            axum::extract::State(state),
+            axum::extract::Path(msgid.to_string()),
+        )
+        .await
+        .expect("the message is on file");
+        assert_eq!(out.0["verification"]["verdict"], "unverifiable");
+        assert_eq!(
+            out.0["verification"]["verified_by"], "unverifiable-unknown-sender",
+            "a nick is not an identity, and the endpoint must say so rather \
+             than answer with whoever holds it: {:?}",
+            out.0["verification"]
+        );
     }
 
     /// A federated *edit*: the linkage it signs lives in the row's

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -5204,6 +5204,33 @@ mod signature_verdict_tests {
         assert_eq!(out.0["sender_did"], did);
     }
 
+    /// The classifier resolves the key the signature's `kid` names, never the
+    /// identity's newest. The third of the three chat paths that must agree
+    /// on this (the other two are pinned in `server.rs`): a reader coming back
+    /// to old history after the signer reconnected must still get a verdict
+    /// about the message, not about which key is current.
+    #[test]
+    fn the_classifier_resolves_a_key_by_kid_not_by_latest() {
+        let state = test_state_with_db();
+        let old = SigningKey::from_bytes(&[21u8; 32]);
+        let newer = SigningKey::from_bytes(&[22u8; 32]);
+        for key in [&old, &newer] {
+            state
+                .with_db(|db| db.save_signing_key(DID, key.verifying_key().as_bytes()))
+                .expect("test state has a database");
+        }
+
+        let canonical = doc().canonical();
+        let sig = doc().sign(&old);
+        let (verdict, by, _) =
+            classify_message_signature(&state, Some(DID), Some(&canonical), Some(&sig));
+        assert_eq!(
+            (verdict, by),
+            ("valid", "client-session-key"),
+            "a signature from a retired key must still verify"
+        );
+    }
+
     /// A row that names no sender is answered as one, not guessed at. The
     /// endpoint used to fall back to whoever holds the sender's nick on this
     /// server, which rebuilt a document around a DID the signer never signed

--- a/freeq-server/tests/account_tag_on_tagmsg.rs
+++ b/freeq-server/tests/account_tag_on_tagmsg.rs
@@ -17,7 +17,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
+use ed25519_dalek::SigningKey;
 use freeq_sdk::auth::{self, ChallengeSigner, KeySigner};
+use freeq_sdk::chatsig::{ChatDoc, EVENT_ID_TAG, Mutation, channel_venue};
 use freeq_sdk::crypto::PrivateKey;
 use freeq_sdk::did::{self, DidResolver};
 
@@ -211,6 +213,40 @@ impl C {
             })
             .unwrap_or_default()
     }
+
+    /// Register a session signing key, as every signing client does after auth.
+    fn msgsig(&mut self, key: &SigningKey) {
+        use base64::Engine;
+        let pubkey =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.verifying_key().as_bytes());
+        self.tx(&format!("MSGSIG {pubkey}"));
+        self.rx(|l| l.contains("MSGSIG"), "MSGSIG ack");
+    }
+}
+
+/// The tags of a mutation an identity signed. An authenticated sender's
+/// delete or reaction is refused without one, so every such test here sends
+/// the real thing.
+fn signed_mutation_tags(
+    kind: Mutation,
+    subject_tag: &str,
+    subject: &str,
+    emoji: Option<&str>,
+    channel: &str,
+    key: &SigningKey,
+) -> String {
+    let event_id = freeq_server::msgid::generate();
+    let venue = channel_venue(channel);
+    let mut doc = ChatDoc::mutation(kind, DID_ALICE, &event_id, &venue, subject);
+    if let Some(emoji) = emoji {
+        doc = doc.with_emoji(emoji);
+    }
+    let sig = doc.sign(key);
+    let head = match emoji {
+        Some(e) => format!("{subject_tag}={e};+reply={subject}"),
+        None => format!("{subject_tag}={subject}"),
+    };
+    format!("{head};{EVENT_ID_TAG}={event_id};+freeq.at/sig={sig}")
 }
 
 /// The `account` tag value on an IRC line, if it carries one. Matches the
@@ -234,6 +270,8 @@ async fn delete_names_the_sender_for_a_recipient_that_asked_for_account_tag() {
     run(addr, move |addr| {
         let mut alice = C::authed(addr, "at_alice", CAPS_WITH_ACCOUNT, DID_ALICE, key);
         alice.reg();
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
+        alice.msgsig(&signing);
         alice.drain();
         let mut bob = C::guest(addr, "at_bob", CAPS_WITH_ACCOUNT);
         bob.reg();
@@ -247,7 +285,15 @@ async fn delete_names_the_sender_for_a_recipient_that_asked_for_account_tag() {
         assert!(!msgid.is_empty(), "no msgid on the message: {seen}");
         bob.drain();
 
-        alice.tx(&format!("@+draft/delete={msgid} TAGMSG #atd"));
+        let tags = signed_mutation_tags(
+            Mutation::Delete,
+            "+draft/delete",
+            &msgid,
+            None,
+            "#atd",
+            &signing,
+        );
+        alice.tx(&format!("@{tags} TAGMSG #atd"));
         let del = bob
             .maybe(|l| l.contains("TAGMSG") && l.contains("+draft/delete"), 2000)
             .expect("bob receives the delete");
@@ -268,6 +314,8 @@ async fn delete_omits_account_for_a_recipient_that_did_not_ask() {
     run(addr, move |addr| {
         let mut alice = C::authed(addr, "at2_alice", CAPS_WITH_ACCOUNT, DID_ALICE, key);
         alice.reg();
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
+        alice.msgsig(&signing);
         alice.drain();
         // Bob negotiated message-tags but NOT account-tag.
         let mut bob = C::guest(addr, "at2_bob", CAPS_WITHOUT_ACCOUNT);
@@ -281,7 +329,15 @@ async fn delete_omits_account_for_a_recipient_that_did_not_ask() {
         let msgid = C::extract_msgid(&seen);
         bob.drain();
 
-        alice.tx(&format!("@+draft/delete={msgid} TAGMSG #atd2"));
+        let tags = signed_mutation_tags(
+            Mutation::Delete,
+            "+draft/delete",
+            &msgid,
+            None,
+            "#atd2",
+            &signing,
+        );
+        alice.tx(&format!("@{tags} TAGMSG #atd2"));
         let del = bob
             .maybe(|l| l.contains("TAGMSG") && l.contains("+draft/delete"), 2000)
             .expect("bob still receives the delete itself");
@@ -339,6 +395,8 @@ async fn a_channel_reaction_names_the_sender() {
     run(addr, move |addr| {
         let mut alice = C::authed(addr, "at4_alice", CAPS_WITH_ACCOUNT, DID_ALICE, key);
         alice.reg();
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
+        alice.msgsig(&signing);
         alice.drain();
         let mut bob = C::guest(addr, "at4_bob", CAPS_WITH_ACCOUNT);
         bob.reg();
@@ -351,7 +409,15 @@ async fn a_channel_reaction_names_the_sender() {
         let msgid = C::extract_msgid(&seen);
         bob.drain();
 
-        alice.tx(&format!("@+react=\u{1F44D};+reply={msgid} TAGMSG #atr"));
+        let tags = signed_mutation_tags(
+            Mutation::React,
+            "+react",
+            &msgid,
+            Some("\u{1F44D}"),
+            "#atr",
+            &signing,
+        );
+        alice.tx(&format!("@{tags} TAGMSG #atr"));
         let tagmsg = bob
             .maybe(|l| l.contains("TAGMSG") && l.contains("+react"), 2000)
             .expect("bob receives the reaction");

--- a/freeq-server/tests/chat_signing.rs
+++ b/freeq-server/tests/chat_signing.rs
@@ -1672,6 +1672,63 @@ async fn an_unreaction_leaves_the_event_that_removed_the_reaction() {
     assert_eq!(live, 0, "the reaction was taken back");
 }
 
+/// A reaction from outside a `+n` channel is refused at the door, and the
+/// door is what the row has to be behind: filing first left a reaction on
+/// file that no member ever received, visible to everyone on the next join.
+#[tokio::test]
+async fn a_non_members_reaction_leaves_nothing_behind() {
+    use freeq_sdk::chatsig::Mutation;
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, db_path, _h) =
+        start_with_db(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    let db_for_test = db_path.clone();
+    run(addr, move |addr| {
+        // Bob owns the channel; alice never joins it. `+n` is on by default.
+        let mut bob = C::authenticated(addr, "bob", did_bob, kb);
+        bob.join("#members");
+        let msgid = freeq_server::msgid::generate();
+        bob.tx(&format!(
+            "@{EVENT_ID_TAG}={msgid} PRIVMSG #members :members only"
+        ));
+        bob.rx(|l| l.contains("members only"), "bob's message");
+
+        let mut outsider = C::authenticated(addr, "alice", DID_ALICE, ka);
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
+        outsider.msgsig(&signing);
+        let event_id = freeq_server::msgid::generate();
+        let tags = signed_mutation_tags(
+            Mutation::React,
+            "+react",
+            &msgid,
+            Some("👍"),
+            "#members",
+            &event_id,
+            &signing,
+        );
+        outsider.tx(&format!("@{tags} TAGMSG #members"));
+        outsider.rx(
+            |l| l.contains("Cannot send to channel"),
+            "the +n refusal",
+        );
+        assert!(
+            bob.maybe(|l| l.contains("+react"), 500).is_none(),
+            "a non-member's reaction must not reach the channel"
+        );
+    })
+    .await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let conn = rusqlite::Connection::open(&db_for_test).unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM reactions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        rows, 0,
+        "a reaction nobody received must not be on file either"
+    );
+}
+
 /// The log records events, not signatures. A guest has no identity to bind and
 /// nothing to sign with — and their acts still happened, so they are still on
 /// file: a server-minted id, no signature, no canonical, and honest about all

--- a/freeq-server/tests/chat_signing.rs
+++ b/freeq-server/tests/chat_signing.rs
@@ -511,12 +511,82 @@ async fn a_signature_that_fails_is_not_quietly_replaced_with_the_servers() {
             .sign(&signing);
         alice.send_signed(&id, "#sig", "what I sent", &sig);
 
-        let seen = bob.rx(|l| l.contains("what I sent"), "delivery");
-        assert_eq!(
-            C::sig_of(&seen),
-            None,
+        // Neither laundered into a server signature nor delivered without the
+        // half that disagreed: refused outright.
+        assert!(
+            bob.maybe(|l| l.contains("what I sent"), 500).is_none(),
             "a signature that didn't check out must not be laundered into a \
-             server signature: {seen}"
+             server signature, and its message must not be relayed either"
+        );
+    })
+    .await;
+}
+
+/// A message whose signature fails against the key it names is evidence the
+/// bytes moved between the signer and here. It is refused rather than
+/// relayed stripped of the signature: the words and the proof arrived
+/// together and disagreed, and passing on the half that still looks fine
+/// hides exactly the fact worth knowing.
+#[tokio::test]
+async fn a_message_whose_signature_fails_is_refused_at_the_origin() {
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    run(addr, move |addr| {
+        let mut bob = C::authenticated(addr, "bob", did_bob, kb);
+        bob.join("#tampered");
+        let mut alice = C::authenticated(addr, "alice", DID_ALICE, ka);
+        alice.join("#tampered");
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
+        alice.msgsig(&signing);
+
+        // Signed over one body, sent with another — what a relay rewriting a
+        // message in flight produces.
+        let msgid = freeq_server::msgid::generate();
+        let sig = ChatDoc::message(DID_ALICE, &msgid, &channel_venue("#tampered"), "what she wrote")
+            .sign(&signing);
+        alice.tx(&format!(
+            "@{EVENT_ID_TAG}={msgid};+freeq.at/sig={sig} PRIVMSG #tampered :what arrived instead"
+        ));
+
+        let fail = alice.rx(|l| l.contains("SIGNATURE_INVALID"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL PRIVMSG SIGNATURE_INVALID"),
+            "the refusal names the command and why: {fail}"
+        );
+        assert!(
+            bob.maybe(|l| l.contains("what arrived instead"), 500).is_none(),
+            "a message whose signature failed must not reach anyone"
+        );
+    })
+    .await;
+}
+
+/// The other two verdicts are untouched: a message nobody signed still goes,
+/// carrying this server's vouch, and so does one signed under the retired
+/// format — which no key can check and which is therefore never evidence of
+/// tampering.
+#[tokio::test]
+async fn an_uncheckable_signature_still_delivers() {
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    run(addr, move |addr| {
+        let mut bob = C::authenticated(addr, "bob", did_bob, kb);
+        bob.join("#legacy");
+        let mut alice = C::authenticated(addr, "alice", DID_ALICE, ka);
+        alice.join("#legacy");
+
+        // A legacy signature: a bare base64 blob over the retired canonical.
+        alice.tx("@+freeq.at/sig=bGVnYWN5c2lnbmF0dXJl PRIVMSG #legacy :from an old client");
+        let seen = bob.rx(|l| l.contains("from an old client"), "the message");
+        assert!(
+            C::sig_of(&seen).is_some(),
+            "an uncheckable signature keeps the server's vouch: {seen}"
+        );
+        assert!(
+            alice.maybe(|l| l.contains("SIGNATURE_INVALID"), 300).is_none(),
+            "a signature nobody can check is not a signature that failed"
         );
     })
     .await;
@@ -550,11 +620,11 @@ async fn the_signed_venue_is_the_folded_channel_not_the_case_the_sender_typed() 
         let unfolded =
             ChatDoc::message(DID_ALICE, &id2, "#SIG", "signed the wrong venue").sign(&signing);
         alice.send_signed(&id2, "#SIG", "signed the wrong venue", &unfolded);
-        let seen2 = bob.rx(|l| l.contains("signed the wrong venue"), "delivery");
-        assert_eq!(
-            C::sig_of(&seen2),
-            None,
-            "a venue that isn't the folded one is not the venue: {seen2}"
+        alice.rx(|l| l.contains("SIGNATURE_INVALID"), "FAIL to the sender");
+        assert!(
+            bob.maybe(|l| l.contains("signed the wrong venue"), 500).is_none(),
+            "a venue that isn't the folded one is not the venue, and a \
+             signature over it does not verify"
         );
     })
     .await;
@@ -1425,16 +1495,11 @@ async fn a_signature_that_failed_is_not_replayed_by_history() {
         let sig = ChatDoc::message(DID_ALICE, &id, &channel_venue("#notlaundered"), "what I signed")
             .sign(&signing);
         alice.send_signed(&id, "#notlaundered", "what I sent", &sig);
-        let live = bob.rx(|l| l.contains("what I sent"), "live delivery");
-        assert_eq!(C::sig_of(&live), None, "live delivery strips it: {live}");
+        alice.rx(|l| l.contains("SIGNATURE_INVALID"), "FAIL to the sender");
 
-        let replayed =
-            history_of(addr, "#notlaundered", "what I sent").expect("history replays the message");
-        assert_eq!(
-            C::sig_of(&replayed),
-            None,
-            "and history must not resurrect a signature the server refused to \
-             stand behind: {replayed}"
+        assert!(
+            history_of(addr, "#notlaundered", "what I sent").is_none(),
+            "a message the server refused must not be on file to replay"
         );
     })
     .await;

--- a/freeq-server/tests/chat_signing.rs
+++ b/freeq-server/tests/chat_signing.rs
@@ -1068,35 +1068,121 @@ async fn a_guest_cannot_attach_a_mutation_signature() {
     .await;
 }
 
-/// An unsigned mutation from an identity is vouched for by the server, the
-/// same way an unsigned message is. The note means the same thing in both
-/// cases — *this server saw this authenticated account do this* — and a
-/// reader tells a vouch from a device's proof by the key each names.
+/// Changing an existing message takes the sender's own proof. A server
+/// signature over someone else's delete says only that this server believes
+/// them, and a reader cannot tell that from the act itself — so the act is
+/// refused rather than vouched for.
 #[tokio::test]
-async fn an_unsigned_delete_is_vouched_for_by_the_server() {
+async fn an_unsigned_delete_from_an_identity_is_refused() {
     let (ka, kb) = (key(), key());
     let did_bob = "did:plc:sig_bob";
     let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
     run(addr, move |addr| {
-        let (mut bob, mut alice, signing, msgid) =
+        let (mut bob, mut alice, _signing, msgid) =
             two_in_a_channel(addr, ka, kb, did_bob, "#plain");
 
         alice.tx(&format!("@+draft/delete={msgid} TAGMSG #plain"));
-        let seen = bob.rx(|l| l.contains("+draft/delete"), "the delete");
-        let sig = C::sig_of(&seen).expect("the server vouches for it");
-        let (kid, _) = freeq_sdk::sigtag::parse(&sig).expect("sig tag is alg:kid:sig");
-        assert_ne!(
-            kid,
-            freeq_sdk::sigtag::derive_kid(&signing.verifying_key()),
-            "a server vouch must not claim to be the sender's key: {seen}"
+        let fail = alice.rx(|l| l.contains("SIGNATURE_REQUIRED"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL TAGMSG SIGNATURE_REQUIRED"),
+            "the refusal names the command and why: {fail}"
         );
         assert!(
-            seen.contains(EVENT_ID_TAG),
-            "a signature covers an id, so the act gets one: {seen}"
+            bob.maybe(|l| l.contains("+draft/delete"), 500).is_none(),
+            "a refused delete must not reach anyone"
         );
-        assert!(seen.contains(&msgid), "the delete still names its subject: {seen}");
+        // And it deleted nothing.
+        alice.tx("CHATHISTORY LATEST #plain * 10");
+        assert!(
+            alice.maybe(|l| l.contains("act on me"), 1000).is_some(),
+            "a refused delete must not have deleted anything"
+        );
     })
     .await;
+}
+
+/// The same rule for a reaction, which had no refusal branch at all: an
+/// unsigned one from an identity is refused, and no row is written.
+#[tokio::test]
+async fn an_unsigned_reaction_from_an_identity_is_refused() {
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, db_path, _h) =
+        start_with_db(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    let db_for_test = db_path.clone();
+    run(addr, move |addr| {
+        let (mut bob, mut alice, _signing, msgid) =
+            two_in_a_channel(addr, ka, kb, did_bob, "#unsignedreact");
+
+        alice.tx(&format!("@+react=👍;+reply={msgid} TAGMSG #unsignedreact"));
+        let fail = alice.rx(|l| l.contains("SIGNATURE_REQUIRED"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL TAGMSG SIGNATURE_REQUIRED"),
+            "the refusal names the command and why: {fail}"
+        );
+        assert!(
+            bob.maybe(|l| l.contains("+react"), 500).is_none(),
+            "a refused reaction must not reach anyone"
+        );
+    })
+    .await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let conn = rusqlite::Connection::open(&db_for_test).unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM reactions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(rows, 0, "a refused reaction must file nothing");
+}
+
+/// And for taking one back. The signed reaction lands first, so what this
+/// pins is that the refusal leaves it standing rather than removing it.
+#[tokio::test]
+async fn an_unsigned_unreaction_from_an_identity_is_refused() {
+    use freeq_sdk::chatsig::Mutation;
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, db_path, _h) =
+        start_with_db(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    let db_for_test = db_path.clone();
+    run(addr, move |addr| {
+        let (mut bob, mut alice, signing, msgid) =
+            two_in_a_channel(addr, ka, kb, did_bob, "#unsignedunreact");
+
+        let event_id = freeq_server::msgid::generate();
+        let tags = signed_mutation_tags(
+            Mutation::React,
+            "+react",
+            &msgid,
+            Some("👍"),
+            "#unsignedunreact",
+            &event_id,
+            &signing,
+        );
+        alice.tx(&format!("@{tags} TAGMSG #unsignedunreact"));
+        bob.rx(|l| l.contains("+react"), "the signed reaction");
+
+        alice.tx(&format!(
+            "@+freeq.at/unreact=👍;+reply={msgid} TAGMSG #unsignedunreact"
+        ));
+        let fail = alice.rx(|l| l.contains("SIGNATURE_REQUIRED"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL TAGMSG SIGNATURE_REQUIRED"),
+            "the refusal names the command and why: {fail}"
+        );
+        assert!(
+            bob.maybe(|l| l.contains("unreact"), 500).is_none(),
+            "a refused unreaction must not reach anyone"
+        );
+    })
+    .await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let conn = rusqlite::Connection::open(&db_for_test).unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM reactions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(rows, 1, "a refused unreaction must not remove the reaction");
 }
 
 /// A guest has no identity to bind, so there is nothing to vouch for and

--- a/freeq-server/tests/chat_signing.rs
+++ b/freeq-server/tests/chat_signing.rs
@@ -975,6 +975,97 @@ async fn an_edit_signature_that_fails_is_refused_and_never_applied() {
     .await;
 }
 
+/// An edit is a mutation like any other: it rewrites a record that already
+/// exists, so it takes the editor's own proof. Refused rather than vouched
+/// for, and the original stands.
+#[tokio::test]
+async fn an_unsigned_edit_from_an_identity_is_refused() {
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    run(addr, move |addr| {
+        let mut bob = C::authenticated(addr, "bob", did_bob, kb);
+        bob.join("#unsignededit");
+        let mut alice = C::authenticated(addr, "alice", DID_ALICE, ka);
+        alice.join("#unsignededit");
+
+        let root = freeq_server::msgid::generate();
+        alice.send_with_id(&root, "#unsignededit", "first draft");
+        bob.rx(|l| l.contains("first draft"), "the original");
+
+        alice.tx(&format!(
+            "@+draft/edit={root} PRIVMSG #unsignededit :revised without proof"
+        ));
+        let fail = alice.rx(|l| l.contains("SIGNATURE_REQUIRED"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL EDIT SIGNATURE_REQUIRED"),
+            "the refusal names the command and why: {fail}"
+        );
+        assert!(
+            bob.maybe(|l| l.contains("revised without proof"), 500).is_none(),
+            "a refused edit must not reach anyone"
+        );
+        assert!(
+            history_of(addr, "#unsignededit", "first draft").is_some(),
+            "a refused edit must not have changed the original"
+        );
+    })
+    .await;
+}
+
+/// The other half of the same rule. A signature this server cannot check —
+/// here, one naming a key nobody registered — is not proof, and an edit is
+/// refused for want of proof rather than filed on the server's word.
+#[tokio::test]
+async fn an_edit_signed_with_a_key_this_server_cannot_resolve_is_refused() {
+    let (ka, kb) = (key(), key());
+    let did_bob = "did:plc:sig_bob";
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (did_bob, &kb)])).await;
+    run(addr, move |addr| {
+        let mut bob = C::authenticated(addr, "bob", did_bob, kb);
+        bob.join("#unresolvable");
+        let mut alice = C::authenticated(addr, "alice", DID_ALICE, ka);
+        alice.join("#unresolvable");
+
+        let root = freeq_server::msgid::generate();
+        alice.send_with_id(&root, "#unresolvable", "first draft");
+        bob.rx(|l| l.contains("first draft"), "the original");
+
+        // Signed honestly, with a key never registered by MSGSIG: the kid
+        // resolves to nothing here, so the verdict is can't-check.
+        let stranger = SigningKey::from_bytes(&[99u8; 32]);
+        let edit_id = freeq_server::msgid::generate();
+        let sig = ChatDoc::message(
+            DID_ALICE,
+            &edit_id,
+            &channel_venue("#unresolvable"),
+            "revised with an unknown key",
+        )
+        .with_edit(&root)
+        .sign(&stranger);
+        alice.tx(&format!(
+            "@{EVENT_ID_TAG}={edit_id};+draft/edit={root};+freeq.at/sig={sig} \
+             PRIVMSG #unresolvable :revised with an unknown key"
+        ));
+
+        let fail = alice.rx(|l| l.contains("SIGNATURE_REQUIRED"), "FAIL to the sender");
+        assert!(
+            fail.contains("FAIL EDIT SIGNATURE_REQUIRED"),
+            "an unresolvable key is a missing proof, not a bad one: {fail}"
+        );
+        assert!(
+            bob.maybe(|l| l.contains("revised with an unknown key"), 500)
+                .is_none(),
+            "a refused edit must not reach anyone"
+        );
+        assert!(
+            history_of(addr, "#unresolvable", "first draft").is_some(),
+            "a refused edit must not have changed the original"
+        );
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn a_signed_multiline_edit_verifies_and_a_tampered_one_is_refused() {
     let (ka, kb) = (key(), key());

--- a/freeq-server/tests/edit_delete_adversarial.rs
+++ b/freeq-server/tests/edit_delete_adversarial.rs
@@ -8,7 +8,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
+use ed25519_dalek::SigningKey;
 use freeq_sdk::auth::{self, ChallengeSigner, KeySigner};
+use freeq_sdk::chatsig::{ChatDoc, EVENT_ID_TAG, Mutation, dm_venue};
 use freeq_sdk::crypto::PrivateKey;
 use freeq_sdk::did::{self, DidResolver};
 
@@ -1114,6 +1116,101 @@ impl C {
             "@+freeq.at/unreact={emoji};+reply={msgid} TAGMSG {target}"
         ));
     }
+    /// Register a session signing key, as every signing client does after auth.
+    fn msgsig(&mut self, key: &SigningKey) {
+        use base64::Engine;
+        let pubkey =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.verifying_key().as_bytes());
+        self.tx(&format!("MSGSIG {pubkey}"));
+        self.rx(|l| l.contains("MSGSIG"), "MSGSIG ack");
+    }
+    /// The same reaction, carrying the proof an identity's mutation needs.
+    fn send_signed_react(
+        &mut self,
+        target: &str,
+        venue: &str,
+        did: &str,
+        msgid: &str,
+        emoji: &str,
+        key: &SigningKey,
+    ) {
+        self.send_signed_mutation(
+            Mutation::React,
+            "+react",
+            target,
+            venue,
+            did,
+            msgid,
+            Some(emoji),
+            key,
+        );
+    }
+    fn send_signed_unreact(
+        &mut self,
+        target: &str,
+        venue: &str,
+        did: &str,
+        msgid: &str,
+        emoji: &str,
+        key: &SigningKey,
+    ) {
+        self.send_signed_mutation(
+            Mutation::Unreact,
+            "+freeq.at/unreact",
+            target,
+            venue,
+            did,
+            msgid,
+            Some(emoji),
+            key,
+        );
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn send_signed_mutation(
+        &mut self,
+        kind: Mutation,
+        subject_tag: &str,
+        target: &str,
+        venue: &str,
+        did: &str,
+        subject: &str,
+        emoji: Option<&str>,
+        key: &SigningKey,
+    ) {
+        let event_id = freeq_server::msgid::generate();
+        let mut doc = ChatDoc::mutation(kind, did, &event_id, venue, subject);
+        if let Some(emoji) = emoji {
+            doc = doc.with_emoji(emoji);
+        }
+        let sig = doc.sign(key);
+        let head = match emoji {
+            Some(e) => format!("{subject_tag}={e};+reply={subject}"),
+            None => format!("{subject_tag}={subject}"),
+        };
+        self.tx(&format!(
+            "@{head};{EVENT_ID_TAG}={event_id};+freeq.at/sig={sig} TAGMSG {target}"
+        ));
+    }
+    /// An edit signed by its author — an edit is a message, and its document
+    /// covers the message it revises.
+    fn send_signed_edit(
+        &mut self,
+        target: &str,
+        venue: &str,
+        did: &str,
+        original_msgid: &str,
+        new_text: &str,
+        key: &SigningKey,
+    ) {
+        let edit_id = freeq_server::msgid::generate();
+        let sig = ChatDoc::message(did, &edit_id, venue, new_text)
+            .with_edit(original_msgid)
+            .sign(key);
+        self.tx(&format!(
+            "@{EVENT_ID_TAG}={edit_id};+draft/edit={original_msgid};+freeq.at/sig={sig} \
+             PRIVMSG {target} :{new_text}"
+        ));
+    }
     /// Send a message and an edit of it; returns (original id, edit's own id).
     fn say_then_edit(
         &mut self,
@@ -1418,22 +1515,29 @@ async fn a_dm_reaction_survives_an_edit() {
     let resolver = resolver_with(vec![(DID_ALICE, &key_a), (DID_BOB, &key_b)]);
     let (addr, _h) = start(resolver).await;
     run(addr, move |addr| {
+        // Both ends sign: an identity's edit and reactions are refused
+        // without proof from the key it registered.
         let mut alice = C::with_sasl(addr, "dmrid_a", DID_ALICE, key_a);
         alice.reg();
+        let signing_a = SigningKey::from_bytes(&[7u8; 32]);
+        alice.msgsig(&signing_a);
         alice.drain();
         let mut bob = C::with_sasl(addr, "dmrid_b", DID_BOB, key_b);
         bob.reg();
+        let signing_b = SigningKey::from_bytes(&[8u8; 32]);
+        bob.msgsig(&signing_b);
         bob.drain();
+        let venue = dm_venue(DID_ALICE, DID_BOB);
 
         alice.tx("PRIVMSG dmrid_b :dm v1");
         let first = bob.rx(|l| l.contains("PRIVMSG") && l.contains("dm v1"), "dm v1");
         let original = C::extract_msgid(&first);
-        alice.send_edit("dmrid_b", &original, "dm v2");
+        alice.send_signed_edit("dmrid_b", &venue, DID_ALICE, &original, "dm v2", &signing_a);
         let edit = bob.rx(|l| l.contains("PRIVMSG") && l.contains("dm v2"), "dm v2");
         let edit_id = C::extract_msgid(&edit);
         assert_ne!(original, edit_id);
 
-        bob.send_react("dmrid_a", &edit_id, "🔥");
+        bob.send_signed_react("dmrid_a", &venue, DID_BOB, &edit_id, "🔥", &signing_b);
         std::thread::sleep(Duration::from_millis(300));
         bob.drain();
         bob.tx("CHATHISTORY LATEST dmrid_a * 50");
@@ -1443,7 +1547,7 @@ async fn a_dm_reaction_survives_an_edit() {
             "a DM reaction filed against the edit id vanished from history"
         );
 
-        bob.send_unreact("dmrid_a", &original, "🔥");
+        bob.send_signed_unreact("dmrid_a", &venue, DID_BOB, &original, "🔥", &signing_b);
         std::thread::sleep(Duration::from_millis(300));
         bob.drain();
         bob.tx("CHATHISTORY LATEST dmrid_a * 50");

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -314,6 +314,19 @@ fn connect(
     client::connect(config, Some(id.signer()))
 }
 
+/// A client with no identity — the other end of a thread that can never have
+/// a signed venue.
+fn connect_guest(server: &TestServer, nick: &str) -> (client::ClientHandle, mpsc::Receiver<Event>) {
+    let config = ConnectConfig {
+        server_addr: server.irc_addr.clone(),
+        nick: nick.to_string(),
+        user: nick.to_string(),
+        realname: "federation test".to_string(),
+        ..Default::default()
+    };
+    client::connect(config, None)
+}
+
 async fn wait_event(
     rx: &mut mpsc::Receiver<Event>,
     pred: impl Fn(&Event) -> bool,
@@ -645,6 +658,100 @@ async fn tagmsg_to_remote_did_relays_as_structured_tagmsg() {
     ha.quit(None).await.ok();
     hb.quit(None).await.ok();
     drop((srv_a, srv_b));
+}
+
+// ── a DM with a guest on the peer keeps its mutations ────────────
+//
+// The signature requirement asks for proof only where proof could exist. A
+// guest has no DID, so a DM thread with one has no venue: neither end can
+// build the document, so no signature can ever accompany a delete or an edit
+// there. The rule exempts that case locally; a relayed one arrives
+// account-stamped from the origin's authenticated sender and venue-less all
+// the same, and must be exempt on the receiving side too — otherwise the
+// delete applies where it was typed and nowhere else, and the two servers
+// hold different history for good.
+
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn a_dm_with_a_guest_on_the_peer_keeps_its_deletes() {
+    let alice = TestId::new("did:plc:aliceguestdm");
+    let (srv_a, srv_b) = spawn_pair(&[&alice]).await;
+
+    // A guest on B, an identity on A. Nothing about this thread is signable.
+    let (hg, mut rxg) = connect_guest(&srv_b, "gbob");
+    wait_event(
+        &mut rxg,
+        |e| matches!(e, Event::Registered { .. }),
+        "guest registered",
+    )
+    .await;
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+
+    // Resend until it lands, which also warms the link.
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    let mut delivered = None;
+    while tokio::time::Instant::now() < deadline {
+        ha.privmsg("gbob", "across to a guest").await.ok();
+        delivered =
+            msgid_of_message(&mut rxg, "across to a guest", Duration::from_secs(2)).await;
+        if delivered.is_some() {
+            break;
+        }
+    }
+    let msgid = delivered.expect("the guest received the cross-server DM");
+
+    // Alice deletes it. Neither server can check a signature that cannot
+    // exist, and both must apply the delete rather than demand one.
+    let mut del_tags = std::collections::HashMap::new();
+    del_tags.insert("+draft/delete".to_string(), msgid.clone());
+    ha.send_tagmsg("gbob", del_tags).await.unwrap();
+
+    let seen = wait_for_tagmsg(&mut rxg, "+draft/delete", EVENT_TIMEOUT).await;
+    assert!(
+        seen,
+        "a delete in a venue-less DM must cross the hop and apply at the far end"
+    );
+
+    ha.quit(None).await.ok();
+    hg.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}
+
+/// Wait for a message with `text`, returning its msgid.
+async fn msgid_of_message(
+    rx: &mut mpsc::Receiver<Event>,
+    text: &str,
+    within: Duration,
+) -> Option<String> {
+    timeout(within, async {
+        loop {
+            match rx.recv().await {
+                Some(Event::Message { text: t, tags, .. }) if t == text => {
+                    return tags.get("msgid").cloned();
+                }
+                Some(_) => continue,
+                None => return None,
+            }
+        }
+    })
+    .await
+    .unwrap_or(None)
+}
+
+/// Whether a TAGMSG carrying `tag` arrives within the window.
+async fn wait_for_tagmsg(rx: &mut mpsc::Receiver<Event>, tag: &str, within: Duration) -> bool {
+    timeout(within, async {
+        loop {
+            match rx.recv().await {
+                Some(Event::TagMsg { tags, .. }) if tags.contains_key(tag) => return true,
+                Some(_) => continue,
+                None => return false,
+            }
+        }
+    })
+    .await
+    .unwrap_or(false)
 }
 
 // ── a mutation TAGMSG's signature tag crosses the hop byte-identical ─────

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -497,6 +497,61 @@ async fn did_dm_reaches_all_recipient_devices_across_servers() {
     drop((srv_a, srv_b));
 }
 
+/// The sender's *own* other device, signed in on the receiving server.
+///
+/// The origin fans a DM out to the sender's other sessions on its send path;
+/// that code never runs on the far side of a link, so the far side unions the
+/// addressed user's sessions with the sessions of whoever the event names.
+/// That union is delivery into the named identity's own client, so it happens
+/// only on a signature this server checked — and this is the honest case that
+/// must keep working: alice really did send it, and her client really did
+/// sign it.
+#[tokio::test]
+#[ignore = "e2e federation harness; run with --ignored"]
+async fn a_signed_dm_reaches_the_senders_own_device_on_the_far_server() {
+    let alice = TestId::new("did:plc:alicefanout");
+    let bob = TestId::new("did:plc:bobfanout");
+    let (srv_a, srv_b) = spawn_pair(&[&alice, &bob]).await;
+
+    // Bob on B; alice on A, and also signed in on B — the device that only
+    // the far side's fan-out can reach.
+    let (hb, mut rxb) = connect(&srv_b, &bob, "bob");
+    wait_auth_and_register(&mut rxb).await;
+    let (ha2, mut rxa2) = connect(&srv_b, &alice, "alice2");
+    wait_auth_and_register(&mut rxa2).await;
+    let (ha, mut rxa) = connect(&srv_a, &alice, "alice");
+    wait_auth_and_register(&mut rxa).await;
+
+    // Warming the link also gets alice's signing key onto B, which is what
+    // makes the signature checkable there rather than merely present.
+    warm_link(&ha, &bob.did, &mut rxb).await;
+
+    // Resend until her own far-side device sees it: the key lookup runs off
+    // the delivery path, so the first send can land before the key does.
+    let deadline = tokio::time::Instant::now() + S2S_SETTLE;
+    let mut reached = false;
+    while tokio::time::Instant::now() < deadline {
+        ha.privmsg(&bob.did, "sent from my other device").await.ok();
+        if try_recv_message(&mut rxa2, "sent from my other device", Duration::from_secs(2))
+            .await
+            .is_some()
+        {
+            reached = true;
+            break;
+        }
+    }
+    assert!(
+        reached,
+        "a signed cross-server DM never reached the sender's own device on the \
+         receiving server"
+    );
+
+    ha.quit(None).await.ok();
+    ha2.quit(None).await.ok();
+    hb.quit(None).await.ok();
+    drop((srv_a, srv_b));
+}
+
 // ── receiver persists the DID-keyed DM (Element C stamp path) ─────
 
 #[tokio::test]

--- a/freeq-server/tests/federation.rs
+++ b/freeq-server/tests/federation.rs
@@ -1718,13 +1718,11 @@ async fn a_dm_reaches_the_senders_own_session_on_the_receiving_server() {
          sent from the other one"
     );
 
-    // A reaction crosses as its own event and needs the same fan-out.
-    ha.raw(&format!(
-        "@+react=\u{1F44D};+reply={msgid} TAGMSG {}",
-        bob.did
-    ))
-    .await
-    .unwrap();
+    // A reaction crosses as its own event and needs the same fan-out. Sent
+    // through the client rather than as a raw line, because a reaction names
+    // the message it acts on and therefore has to carry the reactor's
+    // signature — a raw line skips the one place that signs it.
+    ha.react(&bob.did, "\u{1F44D}", &msgid).await.unwrap();
 
     assert!(saw_reaction(&mut rxb).await, "bob never saw the reaction");
     assert!(

--- a/freeq-server/tests/lying_peer_adversarial.rs
+++ b/freeq-server/tests/lying_peer_adversarial.rs
@@ -172,6 +172,102 @@ async fn a_peer_impersonating_a_local_nick_cannot_delete_that_users_message() {
     );
 }
 
+/// The sharpest version of the impersonation: the peer stamps the victim's
+/// **real** DID on a mutation, which is the one identity every authorization
+/// check here will accept. Naming it is free — a peer chooses what it sends —
+/// so the only thing separating the claim from the act is a signature by the
+/// key that DID registered.
+///
+/// Neither shape gets through: no signature at all, and one that names a key
+/// this server really holds but does not verify against it.
+#[tokio::test]
+async fn a_peer_stamping_the_victims_did_on_a_mutation_is_refused() {
+    let author = TestId::new("did:plc:lpstamped");
+    let watcher = TestId::new("did:plc:lpstampedwatch");
+    let (srv, mut peer, ha, mut rxw) = open_room(&author, &watcher).await;
+
+    // Posting registers the author's signing key here, so a forged signature
+    // can name a kid this server can actually resolve — a real failure rather
+    // than "cannot check".
+    let msgid = post(&ha, &mut rxw, "theirs to delete").await;
+    let kid = registered_kid(&srv.db_path, &author.did)
+        .expect("the author's client registered a signing key");
+    let forged_sig = format!("ed25519:{kid}:{}", "A".repeat(86));
+
+    // (1) A delete under the victim's DID, unsigned.
+    let forged = peer.delete("mallory", "#room", &msgid, Some(&author.did));
+    peer.forge(forged).await;
+    assert_link_alive(&mut peer, &mut rxw, "probe-after-unsigned-stamped-delete").await;
+    assert!(
+        !is_deleted(&srv.db_path, &msgid),
+        "an unsigned delete stamped with the victim's DID deleted their message"
+    );
+
+    // (2) The same delete, carrying a signature that does not verify against
+    // the DID it names.
+    let forged = peer.signed_delete(
+        "mallory",
+        "#room",
+        &msgid,
+        Some(&author.did),
+        &forged_sig,
+    );
+    peer.forge(forged).await;
+    assert_link_alive(&mut peer, &mut rxw, "probe-after-forged-stamped-delete").await;
+    assert!(
+        !is_deleted(&srv.db_path, &msgid),
+        "a delete whose signature failed against the victim's own key still applied"
+    );
+
+    // (3) Reactions and their removal, both shapes, under the victim's DID.
+    for (label, event) in [
+        (
+            "unsigned react",
+            peer.react("mallory", "#room", &msgid, "👍", Some(&author.did), None),
+        ),
+        (
+            "forged react",
+            peer.react(
+                "mallory",
+                "#room",
+                &msgid,
+                "👍",
+                Some(&author.did),
+                Some(&forged_sig),
+            ),
+        ),
+        (
+            "unsigned unreact",
+            peer.unreact("mallory", "#room", &msgid, "👍", Some(&author.did), None),
+        ),
+        (
+            "forged unreact",
+            peer.unreact(
+                "mallory",
+                "#room",
+                &msgid,
+                "👍",
+                Some(&author.did),
+                Some(&forged_sig),
+            ),
+        ),
+    ] {
+        peer.forge(event).await;
+        let leaked = try_event(
+            &mut rxw,
+            |e| matches!(e, Event::TagMsg { tags, .. } if tags.contains_key("+react")
+                || tags.contains_key("+freeq.at/unreact")),
+            NO_EFFECT_WINDOW,
+        )
+        .await;
+        assert!(
+            leaked.is_none(),
+            "a {label} stamped with the victim's DID reached a local client: {leaked:?}"
+        );
+    }
+    assert_link_alive(&mut peer, &mut rxw, "probe-after-stamped-reactions").await;
+}
+
 // ── signatures ───────────────────────────────────────────────────
 
 /// A peer that attaches a signature which does not check out. Nothing

--- a/freeq-server/tests/lying_peer_adversarial.rs
+++ b/freeq-server/tests/lying_peer_adversarial.rs
@@ -175,10 +175,10 @@ async fn a_peer_impersonating_a_local_nick_can_currently_delete_that_users_messa
 
 // ── signatures ───────────────────────────────────────────────────
 
-/// A peer that attaches a signature which does not check out. The words still
-/// arrive — a bad signature is not grounds to drop someone's message — but the
-/// signature does not, because a client that saw it would draw a lock beside
-/// text nobody proved.
+/// A peer that attaches a signature which does not check out. Nothing
+/// arrives: the words and the proof came together and disagreed, and relaying
+/// the words alone would put text under the author's name that the evidence
+/// on the wire says is not theirs.
 ///
 /// The forged signature names a key this server really holds (the author's own
 /// registered key id), so the verdict is a genuine failure rather than "cannot
@@ -208,18 +208,15 @@ async fn a_peer_cannot_attach_a_signature_that_does_not_check_out() {
     );
     peer.forge(msg).await;
 
-    let seen = wait_event(
+    let leaked = try_event(
         &mut rxw,
         |e| matches!(e, Event::Message { text: t, .. } if t == "words with a forged seal"),
-        "the peer's signed message",
+        NO_EFFECT_WINDOW,
     )
     .await;
-    let Event::Message { tags, .. } = &seen else {
-        unreachable!("matched above")
-    };
     assert!(
-        !tags.contains_key("+freeq.at/sig"),
-        "a signature that failed verification reached a local client: {tags:?}"
+        leaked.is_none(),
+        "a message whose signature failed verification reached a local client: {leaked:?}"
     );
 
     assert_link_alive(&mut peer, &mut rxw, "probe-after-forged-signature").await;

--- a/freeq-server/tests/lying_peer_adversarial.rs
+++ b/freeq-server/tests/lying_peer_adversarial.rs
@@ -268,6 +268,51 @@ async fn a_peer_stamping_the_victims_did_on_a_mutation_is_refused() {
     assert_link_alive(&mut peer, &mut rxw, "probe-after-stamped-reactions").await;
 }
 
+/// A DM the peer says a *local* user sent.
+///
+/// The receiving server unions the addressed user's sessions with the
+/// sessions of whoever the `account` names, so the sender's own devices see a
+/// message they sent from elsewhere. A peer that stamps a local user's DID on
+/// its own DM therefore reaches that user's client — and reaches it in the
+/// sender's position, as a line in their outbox that they never wrote.
+#[tokio::test]
+async fn a_peer_cannot_put_a_dm_in_a_local_users_outbox() {
+    let victim = TestId::new("did:plc:lpdmvictim");
+    let addressee = TestId::new("did:plc:lpdmaddressee");
+    let (srv, mut peer) = spawn_server_with_peer(&[&victim, &addressee]).await;
+
+    let (hv, mut rxv) = connect(&srv, &victim, "victim");
+    wait_auth_and_register(&mut rxv).await;
+    let (ha, mut rxa) = connect(&srv, &addressee, "addressee");
+    wait_auth_and_register(&mut rxa).await;
+
+    // Warm the link through a channel both share, so "nothing arrived" below
+    // cannot be a link that was never up.
+    hv.join("#room").await.unwrap();
+    wait_event(&mut rxv, |e| matches!(e, Event::Joined { .. }), "victim join").await;
+    warm_link(&mut peer, "mallory", "#room", &mut rxv).await;
+
+    // The peer's own DM to the addressee, stamped as the victim's.
+    let forged = peer.privmsg("mallory", "addressee", "did I send this?", Some(&victim.did));
+    peer.forge(forged).await;
+
+    let echoed = try_event(
+        &mut rxv,
+        |e| matches!(e, Event::Message { text: t, .. } if t == "did I send this?"),
+        NO_EFFECT_WINDOW,
+    )
+    .await;
+    assert!(
+        echoed.is_none(),
+        "a peer's DM stamped with a local user's DID reached that user's own \
+         session, where it reads as a message they sent: {echoed:?}"
+    );
+
+    assert_link_alive(&mut peer, &mut rxv, "probe-after-outbox-forgery").await;
+    hv.quit(None).await.ok();
+    ha.quit(None).await.ok();
+}
+
 // ── signatures ───────────────────────────────────────────────────
 
 /// A peer that attaches a signature which does not check out. Nothing

--- a/freeq-server/tests/lying_peer_adversarial.rs
+++ b/freeq-server/tests/lying_peer_adversarial.rs
@@ -145,17 +145,17 @@ async fn a_peer_cannot_delete_a_message_authored_by_someone_else() {
     assert!(leaked.is_none(), "a rejected delete was still fanned out to clients");
 }
 
-/// **Known gap, pinned deliberately.** A peer that puts a *local* user's nick
-/// in `from` and sends no `account` has the delete authorized: with no DID on
-/// the event, the receiver falls back to its own `nick_owners` map, resolves
-/// the nick to the local user who owns it, and concludes the author is acting.
+/// A peer that puts a *local* user's nick in `from` and sends no `account`
+/// used to have the delete authorized: with no DID on the event, the receiver
+/// looked the nick up in its own `nick_owners` map, resolved it to the local
+/// user who owns it, and concluded the author was acting. A nick is
+/// peer-assertable, so that was an impersonation route.
 ///
-/// The fallback exists for peers predating the `account` field, and a nick is
-/// peer-assertable, so it is an impersonation route. Closing it means deciding
-/// what to do about those older peers — out of scope here; this test states
-/// the current behaviour so a change to it is visible rather than silent.
+/// The receiver no longer answers "who is this" from a nick a peer chose.
+/// Without a DID the event is a stranger's, and a stranger cannot delete
+/// someone else's message.
 #[tokio::test]
-async fn a_peer_impersonating_a_local_nick_can_currently_delete_that_users_message() {
+async fn a_peer_impersonating_a_local_nick_cannot_delete_that_users_message() {
     let author = TestId::new("did:plc:lpauthor2");
     let watcher = TestId::new("did:plc:lpwatcher2");
     let (srv, mut peer, ha, mut rxw) = open_room(&author, &watcher).await;
@@ -167,9 +167,8 @@ async fn a_peer_impersonating_a_local_nick_can_currently_delete_that_users_messa
     assert_link_alive(&mut peer, &mut rxw, "probe-after-nick-impersonation").await;
 
     assert!(
-        is_deleted(&srv.db_path, &msgid),
-        "the nick fallback no longer authorizes a peer-asserted delete — \
-         if that was intentional, delete this test"
+        !is_deleted(&srv.db_path, &msgid),
+        "a peer wearing a local user's nick deleted that user's message"
     );
 }
 

--- a/freeq-server/tests/sdk_client.rs
+++ b/freeq-server/tests/sdk_client.rs
@@ -772,6 +772,17 @@ async fn dm_delete_persists_across_history_replay() {
     wait(&mut rxc, |e| matches!(e, Event::Registered { .. }), "reg C").await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
+    // Ask who the peer is before acting on the thread. A DM's signed venue is
+    // the two DIDs, so a client that only knows a nick has no document to
+    // sign — and a mutation nobody signed is refused.
+    ha.raw("WHOIS delc").await.unwrap();
+    wait(
+        &mut rxa,
+        |e| matches!(e, Event::MemberDid { did, .. } if did == DID_C),
+        "A learns C's DID",
+    )
+    .await;
+
     ha.privmsg("delc", "delete me").await.unwrap();
     // The sender's echo carries the server-assigned msgid.
     let echo = wait(
@@ -974,6 +985,13 @@ async fn guest_dm_edit_relays_without_persistence() {
 }
 
 /// Same for delete: relays as a +draft/delete TAGMSG to the guest.
+///
+/// A guest recipient has no DID, so this thread has no venue any signature
+/// could name — no document for the sender to sign, none for a reader to
+/// rebuild. The signature requirement does not reach here: it ends the
+/// server vouching for acts it could not check, and there was never anything
+/// to vouch for in a thread like this one. Requiring proof that cannot exist
+/// would end deletes in guest DMs and end nothing else.
 #[tokio::test]
 async fn guest_dm_delete_relays_without_persistence() {
     let key_a = PrivateKey::generate_ed25519();

--- a/freeq-server/tests/util/lying_peer.rs
+++ b/freeq-server/tests/util/lying_peer.rs
@@ -354,6 +354,87 @@ impl LyingPeer {
         }
     }
 
+    /// A reaction to `msgid`, claimed by `from` and (optionally) `account`,
+    /// carrying `sig` when the peer chose to attach one.
+    pub fn react(
+        &mut self,
+        from: &str,
+        target: &str,
+        msgid: &str,
+        emoji: &str,
+        account: Option<&str>,
+        sig: Option<&str>,
+    ) -> S2sMessage {
+        self.mutation(from, target, "+react", emoji, Some(msgid), account, sig)
+    }
+
+    /// The removal of one, same shape.
+    pub fn unreact(
+        &mut self,
+        from: &str,
+        target: &str,
+        msgid: &str,
+        emoji: &str,
+        account: Option<&str>,
+        sig: Option<&str>,
+    ) -> S2sMessage {
+        self.mutation(
+            from,
+            target,
+            "+freeq.at/unreact",
+            emoji,
+            Some(msgid),
+            account,
+            sig,
+        )
+    }
+
+    /// A delete carrying a signature the peer chose.
+    pub fn signed_delete(
+        &mut self,
+        from: &str,
+        target: &str,
+        msgid: &str,
+        account: Option<&str>,
+        sig: &str,
+    ) -> S2sMessage {
+        self.mutation(from, target, "+draft/delete", msgid, None, account, Some(sig))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mutation(
+        &mut self,
+        from: &str,
+        target: &str,
+        tag: &str,
+        value: &str,
+        subject: Option<&str>,
+        account: Option<&str>,
+        sig: Option<&str>,
+    ) -> S2sMessage {
+        let mut tags = HashMap::from([(tag.to_string(), value.to_string())]);
+        if let Some(subject) = subject {
+            tags.insert("+reply".to_string(), subject.to_string());
+        }
+        if let Some(sig) = sig {
+            tags.insert("+freeq.at/sig".to_string(), sig.to_string());
+            // A signature covers an event id, so one has to be there — and
+            // shaped like an id a server would adopt.
+            tags.insert(
+                freeq_sdk::chatsig::EVENT_ID_TAG.to_string(),
+                freeq_server::msgid::generate(),
+            );
+        }
+        S2sMessage::Tagmsg {
+            event_id: self.next_event_id(),
+            from: from.to_string(),
+            target: target.to_string(),
+            tags,
+            origin: self.id.clone(),
+            account: account.map(str::to_string),
+        }
+    }
+
     /// An edit that rewrites `replaces` with `text`.
     pub fn edit(
         &mut self,


### PR DESCRIPTION
A logged-in user's edit, delete, react, and unreact must now carry a valid signature from the sender's own key, locally and over federation. Unsigned changes are refused with `FAIL <command> SIGNATURE_REQUIRED`, and the server no longer signs changes on anyone's behalf. All supported clients already sign every message and change on the sender's device, so the refusals affect only older releases, bots that explicitly disabled signing, and the (unmaintained?) WinUI client, which hasn't yet been updated.

Plain messages from logged-in users are always signed — the question is by whom. When a client doesn't sign, the server signs the same document with its own key on the sender's behalf; in practice that fallback is the exception today, since every supported client signs its own plain messages. This branch removes the server fallback for changes and leaves it in place for plain messages, though it's arguable that we might want to enforce it there as well.

It's worth noting that current clients don't flag server-signed messages in the scroll; which key signed is revealed only through the explicit verify action. That's mechanical, not aesthetic: today a verdict comes from asking the server about a specific message, so a resting per-row mark would either be an unchecked claim or a server round-trip per rendered row. The working plan already covers the fix: client-side verification (fetch the signer's key, check locally) drives an automatic three-state badge, and only a sender-device signature wears the verified mark — server-signed messages render distinctly. Once that lands, the difference stops hiding behind a click. But, at least for now, it remains a consideration.

Also in the branch, by kind:

**Relay-path trust fixes**
* Relayed changes apply only on the actor's own verified signature, and the four places a receiver guessed the sender from its own nick records are removed.
* A relayed DM is delivered into the claimed sender's own sessions only when its signature verifies — closes an outbox forgery.
* A message whose signature fails verification is rejected at origin and dropped by receivers (main already refuses failed edits; messages are new here).

**Smaller fixes**
* Reaction rows are written only after the channel's +n/+m checks, so a non-member's reaction no longer leaves a stored row.
* Writers use the current tag spellings; readers still accept the old ones.

**Pins, no behavior change**
* Chat key lookups locked by test to the key id the signature names.
* The covered-tag list pinned by name in both languages.

**New adversarial tests**
* A peer stamping a victim's real DID on a change; nick impersonation; DM outbox injection.

Guests are unchanged everywhere, including DMs with a guest. A DM's signature names the two participants' DIDs and a guest has none, so in those threads there is no document for anyone — sender or server — to sign; they keep the old nick rules.

**Not for merge yet**. Three prerequisites: both servers on current code, an announced date, and `--s2s-peer-api` configured on both servers for each other — an enforcing server drops every change from a peer it cannot fetch keys for.

Tests: server+sdk 1966 passed, 0 failed, 30 ignored; two-server federation subset 23 passed, run serially; sdk-js 394 passed with a clean build. Every enforcement test was watched failing with its check disabled before landing.