### PR TITLE
Tier 1 of RFC v0.5: receipts, act-replaces, and bounty

### DIFF
--- a/docs/ACT-TIER1-PLAN.md
+++ b/docs/ACT-TIER1-PLAN.md
@@ -1,0 +1,271 @@
+# Tier 1 of RFC v0.5: receipts, `bounty`, `act-replaces`
+
+The three pieces of RFC v0.5 (`freeq.at/act`) that are proposed or specified but
+have no code behind them, scoped to **one server** — the federation phase
+(defer queues, home routing, orphans) is explicitly out.
+
+RFC: https://gist.github.com/zapnap/2510b695c9d5e1cf99aac2fba709d307
+Everything here extends the substrate merged in PR #60 and realigned to the
+v0.5 canonical on 2026-08-20 (`6732f129`, `24a71a9a`, `a9f17194`).
+
+## Ground rules (read before writing code)
+
+- **Rules are data.** Behavior differences between kinds live in
+  `spec/act-transitions.json`, never in `match kind` arms. If a new kind needs
+  code, the substrate failed its own test — fix the schema, not the validator.
+- **Both SDKs move in lockstep.** Rust (`freeq-sdk/src/act.rs`,
+  `act_transitions.rs`) and TypeScript (`freeq-bot-kit-js/src/act*.ts`,
+  `freeq-sdk-js/src/signing.ts`) load the same transitions file and must reach
+  the same verdict on every sequence in it. New wire shapes get frozen vectors
+  in `spec/act-signing-vectors.json` that both implementations reproduce
+  byte-for-byte — follow the existing conventions in that file exactly.
+- **Every refusal has one approved sentence and a named test.** Study the
+  existing copy in `spec/act-transitions.json` (`refusals`) and
+  `freeq-server/src/connection/act.rs` before writing new copy; match the
+  voice. Each new refusal gets a test in `freeq-server/tests/act_gate.rs`
+  that triggers exactly it.
+- **The canonical covers whatever is present.** `act-*` tags are swept into the
+  signed document automatically; adding tags (`act-subject`, `act-replaces`,
+  `act-bid`) requires **no** canonical change. Do not special-case them in
+  signing code.
+- **The log is the record; the view is derived.** Any new view column must be
+  filled by the rebuild path too, and the rebuild-matches test
+  (`freeq-server/src/db.rs` tests) must cover it.
+- **House prose style** for comments and commit messages: plain sentences that
+  say why, no bullet-list changelogs, no "Add X" — read recent commits by nap
+  (`6732f129`, `24a71a9a`) and match them.
+
+---
+
+## 1. Receipts — the home's signed confirmation (`confirm` / `act-subject`)
+
+RFC section "Confirmation: the receipt". Single-server resolution of the RFC's
+undefined trigger ("an action other servers are involved in"): **always emit**.
+Receipts are small, replay is free, and a rule with no condition cannot be
+implemented wrong. Note this decision in a comment where the receipt is minted.
+
+### What to build
+
+When the server **files a participant-authored state transition** — a verb
+whose `from` state differs from its `to` state: `accept`, `claim`, `decline`,
+`complete`, `fail`, `cancel` — it appends one home-signed event:
+
+```
+@+freeq.at/act=<kind>;+freeq.at/act-verb=confirm;+freeq.at/from=did:web:<server>;
+ +freeq.at/eventid=<fresh ULID>;+freeq.at/act-id=<action id>;
+ +freeq.at/act-subject=<eventid of the confirmed event>;+freeq.at/sig=… TAGMSG <venue>
+```
+
+Not for: `offer` (opening creates the action; nothing raced it), `progress`
+(additive, `from == to`), `expire`/system verbs (home-signed already — the
+degenerate case, per the RFC).
+
+### Mechanics
+
+- **Mint and sign exactly as `expire_task` does** (`connection/act.rs`): server
+  DID (`did:web:<server_name>`), fresh ULID, standard act canonical (the
+  `act-subject` tag is swept like any other), `sign_canonical` with the server
+  key, filed through `apply_act_event` with `from_system: true`.
+- **`confirm` is generic, not a table row.** The validator recognizes it before
+  the per-kind verb lookup. A client that sends `act-verb=confirm` is refused
+  with the existing `WRONG_SENDER` machinery and a new approved sentence
+  ("Only the action's home confirms" — adjust to match the copy sheet's voice).
+  It must not fall through to `UNKNOWN_VERB`: that answer would imply a kind
+  could add its own `confirm` row, which the RFC forbids.
+- **A receipt carries no state.** Filing it must not touch the materialized
+  view (state was already advanced when the subject event was filed). It is
+  an appended record: event log + broadcast + replay only.
+- **Broadcast** to the venue under the same `freeq.at/act` client-capability
+  gating as every act event; **no companion PRIVMSG** (the subject event's
+  companion already told the humans; a receipt is machine record).
+- **Replay**: receipts ride `replay_lines` like any stored act event — verify
+  they appear, in order, to a late joiner holding the `freeq.at/act` cap.
+- **REST**: `GET /api/v1/actions/{id}` already serves all events for the
+  action; confirm events must appear there with canonical + signature. Add
+  nothing new; test that they do.
+- **DM venues**: follow the expiry precedent exactly (deliver to both
+  participants' sessions; the same known limitation about where clients file a
+  server-authored line applies — restate it where the expiry code states it).
+
+### Tests
+
+- After an `accept`, the event log for the action holds a `confirm` whose
+  `act-subject` is the accept's eventid, signed by `did:web:` — and the
+  signature verifies against the server's published key.
+- Every state transition gets exactly one receipt; `progress` gets none;
+  `offer` gets none; `expire` gets none.
+- A client-sent `confirm` is refused with the approved sentence; the refusal
+  test names it.
+- Replay to a late joiner includes the receipt; a client without the cap gets
+  neither act events nor receipts.
+- REST event list carries the receipt verbatim (canonical bytes + sig).
+- Acceptance (`freeq-bot-kit-js/examples/act-acceptance.ts`): extend the
+  existing lifecycle run to assert receipts appear for accept and complete,
+  and that their signatures verify.
+
+### Vectors
+
+Add a receipt canonical to `spec/act-signing-vectors.json` following the file's
+existing conventions (deterministic keys, byte-exact canonical, kid,
+signature). Include one negative: a receipt whose `act-subject` was swapped
+reads **invalid**.
+
+---
+
+## 2. `bounty` — the second kind, and the test of generality
+
+RFC: "bids are additive events; the poster picks the winner with a signed
+`award`; the server never picks." The deliverable is **a transitions-file entry
+plus whatever schema the entry exposes as missing** — if the validator needs a
+`match "bounty"` anywhere, stop and fix the schema instead.
+
+### Transitions entry
+
+```json
+"bounty": {
+  "opens": { "verb": "offer", "open": "open" },
+  "terminal": ["completed", "failed", "cancelled", "expired"],
+  "transitions": [
+    { "verb": "bid",      "from": "open",     "to": "open",      "who": "anyone",   "before_deadline": true },
+    { "verb": "award",    "from": "open",     "to": "assigned",  "who": "offerer",  "before_deadline": true,
+      "assignee_from": "act-to", "requires": ["act-to"] },
+    { "verb": "progress", "from": "assigned", "to": "assigned",  "who": "assignee" },
+    { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
+    { "verb": "fail",     "from": "assigned", "to": "failed",    "who": "assignee" },
+    { "verb": "cancel",   "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
+    { "verb": "expire",   "from": "*nonterminal", "to": "expired", "who": "system" }
+  ]
+}
+```
+
+Design notes, to be honored and documented in the file's `_readme`:
+
+- **`opens` with no `directed` key**: a bounty is open by construction — a
+  directed bounty is just a handoff. The schema must treat a missing `directed`
+  as "an opener carrying `act-to` is refused" (`ILLEGAL_STEP` or a clearer
+  refusal if one exists; pick and test).
+- **Two schema additions**, both generic:
+  - `assignee_from` — which field names the assignee when this transition
+    assigns. Default (absent) is `actor`, which is what `accept`/`claim`
+    already mean; `award` sets it to `act-to`. This is view logic driven by
+    data, in both implementations.
+  - `requires` — tags that must be present for the transition to be legal.
+    Missing ⇒ a refusal with its own approved sentence ("An award names its
+    winner" — match the copy voice) and named test. Guard the general case:
+    an empty/absent `requires` changes nothing for existing kinds.
+- **Bids are sovereign, so is the award.** The server does not check that the
+  awarded DID ever bid — the RFC's "the server never picks" cuts both ways;
+  the poster's signed choice is the record. State this in a comment and in the
+  transitions `_readme`; do not add the check.
+- **Bid payload**: a bid may carry `act-note` (freeform, already swept by the
+  canonical). Do not invent an `act-bid-amount` tag — pricing semantics are
+  agent-level, not substrate.
+
+### SDK verbs
+
+`freeq-bot-kit-js/src/act-verbs.ts`: `bid(ctx, taskId, opts)` and
+`award(ctx, taskId, winnerDid, opts)`, shaped exactly like the existing verbs
+(paired send: signed TAGMSG + companion PRIVMSG; `award` sets
+`+freeq.at/act-to`). Mirror any Rust-side helpers if the Rust SDK has per-verb
+helpers (check `freeq-sdk` — if it exposes only the canonical builder, that is
+already enough; do not invent a new Rust surface).
+
+### Tests
+
+- The transitions sequences in `spec/act-transitions.json` gain bounty
+  sequences (open → two bids → award → complete; a bid after deadline; an
+  award by a non-poster; an award without `act-to`; a bid on an awarded
+  bounty) — replayed by **both** implementations' sequence tests.
+- Server gate tests for each new refusal, named.
+- View: after `award`, the assignee is the awarded DID, not the actor; the
+  rebuild-matches test covers a bounty.
+- Acceptance: a second scenario in `act-acceptance.ts` — poster offers a
+  bounty, two bots bid, poster awards one, winner completes; assert bids are
+  all on file (additive), the loser's late `complete` is refused
+  (`WRONG_SENDER`), receipts appear for `award` and `complete`.
+
+### Vectors
+
+Bounty vectors in `spec/act-signing-vectors.json`: a bid canonical and an award
+canonical (with `act-to`), plus one negative (award with `act-to` stripped
+reads invalid — the sweep covers it).
+
+---
+
+## 3. `act-replaces` — the typed revival relation
+
+RFC: "`act-replaces` names a terminal predecessor a new action revives (a
+failed handoff re-offered, a forfeited bounty re-listed). … Receivers must
+tolerate an `act-replaces` naming an action they never saw — annotate, don't
+refuse."
+
+### Rules
+
+- Legal **only on an opener** (`offer`). On any other verb: refuse (one
+  sentence, one test).
+- Value must be ULID-shaped. Malformed: refuse.
+- If the named action is on file and **not terminal**: refuse —
+  new refusal `replaces-not-terminal`, sentence in the transitions file's
+  `refusals` map ("The action it replaces is not finished" — match voice).
+- If the named action is not on file: **accept and annotate** — single-server
+  today, but the rule is load-bearing for federation later; comment says so.
+- The tag is swept by the canonical automatically — verify with a vector, not
+  with new signing code.
+
+### Storage & surfaces
+
+- View: new column `replaces` on `act_actions` — **new migration** (007;
+  migrations are append-only, do not touch 006), filled at apply time and by
+  the rebuild path; rebuild-matches test extended.
+- REST: `replaces` in the task JSON when present, both in the list and the
+  detail.
+- SDK: `offer(ctx, { …, replaces })` in bot-kit (tag only when present).
+
+### Tests
+
+- Re-offer of a failed handoff carries the link; REST shows it on the new
+  action; the old action is untouched.
+- Replaces naming a live (non-terminal) action: refused, named test.
+- Replaces naming an unknown ULID: accepted, annotated, visible over REST.
+- Replaces on a non-opener: refused, named test.
+- A vector with `act-replaces` present (signature covers it).
+
+---
+
+## Sequencing, verification, and done
+
+Build order: **receipts → act-replaces → bounty** (receipts first so bounty's
+acceptance scenario can assert them; replaces before bounty because re-listing
+a forfeited bounty is one of its uses).
+
+After each stage, run at minimum:
+
+```
+cargo test -p freeq-server --test act_gate --test act_api
+cargo test -p freeq-sdk
+(cd freeq-sdk-js && npx vitest run)
+(cd freeq-bot-kit-js && npx vitest run)
+cargo build -p freeq-server && (cd freeq-bot-kit-js && FREEQ_SERVER_BIN=../target/debug/freeq-server npx tsx examples/act-acceptance.ts)
+```
+
+Before declaring done:
+
+```
+cargo fmt --all && cargo clippy --workspace --exclude freeq-av-client --exclude freeq-eliza --exclude freeq-av --exclude freeq-av-image -- -D warnings
+cargo test --workspace --exclude freeq-av-client --exclude freeq-eliza --exclude freeq-av --exclude freeq-av-image
+```
+
+Definition of done:
+
+- All three features implemented per above; all listed tests exist, are named
+  for what they refuse or prove, and pass.
+- `spec/act-transitions.json` and `spec/act-signing-vectors.json` extended;
+  both implementations replay/reproduce them; no implementation contains
+  kind-specific code.
+- Full workspace suite green, fmt clean, clippy clean.
+- Work committed in small commits on this branch (`act-tier1`), one concern
+  per commit, messages in the house voice. **Do not push.**
+
+Out of scope (do not build): federation defer queue, receipt park/eviction
+rules, home routing, orphan annotation, receipt sequence numbers, DID-document
+key anchoring, encrypted-content mode, any REST write path.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -203,7 +203,7 @@ const bounty = await offer(ctx, {
 });
 
 // a worker, elsewhere in the room
-const myBid = await bid(ctx, bounty, { amount: '250 USD', payTo: ctx.did, note: 'two days' });
+const myBid = await bid(ctx, bounty, { price: '250 USD', payTo: ctx.did, note: 'two days' });
 
 // the poster, having read the bids
 await award(ctx, bounty, myBid);      // the bid's event id, not a DID

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -160,6 +160,63 @@ Two words appear throughout freeq's errors and records, and they are not interch
 
 **A task from another server is display-only, for now.** Task messages relay across servers intact — signature and all — so a task-aware client on either side can render the card. But only the server where a task was created has it on file. Acting on a remote task draws `FAIL TAGMSG UNKNOWN_TASK :That task is not on file`, and will until cross-server participation lands. Read a remote task, follow along with it, and offer your own work on your own server; do not build a flow whose next step is accepting someone else's remote offer.
 
+### Bounties: priced work, bid on and awarded
+
+A handoff moves a unit of work to someone. A **bounty** is the same lifecycle with an auction in front of it and a review gate behind it: the work is posted openly, agents bid, the poster picks one bid, and the poster — not the worker — is who says the job is done.
+
+The run, end to end:
+
+```
+offer      (anyone)    → open           the bounty is posted, with what it pays
+bid        (anyone)    → open           additive: every bid stays on file
+award      (poster)    → assigned       the poster takes one bid
+progress   (worker)    → assigned
+submit     (worker)    → under_review   the work is in, not finished
+revise     (poster)    → assigned       sent back for another pass
+accept-work(poster)    → accepted       terminal
+forfeit    (worker)    → forfeited      terminal, from assigned or under_review
+cancel     (poster)    → cancelled      from open or assigned, never under_review
+```
+
+There is no `complete` on a bounty. The worker hands work in; the offerer signs off. And once work is in, the poster cannot withdraw it — a poster who could cancel after seeing the work would get it for nothing.
+
+**`act-accepts` names a bid, not a bidder.** An award carries the winning bid's own event id and no `act-to` at all. A bounty's terms live in the bid — what the bidder asks, where they want paying, what they propose — and bids are the one place several candidates sit side by side, so taking one means naming the exact event. The assignee is whoever wrote that bid. The server checks only that the named event is a `bid` on this bounty; naming anything else draws `FAIL TAGMSG ACCEPTS_NOT_A_BID`, and naming nothing draws `MISSING_REQUIREMENT`. Which bid is worth taking is not the server's business.
+
+**The review window closes on its own.** Work left in `under_review` past the server's `act_review_secs` — fourteen days by default — is deemed accepted, under an `auto-accept` event the server signs itself. That is the answer to a poster who takes delivery and then goes quiet: without it, the ordinary abandonment sweep would eventually close the task as an expiry, which reads as the *worker* having dropped it. The clock is per-submission, so a poster who asks for changes is never caught by it and a fresh submission starts a fresh window. Ask your server operator what its window is; every bidder is bidding under it.
+
+Endless revision is not closed by any of this, and deliberately so: from the outside a real revision and a stall are identical. So are "accepted but never paid" and any other question about money. Those live above the substrate — in reputation, escrow, and dispute — not in a transition table.
+
+**Money is opaque.** `act-price` on the offer, `act-bid` and `act-pay-to` on a bid, `act-tx` on the acceptance. All four are stored, relayed, replayed, and covered by the signature because they are present — and read by nothing. `act-tx` records that a payment was *claimed*, never that one happened.
+
+Two deadlines, both on the offer and both optional: `act-deadline` bounds how long the offer stands, and `act-bid-deadline` bounds how long it takes bids, which usually closes sooner. A bid past the cutoff draws `DEADLINE_PASSED`; the award is measured against `act-deadline` instead, so bidding closing does not stop the poster picking.
+
+In bot-kit:
+
+```ts
+import { offer, bid, award, submit, revise, acceptWork, forfeit } from '@freeq/bot-kit';
+
+const bounty = await offer(ctx, {
+  title: 'index the archive',
+  kind: 'bounty',
+  price: '250 USD',
+  bidDeadline: Math.floor(Date.now() / 1000) + 86_400,
+});
+
+// a worker, elsewhere in the room
+const myBid = await bid(ctx, bounty, { amount: '250 USD', payTo: ctx.did, note: 'two days' });
+
+// the poster, having read the bids
+await award(ctx, bounty, myBid);      // the bid's event id, not a DID
+
+// the worker
+await submit(ctx, bounty, { note: 'branch pushed' });
+
+// the poster
+await acceptWork(ctx, bounty, { tx: 'eth:0xabc' });
+```
+
+Re-running a bounty that was forfeited or expired is a **new** bounty naming the old one in `replaces` — the machine only runs forward, and a terminal state is final.
+
 ### Messages and notices
 
 Both are signed with the same document, and the difference that matters is durability: **a notice leaves no record.** The server stores and logs messages only, so a notice is verifiable in flight and by nothing afterwards — absent from channel history, from CHATHISTORY replay, and from `/api/v1/verify`.

--- a/docs/tag-registry.md
+++ b/docs/tag-registry.md
@@ -60,6 +60,13 @@ across the Rust and TypeScript SDKs with shared test vectors
 | `+freeq.at/act-title` | Human-readable title. |
 | `+freeq.at/from` | The signer/actor (envelope tag; the document key is `from`). |
 | `+freeq.at/eventid` | The event id the signer minted; the server adopts it (shared with chat). |
+| `+freeq.at/act-accepts` | The bid an award takes — that bid's own event id. The assignee is its author. |
+| `+freeq.at/act-deadline` | How long the offer stands, unix seconds. Compared by the referee. |
+| `+freeq.at/act-bid-deadline` | How long a bounty takes bids, unix seconds. Compared by the referee. |
+| `+freeq.at/act-price` | What a bounty offers to pay. Opaque: stored, relayed, signed, never read. |
+| `+freeq.at/act-bid` | What a bidder asks for. Opaque. |
+| `+freeq.at/act-pay-to` | Where a bidder wants paying. Opaque. |
+| `+freeq.at/act-tx` | A payment reference on the acceptance. Opaque — a claim on the record, never a confirmation. |
 
 ## Governance & budgets
 

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -220,6 +220,32 @@ async function main() {
       check(verdict.ok === true, 'and its signature verifies against the key the server publishes');
     }
 
+    // ── the revival relation ──
+    step('replaces', 'the finished task is re-offered, naming what it revives');
+    const revived = await act.offer(poster.ctx, {
+      title: 'ship the release, again',
+      to: worker.ctx.did,
+      replaces: task,
+    });
+    await sleep(700);
+    check(
+      (await openWork()).find((t) => t.act_id === revived)?.replaces === task,
+      `the new task names the one it revives (${revived} → ${task})`,
+    );
+    check(
+      (await api(`/api/v1/actions/${task}`)).events.length === 6,
+      'and the task it replaces is exactly as it ended',
+    );
+
+    step('replaces refused', 'a re-offer naming a task that has not finished');
+    poster.seen.fails.length = 0;
+    await act.offer(poster.ctx, { title: 'too soon', replaces: revived }).catch(() => {});
+    await sleep(700);
+    check(
+      poster.seen.fails.some((l) => l.includes('REPLACES_NOT_TERMINAL')),
+      'refused: REPLACES_NOT_TERMINAL',
+    );
+
     // ── replay ──
     step('replay', 'a third client joins late and is given the history');
     const late = await spawnBot('acceptance-latecomer');

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -271,7 +271,7 @@ async function main() {
       `open (${bounty})`,
     );
 
-    await act.bid(worker.ctx, bounty, { note: 'two days' });
+    const workerBid = await act.bid(worker.ctx, bounty, { note: 'two days' });
     await act.bid(rival.ctx, bounty, { note: 'one day, no sources' });
     await sleep(900);
     check(
@@ -284,14 +284,14 @@ async function main() {
       'both bids are on file, neither superseding the other',
     );
 
-    step('award', 'the poster picks the winner');
-    const awardId = await act.award(poster.ctx, bounty, worker.ctx.did);
+    step('award', 'the poster takes one of the bids');
+    const awardId = await act.award(poster.ctx, bounty, workerBid);
     await sleep(700);
     const awarded = (await openWork()).find((t) => t.act_id === bounty);
     check(awarded?.state === 'assigned', 'assigned');
     check(
       awarded?.assignee === worker.ctx.did,
-      'and the assignee is the winner the poster named, not the poster',
+      'and the assignee is the author of the bid it took, not the poster',
     );
     check(
       receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(awardId),

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -257,6 +257,65 @@ async function main() {
       'with their signatures, so a late arrival can check them',
     );
 
+    // ── the second kind ──
+    step('bounty', 'a bounty two bots bid on, awarded to one of them');
+    const rival = await spawnBot('acceptance-rival');
+    await sleep(1500);
+    const bounty = await act.offer(poster.ctx, {
+      title: 'index the archive',
+      kind: 'bounty',
+    });
+    await sleep(700);
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'open',
+      `open (${bounty})`,
+    );
+
+    await act.bid(worker.ctx, bounty, { note: 'two days' });
+    await act.bid(rival.ctx, bounty, { note: 'one day, no sources' });
+    await sleep(900);
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'open',
+      'still open — a bid is additive and moves nothing',
+    );
+    const bidding = await api(`/api/v1/actions/${bounty}`);
+    check(
+      bidding.events.filter((e) => e.canonical.includes('"act-verb":"bid"')).length === 2,
+      'both bids are on file, neither superseding the other',
+    );
+
+    step('award', 'the poster picks the winner');
+    const awardId = await act.award(poster.ctx, bounty, worker.ctx.did);
+    await sleep(700);
+    const awarded = (await openWork()).find((t) => t.act_id === bounty);
+    check(awarded?.state === 'assigned', 'assigned');
+    check(
+      awarded?.assignee === worker.ctx.did,
+      'and the assignee is the winner the poster named, not the poster',
+    );
+    check(
+      receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(awardId),
+      'the award is confirmed by the home',
+    );
+
+    step('the loser', 'the bot that did not win tries to finish the work');
+    rival.seen.fails.length = 0;
+    await act.complete(rival.ctx, bounty, { kind: 'bounty' }).catch(() => {});
+    await sleep(700);
+    check(
+      rival.seen.fails.some((l) => l.includes('WRONG_SENDER')),
+      'refused: WRONG_SENDER',
+    );
+
+    step('the winner', 'the winner finishes it');
+    const bountyDone = await act.complete(worker.ctx, bounty, { kind: 'bounty' });
+    await sleep(700);
+    check(!(await openWork()).some((t) => t.act_id === bounty), 'completed — gone from open work');
+    check(
+      receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(bountyDone),
+      'and the completion is confirmed too',
+    );
+
     // ── expiry ──
     step('expiry', `a task nobody touches, swept after ${EXPIRY_SECS}s`);
     poster.seen.notices.length = 0;

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -19,6 +19,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FreeqBot } from '../src/index.js';
 import * as act from '../src/act-verbs.js';
+import { verifyActTags } from '../src/act.js';
 
 const SERVER = process.env.FREEQ_SERVER_BIN ?? 'target/debug/freeq-server';
 const CHANNEL = '#acceptance';
@@ -60,6 +61,30 @@ async function main() {
     return r.json().catch(() => null);
   };
   const openWork = async () => (await api('/api/v1/actions')).tasks ?? [];
+  /** The key this server publishes as its own — what a receipt is checked against. */
+  const homeKey = async () =>
+    new Uint8Array(Buffer.from((await api('/api/v1/signing-key')).public_key, 'base64url'));
+  /**
+   * A stored event, back in the shape a verifier wants: the wire tags its
+   * canonical rebuilds to, plus the two fields the caller injects.
+   */
+  const asWire = (event) => {
+    const doc = JSON.parse(event.canonical);
+    const tags = {};
+    for (const [k, v] of Object.entries(doc)) {
+      if (k !== 'target' && k !== 'id') tags[`+freeq.at/${k}`] = v;
+    }
+    return { tags, target: doc.target, id: doc.id, sig: event.signature };
+  };
+  /** Every receipt in an event list, keyed by the event each one confirms. */
+  const receiptsBySubject = (events) => {
+    const out = new Map();
+    for (const e of events) {
+      const doc = JSON.parse(e.canonical);
+      if (doc['act-verb'] === 'confirm') out.set(doc['act-subject'], e);
+    }
+    return out;
+  };
   // The WebSocket endpoint lives on the web listener, not the IRC one.
   const url = `ws://127.0.0.1:${webPort}/irc`;
 
@@ -108,7 +133,10 @@ async function main() {
     await sleep(700);
     check(!(await openWork()).some((t) => t.act_id === declined), 'declined — gone from open work');
     const declinedHistory = await api(`/api/v1/actions/${declined}`);
-    check(declinedHistory.events.length === 2, 'its history keeps the offer and the decline');
+    check(
+      declinedHistory.events.length === 3,
+      'its history keeps the offer, the decline, and the home\'s word about the decline',
+    );
     check(declinedHistory.task === null, 'and it holds no live row');
 
     // ── the full run ──
@@ -134,7 +162,7 @@ async function main() {
     );
 
     step('accept', 'the worker takes it');
-    await act.accept(worker.ctx, task);
+    const acceptId = await act.accept(worker.ctx, task);
     await sleep(700);
     let row = (await openWork()).find((t) => t.act_id === task);
     check(row?.state === 'assigned', 'assigned');
@@ -158,11 +186,14 @@ async function main() {
     );
 
     step('complete', 'the worker finishes');
-    await act.complete(worker.ctx, task);
+    const completeId = await act.complete(worker.ctx, task);
     await sleep(700);
     check(!(await openWork()).some((t) => t.act_id === task), 'completed — gone from open work');
     const full = await api(`/api/v1/actions/${task}`);
-    check(full.events.length === 4, 'four events on file: offer, accept, progress, complete');
+    check(
+      full.events.length === 6,
+      'six events on file: offer, accept, progress, complete, and a receipt for each move',
+    );
     check(
       full.events.every((e) => typeof e.signature === 'string' && e.signature.startsWith('ed25519:')),
       'each one signed',
@@ -171,6 +202,23 @@ async function main() {
       full.events.every((e) => e.canonical.includes('"act-verb"')),
       'and stored as the exact bytes its signature covers',
     );
+
+    // ── the home's receipts ──
+    step('receipts', 'the home confirms every move, and only the moves');
+    const receipts = receiptsBySubject(full.events);
+    check(receipts.has(acceptId), 'the accept is confirmed');
+    check(receipts.has(completeId), 'the complete is confirmed');
+    check(receipts.size === 2, 'and nothing else is — an offer opens, a progress moves nothing');
+    const key = await homeKey();
+    for (const [subject, event] of receipts) {
+      const wire = asWire(event);
+      check(
+        wire.tags['+freeq.at/from'] === 'did:web:acceptance',
+        `signed under the server's own identity (${subject.slice(0, 8)}…)`,
+      );
+      const verdict = await verifyActTags(wire.tags, wire.target, wire.id, wire.sig, key);
+      check(verdict.ok === true, 'and its signature verifies against the key the server publishes');
+    }
 
     // ── replay ──
     step('replay', 'a third client joins late and is given the history');

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -298,22 +298,45 @@ async function main() {
       'the award is confirmed by the home',
     );
 
-    step('the loser', 'the bot that did not win tries to finish the work');
+    step('the loser', 'the bot whose bid was not taken tries to hand work in');
     rival.seen.fails.length = 0;
-    await act.complete(rival.ctx, bounty, { kind: 'bounty' }).catch(() => {});
+    await act.submit(rival.ctx, bounty).catch(() => {});
     await sleep(700);
     check(
       rival.seen.fails.some((l) => l.includes('WRONG_SENDER')),
       'refused: WRONG_SENDER',
     );
 
-    step('the winner', 'the winner finishes it');
-    const bountyDone = await act.complete(worker.ctx, bounty, { kind: 'bounty' });
+    step('review', 'the winner hands the work in, and the poster sends it back');
+    await act.submit(worker.ctx, bounty);
     await sleep(700);
-    check(!(await openWork()).some((t) => t.act_id === bounty), 'completed — gone from open work');
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'under_review',
+      'under review — handed in, not finished',
+    );
+    poster.seen.fails.length = 0;
+    await act.cancel(poster.ctx, bounty, { kind: 'bounty' }).catch(() => {});
+    await sleep(700);
+    check(
+      poster.seen.fails.some((l) => l.includes('ILLEGAL_STEP')),
+      'and delivered work is not the poster\'s to withdraw: ILLEGAL_STEP',
+    );
+    await act.revise(poster.ctx, bounty);
+    await sleep(700);
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'assigned',
+      'sent back — assigned again, and the worker still holds it',
+    );
+
+    step('the poster accepts', 'the offerer\'s word is what ends a bounty');
+    await act.submit(worker.ctx, bounty);
+    await sleep(700);
+    const bountyDone = await act.acceptWork(poster.ctx, bounty);
+    await sleep(700);
+    check(!(await openWork()).some((t) => t.act_id === bounty), 'accepted — gone from open work');
     check(
       receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(bountyDone),
-      'and the completion is confirmed too',
+      'and the acceptance is confirmed too',
     );
 
     // ── expiry ──

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -19,7 +19,9 @@
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
     "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
     "never checked here. `from` is one state, a list of states, or",
-    "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code."
+    "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
+    "a receipt is the home server's word about an event it filed, not a step anybody takes."
   ],
   "version": 1,
   "kinds": {
@@ -38,13 +40,27 @@
       ]
     }
   },
+  "confirmation": {
+    "_note": [
+      "The receipt an action's home writes for a participant-authored step it has filed: same document as",
+      "any other event, signed under the server's own DID, naming the confirmed event in act-subject.",
+      "The verb is generic on purpose. No kind lists it and no kind may add its own row for it — a receipt",
+      "is a statement about an event, not a move on a task — so the checker recognizes it before it looks",
+      "the verb up in any kind's table, and answers `client-confirm` rather than `unknown-verb`. The second",
+      "answer would say a kind could define confirm for itself, which it cannot.",
+      "A receipt carries no state: whatever moved was moved by the event it names."
+    ],
+    "verb": "confirm",
+    "subject": "act-subject"
+  },
   "refusals": {
     "unknown-kind": "The kind is not in this file. Adding a kind means updating this file first.",
     "unknown-verb": "The kind lists no transition with this verb.",
     "terminal-task": "The task is finished. A later event never un-applies an earlier one.",
     "illegal-step": "The verb is not legal from the task's current state.",
     "wrong-sender": "The sender does not hold the role this transition requires.",
-    "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance."
+    "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance.",
+    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step."
   },
   "deadline_rule": {
     "_note": [
@@ -90,6 +106,13 @@
       "verb": "accept",
       "directed": true,
       "expect_refused": "illegal-step"
+    },
+    {
+      "name": "a confirmation opens nothing, whatever kind it names",
+      "kind": "handoff",
+      "verb": "confirm",
+      "directed": false,
+      "expect_refused": "client-confirm"
     },
     {
       "name": "an opener for a kind this file does not list is refused",
@@ -504,6 +527,27 @@
       "steps": [
         { "verb": "award", "sender": "did:plc:eliza", "expect_refused": "unknown-verb" },
         { "verb": "bid", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "nobody but the home confirms, and no kind can claim the verb for itself",
+      "task": {
+        "kind": "handoff",
+        "offer": "directed",
+        "offerer": "did:plc:eliza",
+        "offeree": "did:plc:scholar",
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "confirm", "sender": "did:plc:scholar", "expect_refused": "client-confirm" },
+        { "verb": "confirm", "sender": "did:plc:eliza", "expect_refused": "client-confirm" },
+        {
+          "verb": "confirm",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect_refused": "client-confirm"
+        },
+        { "verb": "accept", "sender": "did:plc:scholar", "expect": "assigned" }
       ]
     },
     {

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -21,7 +21,17 @@
     "never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
-    "a receipt is the home server's word about an event it filed, not a step anybody takes."
+    "a receipt is the home server's word about an event it filed, not a step anybody takes.",
+    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
+    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
+    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
+    "insists on a field, needs a row here and no code anywhere.",
+    "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
+    "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
+    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
+    "record. A checker that second-guessed it would be picking."
   ],
   "version": 1,
   "kinds": {
@@ -36,6 +46,27 @@
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
         { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
         { "verb": "cancel", "from": ["offered", "assigned", "open"], "to": "cancelled", "who": "offerer" },
+        { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
+      ]
+    },
+    "bounty": {
+      "opens": { "verb": "offer", "open": "open" },
+      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "transitions": [
+        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "award",
+          "from": "open",
+          "to": "assigned",
+          "who": "offerer",
+          "before_deadline": true,
+          "assignee_from": "act-to",
+          "requires": ["act-to"]
+        },
+        { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
+        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
+        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
     }
@@ -78,7 +109,8 @@
     "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step.",
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
-    "replaces-not-terminal": "The action it replaces is not finished."
+    "replaces-not-terminal": "The action it replaces is not finished.",
+    "missing-requirement": "The transition requires a field the event does not carry."
   },
   "deadline_rule": {
     "_note": [
@@ -134,10 +166,24 @@
     },
     {
       "name": "an opener for a kind this file does not list is refused",
-      "kind": "bounty",
+      "kind": "approval",
       "verb": "offer",
       "directed": false,
       "expect_refused": "unknown-kind"
+    },
+    {
+      "name": "a bounty opens to the room, and naming a recipient is not something it can do",
+      "kind": "bounty",
+      "verb": "offer",
+      "directed": false,
+      "expect": "open"
+    },
+    {
+      "name": "a directed bounty is just a handoff, so the opener is refused",
+      "kind": "bounty",
+      "verb": "offer",
+      "directed": true,
+      "expect_refused": "illegal-step"
     }
   ],
   "revival_sequences": [
@@ -608,7 +654,7 @@
     {
       "name": "a kind this file does not list is refused",
       "task": {
-        "kind": "bounty",
+        "kind": "approval",
         "offer": "open",
         "state": "open",
         "offerer": "did:plc:eliza",
@@ -616,8 +662,160 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect_refused": "unknown-kind" },
+        { "verb": "request", "sender": "did:plc:scholar", "expect_refused": "unknown-kind" },
         { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "unknown-kind" }
+      ]
+    },
+    {
+      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+      ]
+    },
+    {
+      "name": "the poster awards the work, and the loser is not the one who finishes it",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
+      ]
+    },
+    {
+      "name": "an award names its winner, or it assigns nobody",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "expect_refused": "missing-requirement"
+        },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "the poster is the only one who awards the work",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:scholar",
+          "tags": ["act-to"],
+          "expect_refused": "wrong-sender"
+        },
+        {
+          "verb": "award",
+          "sender": "did:plc:mallory",
+          "tags": ["act-to"],
+          "expect_refused": "wrong-sender"
+        }
+      ]
+    },
+    {
+      "name": "a bid after the deadline is refused, exactly as an award is",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "expect_refused": "deadline-passed"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "an awarded bounty takes no further bids",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
+      ]
+    },
+    {
+      "name": "a bounty has no offeree, so it is never accepted or declined",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "accept", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "claim", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
       ]
     }
   ]

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -53,6 +53,21 @@
     "verb": "confirm",
     "subject": "act-subject"
   },
+  "revival": {
+    "_note": [
+      "The typed relation a new action uses to name a finished one it revives: a failed handoff re-offered,",
+      "a forfeited bounty re-listed. Named for its relation rather than carried on a generic pointer, so the",
+      "checker knows what the link claims and can hold it to it — which is the whole argument for one tag",
+      "per relation in the _readme above.",
+      "Only an opener revives anything: a step on an action that already exists names no other. The value",
+      "names an action, so it is shaped like one. And the action it names must be finished — reviving",
+      "something still running would leave two live actions each claiming to be the work.",
+      "An action this server never saw is the case that matters later: receivers must tolerate a link to one",
+      "they never filed, and annotate rather than refuse. On one server that is the link a client mistyped;",
+      "under federation it is the ordinary case, since the predecessor lived on somebody else's machine."
+    ],
+    "tag": "act-replaces"
+  },
   "refusals": {
     "unknown-kind": "The kind is not in this file. Adding a kind means updating this file first.",
     "unknown-verb": "The kind lists no transition with this verb.",
@@ -60,7 +75,10 @@
     "illegal-step": "The verb is not legal from the task's current state.",
     "wrong-sender": "The sender does not hold the role this transition requires.",
     "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance.",
-    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step."
+    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step.",
+    "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
+    "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
+    "replaces-not-terminal": "The action it replaces is not finished."
   },
   "deadline_rule": {
     "_note": [
@@ -120,6 +138,43 @@
       "verb": "offer",
       "directed": false,
       "expect_refused": "unknown-kind"
+    }
+  ],
+  "revival_sequences": [
+    {
+      "name": "a re-offer revives the failed action it names",
+      "opens": true,
+      "names": "01M16E7TC0ENDED00000000000",
+      "predecessor": "finished",
+      "expect": "accepted"
+    },
+    {
+      "name": "a re-offer naming an action this server never saw is annotated, not refused",
+      "opens": true,
+      "names": "01M16E7TC0NEVERSEEN0000000",
+      "predecessor": "unknown",
+      "expect": "accepted"
+    },
+    {
+      "name": "an action still running is not something to revive",
+      "opens": true,
+      "names": "01M16E7TC0STANDSYET0000000",
+      "predecessor": "live",
+      "expect_refused": "replaces-not-terminal"
+    },
+    {
+      "name": "a step on an action revives nothing",
+      "opens": false,
+      "names": "01M16E7TC0ENDED00000000000",
+      "predecessor": "finished",
+      "expect_refused": "replaces-not-opener"
+    },
+    {
+      "name": "a value that is not an action id names no action",
+      "opens": true,
+      "names": "01M16E7TC0SHRT",
+      "predecessor": "unknown",
+      "expect_refused": "replaces-malformed"
     }
   ],
   "sequences": [

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -20,6 +20,9 @@
     "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
     "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`before_bid_deadline` is the same comparison against a second time on the same opener: act-deadline",
+    "bounds how long the offer stands, act-bid-deadline how long it takes bids, and a kind that collects",
+    "them wants both. A time the offer never named bounds nothing.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
@@ -29,6 +32,11 @@
     "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What a bounty is worth is nobody's business here: act-price on the offer, act-bid and act-pay-to on a",
+    "bid, act-tx on the acceptance. Stored, relayed, replayed, inside the signature because every act tag is,",
+    "and never read. The server records that a payment was claimed; it never confirms one, and settlement",
+    "lives above this entirely. act-bid-deadline is deliberately not in that list: it is a time the referee",
+    "compares, exactly like act-deadline.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
     "The server still never picks: it checks only that the named event is a `bid` on this action.",
     "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
@@ -61,7 +69,13 @@
       "opens": { "verb": "offer", "open": "open" },
       "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
-        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "bid",
+          "from": "open",
+          "to": "open",
+          "who": "anyone",
+          "before_bid_deadline": true
+        },
         {
           "verb": "award",
           "from": "open",
@@ -983,13 +997,14 @@
       ]
     },
     {
-      "name": "a bid after the deadline is refused, exactly as an award is",
+      "name": "a bounty stops taking bids at its own cutoff",
       "task": {
         "kind": "bounty",
         "offer": "open",
         "offerer": "did:plc:eliza",
         "offeree": null,
-        "deadline": 1788000000
+        "deadline": null,
+        "bid_deadline": 1788000000
       },
       "steps": [
         {
@@ -1002,6 +1017,46 @@
           "verb": "bid",
           "sender": "did:plc:scholar",
           "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "bidding closing does not stop the poster picking",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null,
+        "bid_deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "a bounty that named no bid cutoff takes bids as long as it stands",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
           "expect": "open"
         }
       ]

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -35,7 +35,11 @@
     "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
     "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
     "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
-    "clock, not a further verb."
+    "clock, not a further verb: auto-accept is the server's, it fires on work left unanswered past a window",
+    "every bidder knew before bidding, and it is its own verb rather than a reused expire so the log says",
+    "which of the two happened. The window is one number the operator sets. A per-task act-review-deadline",
+    "the offer declares, read like act-deadline and overriding the global for that task, is the additive",
+    "follow-on: the sweep would change only which number it reads, so nothing here is built to be undone."
   ],
   "version": 1,
   "kinds": {

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -26,7 +26,7 @@
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "accept and claim already mean; a bounty's award sets it to { \"author_of\": \"act-accepts\" }, because the poster picks a bid",
     "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
     "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
     "someone else, or insists on a field, needs a row here and no code anywhere.",
@@ -82,7 +82,7 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "bid-author",
+          "assignee_from": { "author_of": "act-accepts" },
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -22,16 +22,15 @@
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
-    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
-    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
-    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
-    "insists on a field, needs a row here and no code anywhere.",
+    "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
+    "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
+    "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
-    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
-    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
-    "record. A checker that second-guessed it would be picking."
+    "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
+    "The server still never picks: it checks only that the named event is a `bid` on this action."
   ],
   "version": 1,
   "kinds": {
@@ -60,8 +59,8 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "act-to",
-          "requires": ["act-to"]
+          "assignee_from": "bid-author",
+          "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
@@ -110,7 +109,8 @@
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
     "replaces-not-terminal": "The action it replaces is not finished.",
-    "missing-requirement": "The transition requires a field the event does not carry."
+    "missing-requirement": "The transition requires a field the event does not carry.",
+    "accepts-not-a-bid": "The award names an event that is not a bid on this action."
   },
   "deadline_rule": {
     "_note": [
@@ -667,7 +667,7 @@
       ]
     },
     {
-      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "name": "a bounty takes bids, the poster awards one of them, and its author does the work",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -676,17 +676,28 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:rival",
           "expect": "assigned"
         },
-        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+        { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
       ]
     },
     {
@@ -699,13 +710,24 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
@@ -713,7 +735,7 @@
       ]
     },
     {
-      "name": "an award names its winner, or it assigns nobody",
+      "name": "an award names the bid it takes, or it takes nothing",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -730,9 +752,48 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "an award naming the bounty's own opener names no bid",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0THEBNTY000000000",
+          "expect_refused": "accepts-not-a-bid"
+        }
+      ]
+    },
+    {
+      "name": "a bid on another bounty is not one this award can take",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDANTHERACTN0000",
+          "expect_refused": "accepts-not-a-bid"
         }
       ]
     },
@@ -749,13 +810,17 @@
         {
           "verb": "award",
           "sender": "did:plc:scholar",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         },
         {
           "verb": "award",
           "sender": "did:plc:mallory",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         }
       ]
@@ -797,8 +862,9 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -17,8 +17,8 @@
     "Adding a tag is free: the signature covers every act-* tag present, so a second relation never needs a",
     "canonical change, and IRC tags are a flat map — the first event carrying two pointers needs two names anyway.",
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
-    "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
-    "never checked here. `from` is one state, a list of states, or",
+    "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
+    "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
@@ -30,7 +30,12 @@
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
-    "The server still never picks: it checks only that the named event is a `bid` on this action."
+    "The server still never picks: it checks only that the named event is a `bid` on this action.",
+    "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
+    "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
+    "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
+    "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
+    "clock, not a further verb."
   ],
   "version": 1,
   "kinds": {
@@ -50,7 +55,7 @@
     },
     "bounty": {
       "opens": { "verb": "offer", "open": "open" },
-      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
         { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
         {
@@ -63,8 +68,16 @@
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
-        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
-        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "submit", "from": "assigned", "to": "under_review", "who": "assignee" },
+        { "verb": "revise", "from": "under_review", "to": "assigned", "who": "offerer" },
+        { "verb": "accept-work", "from": "under_review", "to": "accepted", "who": "offerer" },
+        {
+          "verb": "forfeit",
+          "from": ["assigned", "under_review"],
+          "to": "forfeited",
+          "who": "assignee"
+        },
+        { "verb": "auto-accept", "from": "under_review", "to": "accepted", "who": "system" },
         { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
@@ -697,7 +710,147 @@
           "expect": "assigned"
         },
         { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect": "assigned" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "the work is the worker's to hand in and the poster's to accept",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "revise", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "delivered work is not something the poster can withdraw",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect": "cancelled" }
+      ]
+    },
+    {
+      "name": "once the work is in, the poster takes it or sends it back and nothing else",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "illegal-step" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "a bounty is not finished by the worker saying so",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "complete", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "fail", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "the worker walks away from work they hold, before or after handing it in",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "forfeit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "forfeit", "sender": "did:plc:scholar", "expect": "forfeited" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect_refused": "terminal-task" }
+      ]
+    },
+    {
+      "name": "the review clock is the server's to run out, and nobody else's",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "auto-accept", "sender": "did:web:irc.example", "system": true, "expect_refused": "illegal-step" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "auto-accept", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "auto-accept", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        {
+          "verb": "auto-accept",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect": "accepted"
+        }
       ]
     },
     {
@@ -730,7 +883,7 @@
           "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
-        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
       ]
     },

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -14,6 +14,7 @@ import {
   checkOpen,
   CONFIRMATION_VERB,
   REVIVAL_TAG,
+  assigneeSource,
   checkRevival,
   checkTransition,
   isConfirmation,
@@ -39,6 +40,11 @@ interface Step {
   sender: string;
   event_id?: string;
   system?: boolean;
+  /** The act fields the event carries, by document name. What a transition's
+   *  `requires` is checked against. */
+  tags?: string[];
+  /** Who the step assigns, when it names someone other than its sender. */
+  assigns?: string;
   expect?: string;
   expect_refused?: RefusalReason;
 }
@@ -92,7 +98,11 @@ describe("the rules file", () => {
   it("names both initial states, and nothing for an unlisted kind", () => {
     expect(initialState("handoff", true)).toBe("offered");
     expect(initialState("handoff", false)).toBe("open");
-    expect(initialState("bounty", false)).toBeNull();
+    expect(initialState("approval", false)).toBeNull();
+    // A bounty opens to the room and nowhere else: it has no directed form,
+    // because a directed bounty is just a handoff.
+    expect(initialState("bounty", false)).toBe("open");
+    expect(initialState("bounty", true)).toBeNull();
   });
 
   it("carries the five terminal states and no others", () => {
@@ -104,8 +114,8 @@ describe("the rules file", () => {
     }
   });
 
-  it("does not carry the deferred approval kind", () => {
-    expect(Object.keys(canonical.kinds)).toEqual(["handoff"]);
+  it("carries the two kinds it lists, and not the deferred approval", () => {
+    expect(Object.keys(canonical.kinds).sort()).toEqual(["bounty", "handoff"]);
   });
 
   it("uses the same deadline tolerance as the Rust checker", () => {
@@ -148,7 +158,8 @@ describe("opening a task", () => {
 
   it("names the creating verb, which no transition row can", () => {
     expect(openingVerb("handoff")).toBe("offer");
-    expect(openingVerb("bounty")).toBeNull();
+    expect(openingVerb("bounty")).toBe("offer");
+    expect(openingVerb("approval")).toBeNull();
   });
 
   it("lets any logged-in sender open, directed or not", () => {
@@ -177,9 +188,19 @@ describe("opening a task", () => {
   });
 
   it("refuses to open a kind the file does not list", () => {
-    expect(checkOpen("bounty", "offer", false, false)).toEqual({
+    expect(checkOpen("approval", "offer", false, false)).toEqual({
       ok: false,
       reason: "unknown-kind",
+    });
+  });
+
+  // The answer is illegal-step and not unknown-verb: `offer` is exactly the
+  // verb that opens a bounty, and naming a recipient is the part it cannot do.
+  it("refuses to open a bounty to one recipient", () => {
+    expect(checkOpen("bounty", "offer", false, false)).toEqual({ ok: true, to: "open" });
+    expect(checkOpen("bounty", "offer", true, false)).toEqual({
+      ok: false,
+      reason: "illegal-step",
     });
   });
 
@@ -370,9 +391,11 @@ describe("refusals", () => {
   });
 
   it("a kind the file does not list is refused, before the verb is even read", () => {
-    const bounty: Task = { ...directed("open"), kind: "bounty" };
-    expect(checkTransition(bounty, ev("bid"), who(SCHOLAR))).toEqual(refused("unknown-kind"));
-    expect(checkTransition(bounty, ev("cancel"), who(ELIZA))).toEqual(refused("unknown-kind"));
+    const approval: Task = { ...directed("open"), kind: "approval" };
+    expect(checkTransition(approval, ev("request"), who(SCHOLAR))).toEqual(
+      refused("unknown-kind"),
+    );
+    expect(checkTransition(approval, ev("cancel"), who(ELIZA))).toEqual(refused("unknown-kind"));
   });
 });
 
@@ -469,6 +492,62 @@ describe("the deadline", () => {
   });
 });
 
+describe("the two schema additions bounty needed", () => {
+  const refused = (reason: RefusalReason) => ({ ok: false, reason });
+  const bounty = (state: string): Task => ({ kind: "bounty", state, offerer: ELIZA });
+
+  // Checked before authority: an award naming no winner is malformed for
+  // everybody, and "not you" would send the sender after the wrong problem.
+  it("an award names its winner, or it is no award", () => {
+    const bare = { verb: "award", msgid: NOW, fields: [] };
+    expect(checkTransition(bounty("open"), bare, who(ELIZA))).toEqual(
+      refused("missing-requirement"),
+    );
+    expect(checkTransition(bounty("open"), bare, who(MALLORY))).toEqual(
+      refused("missing-requirement"),
+    );
+    const named = { verb: "award", msgid: NOW, fields: ["act-to"] };
+    expect(checkTransition(bounty("open"), named, who(ELIZA))).toEqual({
+      ok: true,
+      to: "assigned",
+    });
+  });
+
+  // The guard has to be free for every row that names nothing, which is
+  // almost all of them.
+  it("leaves a transition that requires nothing exactly as it was", () => {
+    expect(checkTransition(directed("offered"), ev("accept"), who(SCHOLAR))).toEqual({
+      ok: true,
+      to: "assigned",
+    });
+  });
+
+  it("says where each transition's assignee comes from", () => {
+    expect(assigneeSource("bounty", "award", "open")).toEqual({
+      from: "field",
+      field: "act-to",
+    });
+    for (const [kind, verb, from] of [
+      ["handoff", "accept", "offered"],
+      ["handoff", "claim", "open"],
+      ["bounty", "bid", "open"],
+    ]) {
+      expect(assigneeSource(kind, verb, from), `${kind}/${verb}`).toEqual({ from: "actor" });
+    }
+    expect(assigneeSource("approval", "request", "open")).toEqual({ from: "actor" });
+  });
+
+  it("takes bids additively until the work is awarded", () => {
+    expect(checkTransition(bounty("open"), ev("bid"), who(SCHOLAR))).toEqual({
+      ok: true,
+      to: "open",
+    });
+    expect(checkTransition(bounty("assigned"), ev("bid"), who(MALLORY))).toEqual(
+      refused("illegal-step"),
+    );
+  });
+});
+
 describe("the shared sequences", () => {
   const sequences = canonical.sequences as Sequence[];
 
@@ -492,7 +571,7 @@ describe("the shared sequences", () => {
         };
         const result = checkTransition(
           task,
-          { verb: step.verb, msgid: step.event_id ?? NOW },
+          { verb: step.verb, msgid: step.event_id ?? NOW, fields: step.tags ?? [] },
           { did: step.sender, isSystem: step.system ?? false },
         );
         const where = `${seq.name} — step ${i + 1} (${step.verb})`;
@@ -500,8 +579,21 @@ describe("the shared sequences", () => {
         if (step.expect !== undefined) {
           expect(result, where).toEqual({ ok: true, to: step.expect });
           // A refused step changes nothing; an accepted one may name the
-          // assignee, which is the sender who moved it into `assigned`.
-          if (assignee === null && step.expect === "assigned") assignee = step.sender;
+          // assignee. Who that is, is data: the actor by default, and whoever
+          // the transition's field names otherwise — a bounty's award names
+          // its winner rather than becoming one.
+          if (assignee === null && step.expect === "assigned") {
+            const source = assigneeSource(seq.task.kind, step.verb, state);
+            assignee =
+              source.from === "actor"
+                ? step.sender
+                : (step.assigns ??
+                  (() => {
+                    throw new Error(
+                      `${where}: assigns is not set, but this transition takes its assignee from ${source.field}`,
+                    );
+                  })());
+          }
           state = step.expect;
         } else {
           expect(result, where).toEqual({ ok: false, reason: step.expect_refused });

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -557,7 +557,10 @@ describe("the two schema additions bounty needed", () => {
   });
 
   it("says where each transition's assignee comes from", () => {
-    expect(assigneeSource("bounty", "award", "open")).toEqual({ from: "bid-author" });
+    expect(assigneeSource("bounty", "award", "open")).toEqual({
+      from: "author_of",
+      field: "act-accepts",
+    });
     for (const [kind, verb, from] of [
       ["handoff", "accept", "offered"],
       ["handoff", "claim", "open"],
@@ -660,7 +663,7 @@ describe("the shared sequences", () => {
             const source = assigneeSource(seq.task.kind, step.verb, state);
             if (source.from === "actor") {
               assignee = step.sender;
-            } else if (source.from === "bid-author") {
+            } else if (source.from === "author_of") {
               if (!step.accepted_bid) {
                 throw new Error(
                   `${where}: this transition assigns the author of the bid it names, and none was resolved`,

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -70,6 +70,7 @@ interface Sequence {
     offerer: string;
     offeree: string | null;
     deadline: number | null;
+    bid_deadline?: number | null;
   };
   steps: Step[];
 }
@@ -567,6 +568,35 @@ describe("the two schema additions bounty needed", () => {
     expect(assigneeSource("approval", "request", "open")).toEqual({ from: "actor" });
   });
 
+  // A bounty takes bids until its own cutoff, which is a shorter question
+  // than how long the offer stands.
+  it("binds a bid to the offer's bid deadline, and the award to its own", () => {
+    const DEADLINE = 1_788_000_000;
+    const TOO_LATE = "01M16HSC58ACCEPTTOOLATE000";
+    const AT_EDGE = "01M16HSB60ACCEPTATEDGE0000";
+    const takingBids: Task = { ...bounty("open"), bidDeadline: DEADLINE };
+    expect(
+      checkTransition(takingBids, { verb: "bid", msgid: TOO_LATE }, who(SCHOLAR)),
+    ).toEqual(refused("deadline-passed"));
+    expect(checkTransition(takingBids, { verb: "bid", msgid: AT_EDGE }, who(SCHOLAR))).toEqual({
+      ok: true,
+      to: "open",
+    });
+    // Bidding closing does not stop the poster picking: the award is bound by
+    // the offer's own deadline, which this bounty never named.
+    expect(
+      checkTransition(
+        takingBids,
+        { verb: "award", msgid: TOO_LATE, accepts: BID, fields: ["act-accepts"] },
+        took(ELIZA, SCHOLAR),
+      ),
+    ).toEqual({ ok: true, to: "assigned" });
+    // …and no bid cutoff means no bid cutoff.
+    expect(
+      checkTransition(bounty("open"), { verb: "bid", msgid: TOO_LATE }, who(SCHOLAR)),
+    ).toEqual({ ok: true, to: "open" });
+  });
+
   it("takes bids additively until the work is awarded", () => {
     expect(checkTransition(bounty("open"), ev("bid"), who(SCHOLAR))).toEqual({
       ok: true,
@@ -598,6 +628,7 @@ describe("the shared sequences", () => {
           offeree: seq.task.offeree,
           assignee,
           deadline: seq.task.deadline,
+          bidDeadline: seq.task.bid_deadline,
         };
         const result = checkTransition(
           task,

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -45,6 +45,11 @@ interface Step {
   tags?: string[];
   /** Who the step assigns, when it names someone other than its sender. */
   assigns?: string;
+  /** `act-accepts`: the event an award takes. */
+  accepts?: string;
+  /** Who wrote the bid that event turned out to be. Absent when the name
+   *  found no bid on this action. */
+  accepted_bid?: string;
   expect?: string;
   expect_refused?: RefusalReason;
 }
@@ -495,22 +500,50 @@ describe("the deadline", () => {
 describe("the two schema additions bounty needed", () => {
   const refused = (reason: RefusalReason) => ({ ok: false, reason });
   const bounty = (state: string): Task => ({ kind: "bounty", state, offerer: ELIZA });
+  /** The bid an award names in these tests. */
+  const BID = "01M16E7TC0BDTAKEN000000000";
+  const award = { verb: "award", msgid: NOW, accepts: BID, fields: ["act-accepts"] };
+  const took = (did: string, author: string): EventSender => ({
+    did,
+    acceptedBid: { author },
+  });
 
-  // Checked before authority: an award naming no winner is malformed for
+  // Checked before authority: an award naming no bid is malformed for
   // everybody, and "not you" would send the sender after the wrong problem.
-  it("an award names its winner, or it is no award", () => {
+  it("an award names the bid it takes, or it is no award", () => {
     const bare = { verb: "award", msgid: NOW, fields: [] };
-    expect(checkTransition(bounty("open"), bare, who(ELIZA))).toEqual(
+    expect(checkTransition(bounty("open"), bare, took(ELIZA, SCHOLAR))).toEqual(
       refused("missing-requirement"),
     );
-    expect(checkTransition(bounty("open"), bare, who(MALLORY))).toEqual(
+    expect(checkTransition(bounty("open"), bare, took(MALLORY, SCHOLAR))).toEqual(
       refused("missing-requirement"),
     );
-    const named = { verb: "award", msgid: NOW, fields: ["act-to"] };
-    expect(checkTransition(bounty("open"), named, who(ELIZA))).toEqual({
+    expect(checkTransition(bounty("open"), award, took(ELIZA, SCHOLAR))).toEqual({
       ok: true,
       to: "assigned",
     });
+  });
+
+  // The award names one event and the caller resolves it. A name that found
+  // no bid on this action takes nothing, and says so.
+  it("an award naming something that is not a bid takes nothing", () => {
+    expect(checkTransition(bounty("open"), award, who(ELIZA))).toEqual(
+      refused("accepts-not-a-bid"),
+    );
+    expect(checkTransition(bounty("open"), award, who(MALLORY))).toEqual(
+      refused("accepts-not-a-bid"),
+    );
+  });
+
+  // The server still never picks: which of the bids on the table is worth
+  // taking is the poster's to decide.
+  it("lets the poster take whichever bid they name", () => {
+    for (const author of [SCHOLAR, MALLORY, "did:plc:nobody"]) {
+      expect(checkTransition(bounty("open"), award, took(ELIZA, author)), author).toEqual({
+        ok: true,
+        to: "assigned",
+      });
+    }
   });
 
   // The guard has to be free for every row that names nothing, which is
@@ -523,10 +556,7 @@ describe("the two schema additions bounty needed", () => {
   });
 
   it("says where each transition's assignee comes from", () => {
-    expect(assigneeSource("bounty", "award", "open")).toEqual({
-      from: "field",
-      field: "act-to",
-    });
+    expect(assigneeSource("bounty", "award", "open")).toEqual({ from: "bid-author" });
     for (const [kind, verb, from] of [
       ["handoff", "accept", "offered"],
       ["handoff", "claim", "open"],
@@ -571,8 +601,21 @@ describe("the shared sequences", () => {
         };
         const result = checkTransition(
           task,
-          { verb: step.verb, msgid: step.event_id ?? NOW, fields: step.tags ?? [] },
-          { did: step.sender, isSystem: step.system ?? false },
+          {
+            verb: step.verb,
+            msgid: step.event_id ?? NOW,
+            accepts: step.accepts,
+            fields: step.tags ?? [],
+          },
+          {
+            did: step.sender,
+            isSystem: step.system ?? false,
+            // What the caller's log made of the event this one names. A step
+            // that sets nothing named nothing, or named something that is not
+            // a bid — the file does not distinguish, because neither does the
+            // checker.
+            acceptedBid: step.accepted_bid ? { author: step.accepted_bid } : null,
+          },
         );
         const where = `${seq.name} — step ${i + 1} (${step.verb})`;
 
@@ -584,15 +627,22 @@ describe("the shared sequences", () => {
           // its winner rather than becoming one.
           if (assignee === null && step.expect === "assigned") {
             const source = assigneeSource(seq.task.kind, step.verb, state);
-            assignee =
-              source.from === "actor"
-                ? step.sender
-                : (step.assigns ??
-                  (() => {
-                    throw new Error(
-                      `${where}: assigns is not set, but this transition takes its assignee from ${source.field}`,
-                    );
-                  })());
+            if (source.from === "actor") {
+              assignee = step.sender;
+            } else if (source.from === "bid-author") {
+              if (!step.accepted_bid) {
+                throw new Error(
+                  `${where}: this transition assigns the author of the bid it names, and none was resolved`,
+                );
+              }
+              assignee = step.accepted_bid;
+            } else if (!step.assigns) {
+              throw new Error(
+                `${where}: assigns is not set, but this transition takes its assignee from ${source.field}`,
+              );
+            } else {
+              assignee = step.assigns;
+            }
           }
           state = step.expect;
         } else {

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -13,8 +13,12 @@ import {
   DEADLINE_TOLERANCE_MS,
   checkOpen,
   CONFIRMATION_VERB,
+  REVIVAL_TAG,
+  checkRevival,
   checkTransition,
   isConfirmation,
+  isEventId,
+  type Predecessor,
   eventTimeMs,
   initialState,
   isTerminal,
@@ -116,6 +120,9 @@ describe("the rules file", () => {
       ) as string[]),
       ...((canonical.opening_sequences as { expect_refused?: string }[])
         .map((o) => o.expect_refused)
+        .filter(Boolean) as string[]),
+      ...((canonical.revival_sequences as { expect_refused?: string }[])
+        .map((r) => r.expect_refused)
         .filter(Boolean) as string[]),
     ]);
     for (const reason of used) {
@@ -247,6 +254,53 @@ describe("the receipt verb", () => {
       expect(isConfirmation(kind.opens.verb), name).toBe(false);
     }
   });
+});
+
+describe("the revival relation", () => {
+  const refused = (reason: RefusalReason) => ({ ok: false, reason });
+  const DEAD = "01M16E7TC0ENDED00000000000";
+
+  it("only an opener revives a finished action", () => {
+    expect(REVIVAL_TAG).toBe("act-replaces");
+    expect(checkRevival(true, DEAD, "finished")).toEqual({ ok: true });
+    expect(checkRevival(true, DEAD, "unknown")).toEqual({ ok: true });
+    expect(checkRevival(true, DEAD, "live")).toEqual(refused("replaces-not-terminal"));
+    expect(checkRevival(false, DEAD, "finished")).toEqual(refused("replaces-not-opener"));
+    for (const bad of ["", "not-a-ulid", "01M16E7TC0SHRT", `${DEAD}X`, DEAD.toLowerCase()]) {
+      expect(checkRevival(true, bad, "unknown"), bad).toEqual(refused("replaces-malformed"));
+    }
+  });
+
+  it("reads an action id as twenty-six Crockford characters", () => {
+    expect(isEventId(DEAD)).toBe(true);
+    expect(isEventId(DEAD.slice(0, 25))).toBe(false);
+    // I, L, O and U are not in the alphabet, which is what keeps a ULID from
+    // being confused for something typed by hand.
+    for (const c of ["I", "L", "O", "U", "a", "-"]) {
+      expect(isEventId(DEAD.slice(0, 25) + c), c).toBe(false);
+    }
+  });
+
+  interface RevivalCase {
+    name: string;
+    opens: boolean;
+    names: string;
+    predecessor: Predecessor;
+    expect?: string;
+    expect_refused?: RefusalReason;
+  }
+
+  for (const c of canonical.revival_sequences as RevivalCase[]) {
+    it(c.name, () => {
+      const got = checkRevival(c.opens, c.names, c.predecessor);
+      if (c.expect !== undefined) {
+        expect(c.expect).toBe("accepted");
+        expect(got).toEqual({ ok: true });
+      } else {
+        expect(got).toEqual(refused(c.expect_refused!));
+      }
+    });
+  }
 });
 
 describe("refusals", () => {

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -12,7 +12,9 @@ import { fileURLToPath } from "node:url";
 import {
   DEADLINE_TOLERANCE_MS,
   checkOpen,
+  CONFIRMATION_VERB,
   checkTransition,
+  isConfirmation,
   eventTimeMs,
   initialState,
   isTerminal,
@@ -35,6 +37,13 @@ interface Step {
   system?: boolean;
   expect?: string;
   expect_refused?: RefusalReason;
+}
+
+/** Just enough of a kind's shape for the tests that read the file directly. */
+interface Kind {
+  opens: { verb: string; directed?: string; open: string };
+  terminal: string[];
+  transitions: { verb: string; from: string | string[]; to: string; who: string }[];
 }
 
 interface Sequence {
@@ -100,11 +109,15 @@ describe("the rules file", () => {
   });
 
   it("documents every refusal reason it uses", () => {
-    const used = new Set<string>(
-      (canonical.sequences as Sequence[]).flatMap((s) =>
+    // Both lists count: some reasons only an opener can earn.
+    const used = new Set<string>([
+      ...((canonical.sequences as Sequence[]).flatMap((s) =>
         s.steps.map((st) => st.expect_refused).filter(Boolean),
-      ) as string[],
-    );
+      ) as string[]),
+      ...((canonical.opening_sequences as { expect_refused?: string }[])
+        .map((o) => o.expect_refused)
+        .filter(Boolean) as string[]),
+    ]);
     for (const reason of used) {
       expect(refusalDescription(reason as RefusalReason), reason).not.toBe("refused");
     }
@@ -198,6 +211,40 @@ describe("the happy path", () => {
         ok: true,
         to: "cancelled",
       });
+    }
+  });
+});
+
+describe("the receipt verb", () => {
+  const refused = (reason: RefusalReason) => ({ ok: false, reason });
+
+  // A receipt is the home's word about an event, so a sender's `confirm` is
+  // refused wherever it appears — opening or moving, whatever kind it names,
+  // and even when the sender claims to be the server.
+  it("is never a sender's to write", () => {
+    expect(CONFIRMATION_VERB).toBe("confirm");
+    expect(checkTransition(directed("offered"), ev("confirm"), who(SCHOLAR))).toEqual(
+      refused("client-confirm"),
+    );
+    expect(
+      checkTransition(directed("offered"), ev("confirm"), { did: SERVER, isSystem: true }),
+    ).toEqual(refused("client-confirm"));
+    expect(checkOpen("handoff", "confirm", false, false)).toEqual(refused("client-confirm"));
+  });
+
+  // The answer must not read as "this kind has no such row yet", which would
+  // say a kind could add one. It cannot.
+  it("never reads as a verb a kind could add", () => {
+    expect(checkTransition({ ...directed("offered"), kind: "no-such-kind" }, ev("confirm"), who(SCHOLAR))).toEqual(
+      refused("client-confirm"),
+    );
+    expect(checkOpen("no-such-kind", "confirm", false, false)).toEqual(refused("client-confirm"));
+    for (const [name, kind] of Object.entries(canonical.kinds as Record<string, Kind>)) {
+      expect(
+        kind.transitions.some((t) => isConfirmation(t.verb)),
+        `${name} claims the receipt verb, which belongs to no kind`,
+      ).toBe(false);
+      expect(isConfirmation(kind.opens.verb), name).toBe(false);
     }
   });
 });

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -26,7 +26,8 @@ export type RefusalReason =
   | "terminal-task"
   | "illegal-step"
   | "wrong-sender"
-  | "deadline-passed";
+  | "deadline-passed"
+  | "client-confirm";
 
 /** Allowed, with the state the task lands in — or refused, with the reason. */
 export type CheckResult = { ok: true; to: string } | { ok: false; reason: RefusalReason };
@@ -100,6 +101,25 @@ export function openingVerb(kind: string): string | null {
   return kinds[kind]?.opens.verb ?? null;
 }
 
+/** The verb an action's home writes its receipts under. */
+export const CONFIRMATION_VERB = spec.confirmation.verb;
+
+/** The tag a receipt names the event it confirms in. */
+export const CONFIRMATION_SUBJECT_TAG = spec.confirmation.subject;
+
+/**
+ * Whether this verb is the home's receipt verb.
+ *
+ * Asked before any kind's table is consulted, by every caller that reads a
+ * verb at all. A receipt is a statement about an event, not a move on a task:
+ * no kind lists `confirm`, and letting one fall through to the per-kind lookup
+ * would answer "that kind has no such step" — which reads as an invitation to
+ * add the row, and the row must not exist.
+ */
+export function isConfirmation(verb: string): boolean {
+  return verb === CONFIRMATION_VERB;
+}
+
 /**
  * Decide whether an event may open a new task of `kind`.
  *
@@ -115,6 +135,9 @@ export function checkOpen(
   directed: boolean,
   namesTask: boolean,
 ): CheckResult {
+  // Before the kind is even looked up: a receipt opens nothing, and the answer
+  // must not depend on which kind it named.
+  if (isConfirmation(verb)) return { ok: false, reason: "client-confirm" };
   const k = kinds[kind];
   if (!k) return { ok: false, reason: "unknown-kind" };
   if (k.opens.verb !== verb) {
@@ -175,6 +198,10 @@ export function checkTransition(
   event: TaskEvent,
   sender: EventSender,
 ): CheckResult {
+  // The receipt verb, before the kind lookup and before anything about this
+  // task: a confirmation is not a move, and no table has a row for it. The
+  // home files its own receipts past this checker entirely.
+  if (isConfirmation(event.verb)) return { ok: false, reason: "client-confirm" };
   const kind = kinds[task.kind];
   if (!kind) return { ok: false, reason: "unknown-kind" };
 

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -73,7 +73,7 @@ export interface TaskEvent {
 
 /** The bid an award named, as the caller's log answered for it. */
 export interface AcceptedBid {
-  /** Who wrote the bid. The assignee an award's `bid-author` row lands on. */
+  /** Who wrote the bid. The assignee an award's `author_of` row lands on. */
   author: string;
 }
 
@@ -104,8 +104,9 @@ interface Transition {
   /** Bounded by the offer's `act-bid-deadline` rather than its
    *  `act-deadline`. Data, like its sibling; the comparison is the same code. */
   before_bid_deadline?: boolean;
-  /** The field naming who this transition assigns. Absent = the actor. */
-  assignee_from?: string;
+  /** Who this transition assigns. Absent = the actor; a tag name = the DID in
+   *  that tag; `{ author_of: tag }` = the author of the event that tag names. */
+  assignee_from?: string | { author_of: string };
   /** Fields the transition is illegal without. */
   requires?: string[];
 }
@@ -127,10 +128,6 @@ interface Kind {
 }
 
 const ANY_NONTERMINAL = "*nonterminal";
-
-/** The `assignee_from` value that means "the author of the bid this event
- *  names". */
-const BID_AUTHOR = "bid-author";
 
 /** The verb the event an award names must carry.
  *
@@ -329,7 +326,7 @@ export function checkTransition(
   // reads a log — and a name that found nothing named something that is not a
   // bid on this action. Alongside the requirement above for the same reason:
   // an award that takes no bid is malformed for everybody.
-  if (row.assignee_from === BID_AUTHOR && (!event.accepts || !sender.acceptedBid)) {
+  if (typeof row.assignee_from === "object" && (!event.accepts || !sender.acceptedBid)) {
     return { ok: false, reason: "accepts-not-a-bid" };
   }
 
@@ -385,11 +382,11 @@ export type AssigneeSource =
   | { from: "actor" }
   /** The act field named here, read off the event. */
   | { from: "field"; field: string }
-  /** Whoever wrote the bid the event names in `act-accepts`: a bounty's
-   *  `award` takes one bid, and the terms live in it, so the poster names the
-   *  event rather than a DID. Resolving it is the caller's — this checker
-   *  reads no log — and the answer arrives as `EventSender.acceptedBid`. */
-  | { from: "bid-author" };
+  /** The author of the event named in this act field: a bounty's `award`
+   *  takes one bid, and the terms live in it, so the poster names the event in
+   *  `act-accepts` rather than a DID. Resolving it is the caller's — this
+   *  checker reads no log — and the answer arrives as `EventSender.acceptedBid`. */
+  | { from: "author_of"; field: string };
 
 /**
  * Where the assignee comes from when `verb` moves a `kind` task out of
@@ -408,6 +405,8 @@ export function assigneeSource(
   if (!k) return { from: "actor" };
   const row = k.transitions.find((t) => t.verb === verb && fromMatches(t.from, fromState, k));
   if (!row?.assignee_from) return { from: "actor" };
-  if (row.assignee_from === BID_AUTHOR) return { from: "bid-author" };
+  if (typeof row.assignee_from === "object") {
+    return { from: "author_of", field: row.assignee_from.author_of };
+  }
   return { from: "field", field: row.assignee_from };
 }

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -31,7 +31,8 @@ export type RefusalReason =
   | "replaces-not-opener"
   | "replaces-malformed"
   | "replaces-not-terminal"
-  | "missing-requirement";
+  | "missing-requirement"
+  | "accepts-not-a-bid";
 
 /** Allowed, with the state the task lands in — or refused, with the reason. */
 export type CheckResult = { ok: true; to: string } | { ok: false; reason: RefusalReason };
@@ -55,6 +56,10 @@ export interface TaskEvent {
   /** The id the signer minted; its embedded ULID millisecond is the clock a
    * deadline is measured against. */
   msgid: string;
+  /** `act-accepts`: the event an award takes. Named here rather than read out
+   * of `fields` because it is the one act value a caller must resolve before
+   * asking — see `EventSender.acceptedBid`. */
+  accepts?: string | null;
   /** The act fields the event carries, by their document names (`act-to`,
    * `act-note`, …). Presence only: what a transition's `requires` is checked
    * against. The one place this checker points at a value is
@@ -62,11 +67,28 @@ export interface TaskEvent {
   fields?: string[];
 }
 
-/** Who sent it. */
+/** The bid an award named, as the caller's log answered for it. */
+export interface AcceptedBid {
+  /** Who wrote the bid. The assignee an award's `bid-author` row lands on. */
+  author: string;
+}
+
+/** Who sent it, and what their event resolved to. */
 export interface EventSender {
   did: string;
   /** The server itself — the only actor a `system` transition allows. */
   isSystem?: boolean;
+  /**
+   * The bid this event's `act-accepts` names, when the caller found one on the
+   * action. Absent when it named something that is not a bid here — including
+   * an id belonging to another action, and an id nobody filed.
+   *
+   * This checker reads no log, so the lookup is the caller's: it resolves the
+   * named event among the action's own and hands back the bid's author. A bot
+   * pre-checking its own move has no log — it passes nothing and is told its
+   * award takes nothing, which is the honest answer from where it stands.
+   */
+  acceptedBid?: AcceptedBid | null;
 }
 
 interface Transition {
@@ -98,6 +120,16 @@ interface Kind {
 }
 
 const ANY_NONTERMINAL = "*nonterminal";
+
+/** The `assignee_from` value that means "the author of the bid this event
+ *  names". */
+const BID_AUTHOR = "bid-author";
+
+/** The verb the event an award names must carry.
+ *
+ * Written down once, here, so a caller resolving `act-accepts` asks the rules
+ * rather than spelling a kind's verb into itself. */
+export const BID_VERB = "bid";
 
 const kinds = spec.kinds as unknown as Record<string, Kind>;
 const refusals = spec.refusals as Record<string, string>;
@@ -285,6 +317,15 @@ export function checkTransition(
     return { ok: false, reason: "missing-requirement" };
   }
 
+  // A row that takes its assignee from a named bid needs that bid. Whether the
+  // name found one is the caller's answer, not this checker's — nothing here
+  // reads a log — and a name that found nothing named something that is not a
+  // bid on this action. Alongside the requirement above for the same reason:
+  // an award that takes no bid is malformed for everybody.
+  if (row.assignee_from === BID_AUTHOR && (!event.accepts || !sender.acceptedBid)) {
+    return { ok: false, reason: "accepts-not-a-bid" };
+  }
+
   // Authority second: who the sender is only matters once the move itself
   // makes sense.
   switch (row.who) {
@@ -327,9 +368,13 @@ export function checkTransition(
 export type AssigneeSource =
   /** Whoever took the step — what `accept` and `claim` already mean. */
   | { from: "actor" }
-  /** The act field named here, read off the event: a bounty's `award` names
-   *  its winner in `act-to`, because the poster picks rather than becomes. */
-  | { from: "field"; field: string };
+  /** The act field named here, read off the event. */
+  | { from: "field"; field: string }
+  /** Whoever wrote the bid the event names in `act-accepts`: a bounty's
+   *  `award` takes one bid, and the terms live in it, so the poster names the
+   *  event rather than a DID. Resolving it is the caller's — this checker
+   *  reads no log — and the answer arrives as `EventSender.acceptedBid`. */
+  | { from: "bid-author" };
 
 /**
  * Where the assignee comes from when `verb` moves a `kind` task out of
@@ -347,5 +392,7 @@ export function assigneeSource(
   const k = kinds[kind];
   if (!k) return { from: "actor" };
   const row = k.transitions.find((t) => t.verb === verb && fromMatches(t.from, fromState, k));
-  return row?.assignee_from ? { from: "field", field: row.assignee_from } : { from: "actor" };
+  if (!row?.assignee_from) return { from: "actor" };
+  if (row.assignee_from === BID_AUTHOR) return { from: "bid-author" };
+  return { from: "field", field: row.assignee_from };
 }

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -30,7 +30,8 @@ export type RefusalReason =
   | "client-confirm"
   | "replaces-not-opener"
   | "replaces-malformed"
-  | "replaces-not-terminal";
+  | "replaces-not-terminal"
+  | "missing-requirement";
 
 /** Allowed, with the state the task lands in — or refused, with the reason. */
 export type CheckResult = { ok: true; to: string } | { ok: false; reason: RefusalReason };
@@ -54,6 +55,11 @@ export interface TaskEvent {
   /** The id the signer minted; its embedded ULID millisecond is the clock a
    * deadline is measured against. */
   msgid: string;
+  /** The act fields the event carries, by their document names (`act-to`,
+   * `act-note`, …). Presence only: what a transition's `requires` is checked
+   * against. The one place this checker points at a value is
+   * `assigneeSource`, which names the field rather than reading it. */
+  fields?: string[];
 }
 
 /** Who sent it. */
@@ -69,6 +75,10 @@ interface Transition {
   to: string;
   who: string;
   before_deadline?: boolean;
+  /** The field naming who this transition assigns. Absent = the actor. */
+  assignee_from?: string;
+  /** Fields the transition is illegal without. */
+  requires?: string[];
 }
 
 /** How a task of this kind comes into being: the verb that creates one, and
@@ -267,6 +277,14 @@ export function checkTransition(
   const row = rows.find((t) => fromMatches(t.from, task.state, kind));
   if (!row) return { ok: false, reason: "illegal-step" };
 
+  // What the move needs to be the move at all. Before authority for the same
+  // reason the state is: an award that names no winner is malformed for
+  // everybody, and "not you" would send the sender after the wrong problem.
+  const present = event.fields ?? [];
+  if ((row.requires ?? []).some((f) => !present.includes(f))) {
+    return { ok: false, reason: "missing-requirement" };
+  }
+
   // Authority second: who the sender is only matters once the move itself
   // makes sense.
   switch (row.who) {
@@ -303,4 +321,31 @@ export function checkTransition(
   }
 
   return { ok: true, to: row.to };
+}
+
+/** Who a transition assigns the work to. */
+export type AssigneeSource =
+  /** Whoever took the step — what `accept` and `claim` already mean. */
+  | { from: "actor" }
+  /** The act field named here, read off the event: a bounty's `award` names
+   *  its winner in `act-to`, because the poster picks rather than becomes. */
+  | { from: "field"; field: string };
+
+/**
+ * Where the assignee comes from when `verb` moves a `kind` task out of
+ * `fromState`.
+ *
+ * Data, not code: a kind that assigns someone other than the actor says so in
+ * its row. A verb with no row here answers `actor`, which changes nothing for
+ * a transition that assigns nobody.
+ */
+export function assigneeSource(
+  kind: string,
+  verb: string,
+  fromState: string,
+): AssigneeSource {
+  const k = kinds[kind];
+  if (!k) return { from: "actor" };
+  const row = k.transitions.find((t) => t.verb === verb && fromMatches(t.from, fromState, k));
+  return row?.assignee_from ? { from: "field", field: row.assignee_from } : { from: "actor" };
 }

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -48,6 +48,10 @@ export interface Task {
   assignee?: string | null;
   /** `act-deadline`, unix seconds. */
   deadline?: number | null;
+  /** `act-bid-deadline`, unix seconds. A second time on the same opener,
+   * compared the same way: it bounds how long a bounty collects bids, which
+   * is a shorter question than how long the offer stands. */
+  bidDeadline?: number | null;
 }
 
 /** The event being checked. */
@@ -97,6 +101,9 @@ interface Transition {
   to: string;
   who: string;
   before_deadline?: boolean;
+  /** Bounded by the offer's `act-bid-deadline` rather than its
+   *  `act-deadline`. Data, like its sibling; the comparison is the same code. */
+  before_bid_deadline?: boolean;
   /** The field naming who this transition assigns. Absent = the actor. */
   assignee_from?: string;
   /** Fields the transition is illegal without. */
@@ -353,8 +360,16 @@ export function checkTransition(
       return { ok: false, reason: "wrong-sender" };
   }
 
-  if (row.before_deadline && task.deadline != null) {
-    const limit = task.deadline * 1000 + DEADLINE_TOLERANCE_MS;
+  // Two deadlines, one comparison. A row declares which of the offer's times
+  // bounds it: how long the offer stands, or — on a kind that collects them —
+  // how long it takes bids. A time the offer never named bounds nothing.
+  const bounds = [
+    row.before_deadline ? task.deadline : null,
+    row.before_bid_deadline ? task.bidDeadline : null,
+  ];
+  for (const deadline of bounds) {
+    if (deadline == null) continue;
+    const limit = deadline * 1000 + DEADLINE_TOLERANCE_MS;
     const minted = eventTimeMs(event.msgid);
     // Fail closed: an id whose clock cannot be read cannot be shown to be
     // inside the deadline.

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -27,7 +27,10 @@ export type RefusalReason =
   | "illegal-step"
   | "wrong-sender"
   | "deadline-passed"
-  | "client-confirm";
+  | "client-confirm"
+  | "replaces-not-opener"
+  | "replaces-malformed"
+  | "replaces-not-terminal";
 
 /** Allowed, with the state the task lands in — or refused, with the reason. */
 export type CheckResult = { ok: true; to: string } | { ok: false; reason: RefusalReason };
@@ -118,6 +121,53 @@ export const CONFIRMATION_SUBJECT_TAG = spec.confirmation.subject;
  */
 export function isConfirmation(verb: string): boolean {
   return verb === CONFIRMATION_VERB;
+}
+
+/** The tag a new action names the finished one it revives in. */
+export const REVIVAL_TAG = spec.revival.tag;
+
+/** What the caller's log knows about the action a revival names. */
+export type Predecessor = "unknown" | "live" | "finished";
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/**
+ * Whether `id` is shaped like an event id: a 26-character Crockford ULID.
+ *
+ * Shape only. Whether anything was ever filed under it is the log's answer,
+ * not this one's.
+ */
+export function isEventId(id: string): boolean {
+  return id.length === 26 && [...id].every((c) => CROCKFORD.includes(c));
+}
+
+/** Allowed, or refused with the reason. */
+export type RevivalResult = { ok: true } | { ok: false; reason: RefusalReason };
+
+/**
+ * Decide whether an event may carry the revival relation (`REVIVAL_TAG`),
+ * given what the caller's log knows about the action it names.
+ *
+ * Three rules, cheapest first. Only an opener revives anything: a step on an
+ * action that already exists names no other. The value names an action, so it
+ * is shaped like one. And the action it names must have finished — reviving
+ * something still running would leave two live actions each claiming to be the
+ * work.
+ *
+ * `"unknown"` is accepted, and that is the load-bearing part: receivers must
+ * tolerate a link to an action they never filed and annotate rather than
+ * refuse. A bot pre-checking its own move has no log at all — it passes
+ * `"unknown"` and gets the two rules a message decides on its own.
+ */
+export function checkRevival(
+  opens: boolean,
+  named: string,
+  predecessor: Predecessor,
+): RevivalResult {
+  if (!opens) return { ok: false, reason: "replaces-not-opener" };
+  if (!isEventId(named)) return { ok: false, reason: "replaces-malformed" };
+  if (predecessor === "live") return { ok: false, reason: "replaces-not-terminal" };
+  return { ok: true };
 }
 
 /**

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -192,6 +192,42 @@ describe("the bounty verbs", () => {
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
   });
 
+  it("carries a bid's terms as tags nothing interprets", async () => {
+    const sent: Sent[] = [];
+    await bid(ctxWith(sent), "01JTASK00000000000000000AA", {
+      amount: "250 USD",
+      payTo: "did:plc:worker",
+    });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act-bid"]).toBe("250 USD");
+    expect(tags["+freeq.at/act-pay-to"]).toBe("did:plc:worker");
+  });
+
+  it("carries a bounty's price and bid cutoff on the offer", async () => {
+    const sent: Sent[] = [];
+    await offer(ctxWith(sent), {
+      title: "index the archive",
+      kind: "bounty",
+      price: "250 USD",
+      bidDeadline: 1_788_000_000,
+      deadline: 1_788_600_000,
+    });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act-price"]).toBe("250 USD");
+    expect(tags["+freeq.at/act-bid-deadline"]).toBe("1788000000");
+    // Two different times, both on the offer.
+    expect(tags["+freeq.at/act-deadline"]).toBe("1788600000");
+  });
+
+  it("carries a payment reference on the acceptance, and none by default", async () => {
+    const sent: Sent[] = [];
+    await acceptWork(ctxWith(sent), "01JTASK00000000000000000AA", { tx: "eth:0xabc" });
+    expect(sent[0].tags["+freeq.at/act-tx"]).toBe("eth:0xabc");
+    const bare: Sent[] = [];
+    await acceptWork(ctxWith(bare), "01JTASK00000000000000000AA");
+    expect(bare[0].tags["+freeq.at/act-tx"]).toBeUndefined();
+  });
+
   it("hands the work in without saying it is done", async () => {
     const sent: Sent[] = [];
     await submit(ctxWith(sent), "01JTASK00000000000000000AA", { note: "branch pushed" });

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -176,14 +176,16 @@ describe("the bounty verbs", () => {
     expect(sent[0].taskId).toBe("01JTASK00000000000000000AA");
   });
 
-  it("awards the work to the winner it names, not to the poster naming them", async () => {
+  it("takes the bid it names, and names no DID at all", async () => {
     const sent: Sent[] = [];
-    await award(ctxWith(sent), "01JTASK00000000000000000AA", "did:plc:worker");
+    await award(ctxWith(sent), "01JTASK00000000000000000AA", "01JBID000000000000000000BB");
     const { tags } = sent[0];
     expect(tags["+freeq.at/act-verb"]).toBe("award");
-    expect(tags["+freeq.at/act-to"]).toBe("did:plc:worker");
+    expect(tags["+freeq.at/act-accepts"]).toBe("01JBID000000000000000000BB");
+    // The winner is the bid's author, so the award names no recipient of its
+    // own — two sources for one fact is what naming a DID here would be.
+    expect(tags["+freeq.at/act-to"]).toBeUndefined();
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
-    expect(sent[0].humanText).toContain("did:plc:worker");
   });
 
   it("carries the kind on a bounty's follow-ups too", async () => {

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -252,9 +252,57 @@ describe("the bounty verbs", () => {
     }
   });
 
-  it("carries the kind on a bounty's follow-ups too", async () => {
+  it("carries the kind on the steps both kinds share", async () => {
     const sent: Sent[] = [];
-    await complete(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
+    await progress(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
     expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
+  });
+
+  it("names the kind it was given on every step about the posting, and the task when given none", async () => {
+    for (const [move, past] of [
+      [accept, "accepted"],
+      [decline, "declined"],
+      [claim, "claimed"],
+      [complete, "completed"],
+      [fail, "failed"],
+    ] as const) {
+      const plain: Sent[] = [];
+      await move(ctxWith(plain), "01JTASK00000000000000000AA");
+      expect(plain[0].humanText, past).toBe(`${past} the task`);
+      const named: Sent[] = [];
+      await move(ctxWith(named), "01JTASK00000000000000000AA", { kind: "handoff" });
+      expect(named[0].humanText, past).toBe(`${past} the handoff`);
+    }
+  });
+
+  it("names the kind it was given when cancelling, and the task when given none", async () => {
+    const sent: Sent[] = [];
+    await cancel(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
+    expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
+    expect(sent[0].humanText).toBe("cancelled the bounty");
+    const plain: Sent[] = [];
+    await cancel(ctxWith(plain), "01JTASK00000000000000000AA");
+    expect(plain[0].humanText).toBe("cancelled the task");
+    const named: Sent[] = [];
+    await cancel(ctxWith(named), "01JTASK00000000000000000AA", { kind: "handoff" });
+    expect(named[0].humanText).toBe("cancelled the handoff");
+  });
+
+  it("says each bounty step the way the handoff steps are said", async () => {
+    const lines: [(...a: any[]) => Promise<string>, string][] = [
+      [bid, "bid on the bounty"],
+      [submit, "submitted the work"],
+      [revise, "asked for revisions"],
+      [acceptWork, "accepted the work"],
+      [forfeit, "forfeited the bounty"],
+    ];
+    for (const [move, line] of lines) {
+      const sent: Sent[] = [];
+      await move(ctxWith(sent), "01JTASK00000000000000000AA");
+      expect(sent[0].humanText, line).toBe(line);
+    }
+    const sent: Sent[] = [];
+    await award(ctxWith(sent), "01JTASK00000000000000000AA", "01JBID000000000000000000BB");
+    expect(sent[0].humanText).toBe("awarded the bounty");
   });
 });

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -60,7 +60,7 @@ describe("offer", () => {
   it("carries the optional fields only when given", async () => {
     const bare: Sent[] = [];
     await offer(ctxWith(bare), { title: "t" });
-    for (const k of ["act-caps", "act-deadline", "act-ctx", "act-ctx-h"]) {
+    for (const k of ["act-caps", "act-deadline", "act-ctx", "act-ctx-h", "act-replaces"]) {
       expect(bare[0].tags[`+freeq.at/${k}`]).toBeUndefined();
     }
     const full: Sent[] = [];
@@ -75,6 +75,19 @@ describe("offer", () => {
     expect(full[0].tags["+freeq.at/act-deadline"]).toBe("1788000000");
     expect(full[0].tags["+freeq.at/act-ctx"]).toBe("https://example/brief");
     expect(full[0].tags["+freeq.at/act-ctx-h"]).toBe("sha256:9f00");
+  });
+
+  /// The revival relation is an opener's, and it is the whole of what the
+  /// re-offer says about the action it replaces.
+  it("names the finished action it revives, when it revives one", async () => {
+    const sent: Sent[] = [];
+    await offer(ctxWith(sent), {
+      title: "review the deploy, again",
+      replaces: "01M16E7TC0ENDED00000000000",
+    });
+    expect(sent[0].tags["+freeq.at/act-replaces"]).toBe("01M16E7TC0ENDED00000000000");
+    // Still an opener: its own event id is the new action's id.
+    expect(sent[0].tags["+freeq.at/act-id"]).toBeUndefined();
   });
 });
 

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -195,7 +195,7 @@ describe("the bounty verbs", () => {
   it("carries a bid's terms as tags nothing interprets", async () => {
     const sent: Sent[] = [];
     await bid(ctxWith(sent), "01JTASK00000000000000000AA", {
-      amount: "250 USD",
+      price: "250 USD",
       payTo: "did:plc:worker",
     });
     const { tags } = sent[0];

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -5,7 +5,18 @@
 // a follow-up and never on an opener, and a companion line linked back.
 
 import { describe, expect, it } from "vitest";
-import { accept, cancel, claim, complete, decline, fail, offer, progress } from "./act-verbs.js";
+import {
+  accept,
+  award,
+  bid,
+  cancel,
+  claim,
+  complete,
+  decline,
+  fail,
+  offer,
+  progress,
+} from "./act-verbs.js";
 import type { ActContext } from "./act-verbs.js";
 
 interface Sent {
@@ -139,5 +150,45 @@ describe("what is not here", () => {
   it("has no expire helper: that move is the server's alone", async () => {
     const mod = await import("./act-verbs.js");
     expect(Object.keys(mod)).not.toContain("expire");
+  });
+});
+
+describe("the bounty verbs", () => {
+  it("opens a bounty with the same verb, under its own kind", async () => {
+    const sent: Sent[] = [];
+    await offer(ctxWith(sent), { title: "index the archive", kind: "bounty" });
+    expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
+    expect(sent[0].tags["+freeq.at/act-verb"]).toBe("offer");
+    // A bounty is open by construction: nothing here names a recipient.
+    expect(sent[0].tags["+freeq.at/act-to"]).toBeUndefined();
+  });
+
+  it("bids on the task it names, and moves nothing else", async () => {
+    const sent: Sent[] = [];
+    await bid(ctxWith(sent), "01JTASK00000000000000000AA", { note: "two days" });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act"]).toBe("bounty");
+    expect(tags["+freeq.at/act-verb"]).toBe("bid");
+    expect(tags["+freeq.at/act-id"]).toBe("01JTASK00000000000000000AA");
+    expect(tags["+freeq.at/act-note"]).toBe("two days");
+    // Pricing is the agents' to agree, so there is no tag for it.
+    expect(tags["+freeq.at/act-bid"]).toBeUndefined();
+    expect(sent[0].taskId).toBe("01JTASK00000000000000000AA");
+  });
+
+  it("awards the work to the winner it names, not to the poster naming them", async () => {
+    const sent: Sent[] = [];
+    await award(ctxWith(sent), "01JTASK00000000000000000AA", "did:plc:worker");
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act-verb"]).toBe("award");
+    expect(tags["+freeq.at/act-to"]).toBe("did:plc:worker");
+    expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
+    expect(sent[0].humanText).toContain("did:plc:worker");
+  });
+
+  it("carries the kind on a bounty's follow-ups too", async () => {
+    const sent: Sent[] = [];
+    await complete(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
+    expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
   });
 });

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, it } from "vitest";
 import {
   accept,
   award,
+  submit,
+  revise,
+  acceptWork,
+  forfeit,
   bid,
   cancel,
   claim,
@@ -186,6 +190,30 @@ describe("the bounty verbs", () => {
     // own — two sources for one fact is what naming a DID here would be.
     expect(tags["+freeq.at/act-to"]).toBeUndefined();
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
+  });
+
+  it("hands the work in without saying it is done", async () => {
+    const sent: Sent[] = [];
+    await submit(ctxWith(sent), "01JTASK00000000000000000AA", { note: "branch pushed" });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act"]).toBe("bounty");
+    expect(tags["+freeq.at/act-verb"]).toBe("submit");
+    expect(tags["+freeq.at/act-id"]).toBe("01JTASK00000000000000000AA");
+    expect(tags["+freeq.at/act-note"]).toBe("branch pushed");
+  });
+
+  it("sends the work back, accepts it, or walks away from it", async () => {
+    for (const [move, verb] of [
+      [revise, "revise"],
+      [acceptWork, "accept-work"],
+      [forfeit, "forfeit"],
+    ] as const) {
+      const sent: Sent[] = [];
+      await move(ctxWith(sent), "01JTASK00000000000000000AA");
+      expect(sent[0].tags["+freeq.at/act-verb"], verb).toBe(verb);
+      expect(sent[0].tags["+freeq.at/act"], verb).toBe("bounty");
+      expect(sent[0].taskId, verb).toBe("01JTASK00000000000000000AA");
+    }
   });
 
   it("carries the kind on a bounty's follow-ups too", async () => {

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -201,7 +201,7 @@ export interface BidOptions extends StepOptions {
   /** What you are asking for. Opaque to every server that handles it: stored,
    *  relayed, replayed, and covered by the signature because it is present,
    *  never because anything knows what it means. */
-  amount?: string;
+  price?: string;
   /** Where you want paying. Opaque in the same way. */
   payTo?: string;
 }
@@ -220,7 +220,7 @@ export async function bid(
   opts: BidOptions = {},
 ): Promise<string> {
   const tags = stepTags("bid", ctx.did, taskId, opts.note, BOUNTY);
-  if (opts.amount) tags["+freeq.at/act-bid"] = opts.amount;
+  if (opts.price) tags["+freeq.at/act-bid"] = opts.price;
   if (opts.payTo) tags["+freeq.at/act-pay-to"] = opts.payTo;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? (opts.note ? `bid: ${opts.note}` : "bid on the bounty"),

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -83,6 +83,11 @@ function stepTags(verb: string, did: string, taskId: string, note?: string, kind
   return tags;
 }
 
+/** What a step's default line calls the thing it acts on: the kind, or "task". */
+function named(kind?: string): string {
+  return kind ?? "task";
+}
+
 /**
  * Open a task. Returns its id — the offer's own event id *is* the task's id,
  * which is why an offer carries no `act-id` of its own.
@@ -120,7 +125,7 @@ export async function accept(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("accept", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "accepted the task",
+    humanText: opts.humanText ?? `accepted the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -132,7 +137,7 @@ export async function decline(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("decline", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "declined the task",
+    humanText: opts.humanText ?? `declined the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -144,7 +149,7 @@ export async function claim(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("claim", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "claimed the task",
+    humanText: opts.humanText ?? `claimed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -168,7 +173,7 @@ export async function complete(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("complete", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "completed the task",
+    humanText: opts.humanText ?? `completed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -183,7 +188,7 @@ export async function fail(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("fail", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "failed the task",
+    humanText: opts.humanText ?? `failed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -242,7 +247,7 @@ export async function award(
   const tags = stepTags("award", ctx.did, taskId, opts.note, BOUNTY);
   tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
-    humanText: opts.humanText ?? 'awarded the bounty',
+    humanText: opts.humanText ?? "awarded the bounty",
     taskId,
   });
 }
@@ -302,14 +307,10 @@ export async function acceptWork(
 ): Promise<string> {
   const tags = stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY);
   if (opts.tx) tags["+freeq.at/act-tx"] = opts.tx;
-  return ctx.client.sendAct(
-    ctx.target,
-    tags,
-    {
-      humanText: opts.humanText ?? "accepted the work",
-      taskId,
-    },
-  );
+  return ctx.client.sendAct(ctx.target, tags, {
+    humanText: opts.humanText ?? "accepted the work",
+    taskId,
+  });
 }
 
 /**
@@ -329,8 +330,10 @@ export async function forfeit(
 }
 
 /**
- * Withdraw a task you posted. The poster's unilateral act, legal from every
- * live state including mid-work — the worker gets the event, not a say.
+ * Withdraw a task you posted. The poster's unilateral act: on a handoff, legal
+ * from every live state including mid-work; on a bounty, only until the work
+ * is handed in — from there the poster's moves are to accept it or ask for
+ * revisions. Either way the worker gets the event, not a say.
  */
 export async function cancel(
   ctx: ActContext,
@@ -338,7 +341,7 @@ export async function cancel(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("cancel", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "cancelled the task",
+    humanText: opts.humanText ?? `cancelled the ${named(opts.kind)}`,
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -1,9 +1,9 @@
 // The moves a bot can make on a task.
 //
-// One function per verb the RFC gives a sender. `expire` is not here: only
-// the server may make that move, and it makes it from the sweep, and neither
-// is `confirm`: a receipt is the action's home writing about an event it
-// filed.
+// One function per verb the RFC gives a sender. `expire` and `auto-accept` are
+// not here: only the server may make those moves, and it makes them from the
+// sweep. Neither is `confirm`: a receipt is the action's home writing about an
+// event it filed.
 //
 // Every one does the same paired send — the signed task TAGMSG that *is* the
 // event, and the plain-text line that renders it for the people in the room,
@@ -219,6 +219,78 @@ export async function award(
   tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? 'awarded the bounty',
+    taskId,
+  });
+}
+
+/**
+ * Hand in the work on a bounty you hold. The bounty waits for the poster from
+ * here: nothing about a submission says the work is done, only that it is in.
+ */
+export async function submit(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("submit", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "submitted the work",
+    taskId,
+  });
+}
+
+/**
+ * Send submitted work back for another pass. The bounty is assigned again and
+ * the worker still holds it — asking for changes is the poster answering, so
+ * it also stops the review clock and starts a fresh one on the next
+ * submission.
+ */
+export async function revise(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("revise", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "asked for changes",
+    taskId,
+  });
+}
+
+/**
+ * Accept submitted work on a bounty you posted. Terminal, and the poster's
+ * word rather than the worker's — which is the whole difference between this
+ * kind and a handoff.
+ *
+ * A payment reference rides along as an ordinary act tag if there is one. The
+ * server stores and relays it and never reads it: what settled, and whether it
+ * settled, live above this.
+ */
+export async function acceptWork(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(
+    ctx.target,
+    stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY),
+    {
+      humanText: opts.humanText ?? "accepted the work",
+      taskId,
+    },
+  );
+}
+
+/**
+ * Give up a bounty you hold, before or after handing the work in. Terminal:
+ * re-listing it is a new bounty naming this one in `replaces`, because the
+ * machine only runs forward.
+ */
+export async function forfeit(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("forfeit", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "forfeited the bounty",
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -274,7 +274,7 @@ export async function revise(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("revise", ctx.did, taskId, opts.note, BOUNTY), {
-    humanText: opts.humanText ?? "asked for changes",
+    humanText: opts.humanText ?? "asked for revisions",
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -1,7 +1,9 @@
-// The eight moves a bot can make on a task.
+// The moves a bot can make on a task.
 //
 // One function per verb the RFC gives a sender. `expire` is not here: only
-// the server may make that move, and it makes it from the sweep.
+// the server may make that move, and it makes it from the sweep, and neither
+// is `confirm`: a receipt is the action's home writing about an event it
+// filed.
 //
 // Every one does the same paired send — the signed task TAGMSG that *is* the
 // event, and the plain-text line that renders it for the people in the room,
@@ -28,6 +30,9 @@ export interface ActContext {
 /** What an offer declares. Everything but a title is optional. */
 export interface OfferOptions {
   title: string;
+  /** The kind of task. `handoff` unless something says otherwise — a bounty
+   *  is opened by the same verb, and takes bids instead of a recipient. */
+  kind?: string;
   /** Name a recipient to make the offer directed; leave it out and anyone
    *  may claim it. */
   to?: string;
@@ -50,15 +55,19 @@ export interface OfferOptions {
 export interface StepOptions {
   /** A sentence for the record, covered by the signature like every act tag. */
   note?: string;
+  /** The kind of task this step is on. `handoff` unless something says
+   *  otherwise — a step names the kind it belongs to, the way its opener did. */
+  kind?: string;
   /** The line people see. */
   humanText?: string;
 }
 
+/** What a task is when nobody says otherwise. */
 const KIND = "handoff";
 
-function stepTags(verb: string, did: string, taskId: string, note?: string) {
+function stepTags(verb: string, did: string, taskId: string, note?: string, kind?: string) {
   const tags: Record<string, string> = {
-    "+freeq.at/act": KIND,
+    "+freeq.at/act": kind ?? KIND,
     "+freeq.at/act-verb": verb,
     "+freeq.at/from": did,
     "+freeq.at/act-id": taskId,
@@ -73,7 +82,7 @@ function stepTags(verb: string, did: string, taskId: string, note?: string) {
  */
 export async function offer(ctx: ActContext, opts: OfferOptions): Promise<string> {
   const tags: Record<string, string> = {
-    "+freeq.at/act": KIND,
+    "+freeq.at/act": opts.kind ?? KIND,
     "+freeq.at/act-verb": "offer",
     "+freeq.at/from": ctx.did,
     "+freeq.at/act-title": opts.title,
@@ -99,7 +108,7 @@ export async function accept(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("accept", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("accept", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "accepted the task",
     taskId,
   });
@@ -111,7 +120,7 @@ export async function decline(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("decline", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("decline", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "declined the task",
     taskId,
   });
@@ -123,7 +132,7 @@ export async function claim(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("claim", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("claim", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "claimed the task",
     taskId,
   });
@@ -135,7 +144,7 @@ export async function progress(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("progress", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("progress", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? (opts.note ? `progress: ${opts.note}` : "made progress"),
     taskId,
   });
@@ -147,7 +156,7 @@ export async function complete(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("complete", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("complete", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "completed the task",
     taskId,
   });
@@ -162,8 +171,52 @@ export async function fail(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("fail", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("fail", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "failed the task",
+    taskId,
+  });
+}
+
+/** The only kind that has bids to take and a winner to name. */
+const BOUNTY = "bounty";
+
+/**
+ * Put your name in for an open bounty. Additive: a bid leaves the bounty
+ * exactly where it found it, and every bid stays on file.
+ *
+ * A bid says nothing about price. `note` is freeform and signed like any act
+ * tag; pricing is the agents' to agree, not the substrate's to define.
+ */
+export async function bid(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  const tags = stepTags("bid", ctx.did, taskId, opts.note, BOUNTY);
+  return ctx.client.sendAct(ctx.target, tags, {
+    humanText: opts.humanText ?? (opts.note ? `bid: ${opts.note}` : "bid on the bounty"),
+    taskId,
+  });
+}
+
+/**
+ * Pick the winner of a bounty you posted, and assign the work to them.
+ *
+ * The poster names a winner rather than becoming one, which is why `act-to`
+ * is on the award and why the view reads the assignee from it. Nothing checks
+ * that the winner bid: the server never picks, and that cuts both ways — this
+ * signed choice is the record.
+ */
+export async function award(
+  ctx: ActContext,
+  taskId: string,
+  winnerDid: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  const tags = stepTags("award", ctx.did, taskId, opts.note, BOUNTY);
+  tags["+freeq.at/act-to"] = winnerDid;
+  return ctx.client.sendAct(ctx.target, tags, {
+    humanText: opts.humanText ?? `awarded the bounty to ${winnerDid}`,
     taskId,
   });
 }
@@ -177,7 +230,7 @@ export async function cancel(
   taskId: string,
   opts: StepOptions = {},
 ): Promise<string> {
-  return ctx.client.sendAct(ctx.target, stepTags("cancel", ctx.did, taskId, opts.note), {
+  return ctx.client.sendAct(ctx.target, stepTags("cancel", ctx.did, taskId, opts.note, opts.kind), {
     humanText: opts.humanText ?? "cancelled the task",
     taskId,
   });

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -14,6 +14,7 @@
 // message whose actor is not its sender.
 
 import type { FreeqClient } from "@freeq/sdk";
+import { REVIVAL_TAG } from "./act-transitions.js";
 
 /** What every task step needs: where it happens, and who is doing it. */
 export interface ActContext {
@@ -38,6 +39,9 @@ export interface OfferOptions {
   /** A link to the task's materials, and a hash of them. */
   ctx?: string;
   ctxHash?: string;
+  /** The finished action this one revives — a failed handoff re-offered, a
+   *  forfeited bounty re-listed. Legal only here, on the opener. */
+  replaces?: string;
   /** The line people see. Defaults to something plain. */
   humanText?: string;
 }
@@ -81,6 +85,9 @@ export async function offer(ctx: ActContext, opts: OfferOptions): Promise<string
   }
   if (opts.ctx) tags["+freeq.at/act-ctx"] = opts.ctx;
   if (opts.ctxHash) tags["+freeq.at/act-ctx-h"] = opts.ctxHash;
+  // Tagged only when there is something to revive: an absent relation and an
+  // empty one are different claims, and the signature covers whichever is here.
+  if (opts.replaces) tags[`+freeq.at/${REVIVAL_TAG}`] = opts.replaces;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? `offered: ${opts.title}`,
   });

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -200,23 +200,25 @@ export async function bid(
 }
 
 /**
- * Pick the winner of a bounty you posted, and assign the work to them.
+ * Take one of the bids on a bounty you posted, and assign the work to whoever
+ * wrote it.
  *
- * The poster names a winner rather than becoming one, which is why `act-to`
- * is on the award and why the view reads the assignee from it. Nothing checks
- * that the winner bid: the server never picks, and that cuts both ways — this
- * signed choice is the record.
+ * `bidEventId` is the bid's own event id, not the bidder's DID: a bounty's
+ * terms live in the bid, and bids are the one place several candidates sit
+ * side by side, so taking one means naming the exact event. The server checks
+ * only that the named event is a bid on this action — which of them is worth
+ * taking stays the poster's signed choice.
  */
 export async function award(
   ctx: ActContext,
   taskId: string,
-  winnerDid: string,
+  bidEventId: string,
   opts: StepOptions = {},
 ): Promise<string> {
   const tags = stepTags("award", ctx.did, taskId, opts.note, BOUNTY);
-  tags["+freeq.at/act-to"] = winnerDid;
+  tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
-    humanText: opts.humanText ?? `awarded the bounty to ${winnerDid}`,
+    humanText: opts.humanText ?? 'awarded the bounty',
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -41,6 +41,13 @@ export interface OfferOptions {
   /** Unix seconds. Bounds how long the offer stands — not how long the work
    *  may take. */
   deadline?: number;
+  /** Unix seconds. Bounds how long a bounty takes bids, which closes sooner
+   *  than the offer does. A second time on the same offer, compared the same
+   *  way. */
+  bidDeadline?: number;
+  /** What a bounty offers to pay. Opaque: stored, relayed, replayed, covered
+   *  by the signature because it is present, and never read by any server. */
+  price?: string;
   /** A link to the task's materials, and a hash of them. */
   ctx?: string;
   ctxHash?: string;
@@ -92,6 +99,10 @@ export async function offer(ctx: ActContext, opts: OfferOptions): Promise<string
   if (opts.deadline !== undefined) {
     tags["+freeq.at/act-deadline"] = String(opts.deadline);
   }
+  if (opts.bidDeadline !== undefined) {
+    tags["+freeq.at/act-bid-deadline"] = String(opts.bidDeadline);
+  }
+  if (opts.price) tags["+freeq.at/act-price"] = opts.price;
   if (opts.ctx) tags["+freeq.at/act-ctx"] = opts.ctx;
   if (opts.ctxHash) tags["+freeq.at/act-ctx-h"] = opts.ctxHash;
   // Tagged only when there is something to revive: an absent relation and an
@@ -180,19 +191,32 @@ export async function fail(
 /** The only kind that has bids to take and a winner to name. */
 const BOUNTY = "bounty";
 
+/** What a bid may say about terms, on top of what any step carries. */
+export interface BidOptions extends StepOptions {
+  /** What you are asking for. Opaque to every server that handles it: stored,
+   *  relayed, replayed, and covered by the signature because it is present,
+   *  never because anything knows what it means. */
+  amount?: string;
+  /** Where you want paying. Opaque in the same way. */
+  payTo?: string;
+}
+
 /**
  * Put your name in for an open bounty. Additive: a bid leaves the bounty
- * exactly where it found it, and every bid stays on file.
+ * exactly where it found it, and every bid stays on file — which is what lets
+ * an award name one of them.
  *
- * A bid says nothing about price. `note` is freeform and signed like any act
- * tag; pricing is the agents' to agree, not the substrate's to define.
+ * Terms ride as tags nobody interprets. What settled, and whether it settled,
+ * is the agents' to agree and never the substrate's to say.
  */
 export async function bid(
   ctx: ActContext,
   taskId: string,
-  opts: StepOptions = {},
+  opts: BidOptions = {},
 ): Promise<string> {
   const tags = stepTags("bid", ctx.did, taskId, opts.note, BOUNTY);
+  if (opts.amount) tags["+freeq.at/act-bid"] = opts.amount;
+  if (opts.payTo) tags["+freeq.at/act-pay-to"] = opts.payTo;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? (opts.note ? `bid: ${opts.note}` : "bid on the bounty"),
     taskId,
@@ -255,6 +279,13 @@ export async function revise(
   });
 }
 
+/** What an acceptance may carry, on top of what any step carries. */
+export interface AcceptWorkOptions extends StepOptions {
+  /** A payment reference. Opaque: a claim on the record that something was
+   *  paid, never a confirmation that it was. */
+  tx?: string;
+}
+
 /**
  * Accept submitted work on a bounty you posted. Terminal, and the poster's
  * word rather than the worker's — which is the whole difference between this
@@ -267,11 +298,13 @@ export async function revise(
 export async function acceptWork(
   ctx: ActContext,
   taskId: string,
-  opts: StepOptions = {},
+  opts: AcceptWorkOptions = {},
 ): Promise<string> {
+  const tags = stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY);
+  if (opts.tx) tags["+freeq.at/act-tx"] = opts.tx;
   return ctx.client.sendAct(
     ctx.target,
-    stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY),
+    tags,
     {
       humanText: opts.humanText ?? "accepted the work",
       taskId,

--- a/freeq-bot-kit-js/src/act.test.ts
+++ b/freeq-bot-kit-js/src/act.test.ts
@@ -35,10 +35,11 @@ interface Vector {
 
 /**
  * The named vector's own tags and signature, checked under conditions that
- * must produce the named verdict class. `invalid` negatives carry delivery
- * context the signer never wrote (and the canonical those bytes rebuild to);
- * `unverifiable` negatives describe a check that cannot run — a stripped
- * mandatory tag, an unknown algorithm — where no canonical exists to rebuild.
+ * must produce the named verdict class. `invalid` negatives carry a signed
+ * fact the signer never wrote — delivery context, or a rewritten tag — and the
+ * canonical those bytes rebuild to; `unverifiable` negatives describe a check
+ * that cannot run — a stripped mandatory tag, an unknown algorithm — where no
+ * canonical exists to rebuild.
  */
 interface Negative {
   name: string;
@@ -48,7 +49,16 @@ interface Negative {
   id: string;
   tamperedCanonical?: string;
   strippedTag?: string;
+  swappedTag?: { name: string; value: string };
   sigAlgorithm?: string;
+}
+
+/** The vector's tags as a negative presents them to a verifier. */
+function tagsFor(n: Negative, v: Vector): Record<string, string> {
+  const tags = { ...v.tags };
+  if (n.strippedTag !== undefined) delete tags[n.strippedTag];
+  if (n.swappedTag !== undefined) tags[n.swappedTag.name] = n.swappedTag.value;
+  return tags;
 }
 
 const fixtures: { vectors: Vector[]; negatives: Negative[] } = JSON.parse(
@@ -107,20 +117,30 @@ describe("act signing negatives (shared with Rust)", () => {
     if (n.expected === "invalid") {
       it(`${n.name}: rebuilds the tampered canonical byte-for-byte`, () => {
         expect(v).toBeDefined();
-        expect(actCanonical(v.tags, n.target, n.id)).toBe(n.tamperedCanonical);
+        expect(actCanonical(tagsFor(n, v), n.target, n.id)).toBe(n.tamperedCanonical);
       });
 
       it(`${n.name}: the vector's own signature reads invalid`, async () => {
         expect(
-          await verifyActTags(v.tags, n.target, n.id, v.sigTag, b64urlDecode(v.publicKey)),
+          await verifyActTags(
+            tagsFor(n, v),
+            n.target,
+            n.id,
+            v.sigTag,
+            b64urlDecode(v.publicKey),
+          ),
         ).toEqual({ ok: false, reason: "sig-invalid" });
       });
     } else if (n.strippedTag !== undefined) {
       it(`${n.name}: a stripped mandatory tag reads unverifiable, never invalid`, async () => {
-        const tags = { ...v.tags };
-        delete tags[n.strippedTag!];
         expect(
-          await verifyActTags(tags, n.target, n.id, v.sigTag, b64urlDecode(v.publicKey)),
+          await verifyActTags(
+            tagsFor(n, v),
+            n.target,
+            n.id,
+            v.sigTag,
+            b64urlDecode(v.publicKey),
+          ),
         ).toEqual({ ok: false, reason: "missing-from" });
       });
     } else if (n.sigAlgorithm !== undefined) {

--- a/freeq-bot-kit-js/src/index.ts
+++ b/freeq-bot-kit-js/src/index.ts
@@ -86,7 +86,13 @@ export {
   acceptWork,
   forfeit,
 } from "./act-verbs.js";
-export type { ActContext, OfferOptions, StepOptions } from "./act-verbs.js";
+export type {
+  ActContext,
+  OfferOptions,
+  StepOptions,
+  BidOptions,
+  AcceptWorkOptions,
+} from "./act-verbs.js";
 
 // The task lifecycle rules — which move is legal, from which state, by whom.
 // The rules are data (spec/act-transitions.json, copied into src/); this is

--- a/freeq-bot-kit-js/src/index.ts
+++ b/freeq-bot-kit-js/src/index.ts
@@ -66,9 +66,10 @@ export {
 } from "./act.js";
 export type { ActVerifyResult } from "./act.js";
 
-// The eight moves a bot can make on a task — one function per verb, each
-// doing the paired send (the signed task event, plus the line people read).
-// `expire` is absent on purpose: only the server makes that move.
+// The moves a bot can make on a task — one function per verb, each doing the
+// paired send (the signed task event, plus the line people read). A handoff's
+// first, then the ones only a bounty has. `expire` and `auto-accept` are
+// absent on purpose: only the server makes those moves.
 export {
   offer,
   accept,
@@ -78,6 +79,12 @@ export {
   complete,
   fail,
   cancel,
+  bid,
+  award,
+  submit,
+  revise,
+  acceptWork,
+  forfeit,
 } from "./act-verbs.js";
 export type { ActContext, OfferOptions, StepOptions } from "./act-verbs.js";
 

--- a/freeq-eliza/src/tts.rs
+++ b/freeq-eliza/src/tts.rs
@@ -151,8 +151,10 @@ pub async fn synthesize(
 /// Decode raw 16-bit signed little-endian PCM into f32 `[-1, 1]`. A
 /// trailing odd byte (shouldn't happen for valid PCM) is ignored.
 pub(crate) fn decode_pcm_s16le(data: &[u8]) -> Vec<f32> {
-    data.chunks_exact(2)
-        .map(|b| i16::from_le_bytes([b[0], b[1]]) as f32 / 32768.0)
+    let (samples, _) = data.as_chunks::<2>();
+    samples
+        .iter()
+        .map(|b| i16::from_le_bytes(*b) as f32 / 32768.0)
         .collect()
 }
 

--- a/freeq-eliza/src/video_ascii.rs
+++ b/freeq-eliza/src/video_ascii.rs
@@ -85,7 +85,8 @@ impl GlyphAtlas {
             // glyph's coverage.
             let data = pixmap.data();
             let mut mask = Vec::with_capacity((CELL_W * CELL_H) as usize);
-            for px in data.chunks_exact(4) {
+            let (px4, _) = data.as_chunks::<4>();
+            for px in px4 {
                 mask.push(px[3]);
             }
             masks.push(mask);
@@ -162,7 +163,8 @@ impl AsciiRenderer {
 
         let mut buf = vec![0u8; (VIDEO_W * VIDEO_H * 4) as usize];
         // Opaque black background.
-        for px in buf.chunks_exact_mut(4) {
+        let (px4, _) = buf.as_chunks_mut::<4>();
+        for px in px4 {
             px[3] = 255;
         }
 
@@ -404,7 +406,8 @@ impl AsciiRainRenderer {
         };
 
         let mut buf = vec![0u8; (VIDEO_W * VIDEO_H * 4) as usize];
-        for px in buf.chunks_exact_mut(4) {
+        let (px4, _) = buf.as_chunks_mut::<4>();
+        for px in px4 {
             px[3] = 255;
         }
 
@@ -583,7 +586,8 @@ impl AsciiGlitchRenderer {
         let chan = (2.0 + 12.0 * g) as i32; // chromatic split, px
 
         let mut buf = vec![0u8; (VIDEO_W * VIDEO_H * 4) as usize];
-        for px in buf.chunks_exact_mut(4) {
+        let (px4, _) = buf.as_chunks_mut::<4>();
+        for px in px4 {
             px[3] = 255;
         }
 
@@ -768,7 +772,8 @@ impl AsciiBotRenderer {
         };
 
         let mut buf = vec![0u8; (VIDEO_W * VIDEO_H * 4) as usize];
-        for px in buf.chunks_exact_mut(4) {
+        let (px4, _) = buf.as_chunks_mut::<4>();
+        for px in px4 {
             px[3] = 255;
         }
 

--- a/freeq-sdk-js/src/act-signing.vectors.test.ts
+++ b/freeq-sdk-js/src/act-signing.vectors.test.ts
@@ -16,9 +16,26 @@ interface Vector {
   canonical: string;
 }
 
+interface Negative {
+  vector: string;
+  target: string;
+  id: string;
+  tamperedCanonical?: string;
+  strippedTag?: string;
+  swappedTag?: { name: string; value: string };
+}
+
 const spec = JSON.parse(
   readFileSync(join(__dirname, '../../spec/act-signing-vectors.json'), 'utf8'),
-) as { vectors: Vector[]; negatives: { vector: string; target: string; id: string; tamperedCanonical: string }[] };
+) as { vectors: Vector[]; negatives: Negative[] };
+
+/** The vector's tags as a negative presents them to a verifier. */
+function tagsFor(n: Negative, v: Vector): Record<string, string> {
+  const tags = { ...v.tags };
+  if (n.strippedTag !== undefined) delete tags[n.strippedTag];
+  if (n.swappedTag !== undefined) tags[n.swappedTag.name] = n.swappedTag.value;
+  return tags;
+}
 
 describe('act canonical', () => {
   for (const v of spec.vectors) {
@@ -31,9 +48,9 @@ describe('act canonical', () => {
   // algorithm) have no canonical to rebuild; this suite has no verifier, so
   // only the tamper-class negatives are byte-checked here.
   for (const n of spec.negatives.filter((x) => x.tamperedCanonical !== undefined)) {
-    it(`rebuilds ${n.vector} under other delivery context: ${n.tamperedCanonical!.length} bytes`, () => {
+    it(`rebuilds tampered ${n.vector}: ${n.tamperedCanonical!.length} bytes`, () => {
       const v = spec.vectors.find((x) => x.name === n.vector)!;
-      expect(actCanonical(v.tags, n.target, n.id)).toBe(n.tamperedCanonical);
+      expect(actCanonical(tagsFor(n, v), n.target, n.id)).toBe(n.tamperedCanonical);
     });
   }
 

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -773,9 +773,11 @@ mod tests {
                 id: "01KDEF0000000000000000000K",
             },
             Case {
-                // A bid on a bounty. Additive and unremarkable to the
-                // canonical, which is the point: a second kind needed a row
-                // in the transitions file and nothing at all here.
+                // A bid on a bounty, with terms. Additive and unremarkable
+                // to the canonical, which is the point: a second kind needed
+                // a row in the transitions file and nothing at all here, and
+                // its money tags are covered because they are present rather
+                // than because anything knows what they mean.
                 name: "bounty-bid",
                 seed: 7,
                 tags: vec![
@@ -783,6 +785,12 @@ mod tests {
                     ("+freeq.at/act-verb", "bid"),
                     ("+freeq.at/from", "did:plc:scholar"),
                     ("+freeq.at/act-id", BOUNTY_ID),
+                    // What the bidder asks and where they want it paid.
+                    // Opaque to every server that handles them — the point of
+                    // the vector is that two signers agree on bytes neither of
+                    // them interprets.
+                    ("+freeq.at/act-bid", "250 USD"),
+                    ("+freeq.at/act-pay-to", "did:plc:scholar"),
                     ("+freeq.at/act-note", "two days, sources included"),
                 ],
                 target: "#swarm",

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -765,6 +765,24 @@ mod tests {
                 id: "01KDEF0000000000000000000K",
             },
             Case {
+                // The home's receipt for the accept below: same document as
+                // any other event, signed under the server's own DID, naming
+                // the confirmed event in `act-subject`. Nothing about the
+                // canonical is special — the sweep covers the new tag by
+                // name, which is the whole point of covering by prefix.
+                name: "receipt-confirming-an-accept",
+                seed: 5,
+                tags: vec![
+                    ("+freeq.at/act", "handoff"),
+                    ("+freeq.at/act-verb", "confirm"),
+                    ("+freeq.at/from", "did:web:irc.example"),
+                    ("+freeq.at/act-id", OFFER_ID),
+                    ("+freeq.at/act-subject", "01JACCEPTEVENTID0000000000"),
+                ],
+                target: OFFER_VENUE,
+                id: "01JCONFIRMEVENTID000000000",
+            },
+            Case {
                 // A follow-up: it names the task it is about in `act-id` —
                 // the offer's event id — and mints its own id for itself.
                 name: "accept-minimal-with-escaping",
@@ -795,10 +813,26 @@ mod tests {
         expected: &'static str,
         target: &'static str,
         id: &'static str,
-        /// Strip this wire tag before verifying (missing-mandatory case).
+        /// Strip this wire tag before verifying.
         strip_tag: Option<&'static str>,
+        /// Rewrite this wire tag's value before verifying (tamper case).
+        swap_tag: Option<(&'static str, &'static str)>,
         /// Replace the sig tag's algorithm label (unknown-algorithm case).
         swap_alg: Option<&'static str>,
+    }
+
+    impl Negative {
+        /// The vector's tags as this negative presents them to a verifier.
+        fn tags_of(&self, case: &Case) -> Vec<(&'static str, &'static str)> {
+            case.tags
+                .iter()
+                .filter(|(name, _)| self.strip_tag != Some(*name))
+                .map(|(name, value)| match self.swap_tag {
+                    Some((swapped, to)) if swapped == *name => (*name, to),
+                    _ => (*name, *value),
+                })
+                .collect()
+        }
     }
 
     fn negatives() -> Vec<Negative> {
@@ -810,6 +844,7 @@ mod tests {
                 target: "#random",
                 id: OFFER_ID,
                 strip_tag: None,
+                swap_tag: None,
                 swap_alg: None,
             },
             Negative {
@@ -819,6 +854,21 @@ mod tests {
                 target: OFFER_VENUE,
                 id: "01JOTHEREVENTID00000000000",
                 strip_tag: None,
+                swap_tag: None,
+                swap_alg: None,
+            },
+            Negative {
+                // A receipt re-pointed at another event. The subject is the
+                // whole content of a receipt — "the home confirms *this*" —
+                // so rewriting it must read as tampering, not as a new fact.
+                // The sweep covers act-subject by name, like every act tag.
+                name: "receipt-with-a-swapped-subject",
+                of: "receipt-confirming-an-accept",
+                expected: "invalid",
+                target: OFFER_VENUE,
+                id: "01JCONFIRMEVENTID000000000",
+                strip_tag: None,
+                swap_tag: Some(("+freeq.at/act-subject", "01JOTHEREVENTID00000000000")),
                 swap_alg: None,
             },
             Negative {
@@ -831,6 +881,7 @@ mod tests {
                 target: OFFER_VENUE,
                 id: OFFER_ID,
                 strip_tag: Some("+freeq.at/from"),
+                swap_tag: None,
                 swap_alg: None,
             },
             Negative {
@@ -843,6 +894,7 @@ mod tests {
                 target: OFFER_VENUE,
                 id: OFFER_ID,
                 strip_tag: None,
+                swap_tag: None,
                 swap_alg: Some("rsa4096"),
             },
         ]
@@ -894,15 +946,21 @@ mod tests {
                 });
                 if let Some(tag) = n.strip_tag {
                     entry["strippedTag"] = serde_json::Value::String(tag.to_string());
-                } else if let Some(alg) = n.swap_alg {
+                }
+                if let Some((tag, to)) = n.swap_tag {
+                    entry["swappedTag"] = serde_json::json!({ "name": tag, "value": to });
+                }
+                if let Some(alg) = n.swap_alg {
                     entry["sigAlgorithm"] = serde_json::Value::String(alg.to_string());
-                } else {
-                    // Tamper-class negatives rebuild a real canonical under
-                    // the wrong delivery context; the byte-level suites
-                    // reproduce it. Unverifiable-class negatives have no
-                    // canonical to rebuild — that is what unverifiable means.
+                }
+                // Tamper-class negatives rebuild a real canonical — under the
+                // wrong delivery context, or over a rewritten tag — and the
+                // byte-level suites reproduce it. Unverifiable-class negatives
+                // have no canonical to rebuild; that is what unverifiable
+                // means.
+                if n.expected == "invalid" {
                     entry["tamperedCanonical"] = serde_json::Value::String(
-                        act_canonical(case.tags, n.target, n.id).unwrap(),
+                        act_canonical(n.tags_of(&case), n.target, n.id).unwrap(),
                     );
                 }
                 entry
@@ -916,6 +974,7 @@ mod tests {
             "venueRule": "target is the normalized venue, never the wire target: a channel lowercased, or `dm:<did_a>,<did_b>` with the two DIDs sorted ascending.",
             "eventIdRule": "An offer carries no act-id: its own event id is the task's id. Every later event in a task's life names that id in act-id, and mints its own id for itself.",
             "senderOnlyTagRule": "Only the sender ever writes act-* tags. A server that stamped one of its own would land inside the signature's coverage and break every act signature it relayed.",
+            "negativeRule": "A negative names a vector and the conditions to check it under. `strippedTag` removes a wire tag and `swappedTag` rewrites one before verifying; `sigAlgorithm` relabels the signature's algorithm; `target` and `id` are the delivery context to rebuild from. Every `invalid` negative also carries the canonical those conditions rebuild to, so a byte-level suite with no verifier can still check it; an `unverifiable` one carries none, because having no canonical to rebuild is what unverifiable means.",
             "kidRule": "base64url-nopad(sha256(raw 32-byte ed25519 public key)[0..16])",
             "sigTagFormat": "ed25519:<kid>:<base64url-nopad signature over the UTF-8 canonical bytes>",
             "vectors": vectors,
@@ -971,11 +1030,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("negative {} names unknown vector {}", n.name, n.of));
             let key = test_key(case.seed);
             let real_sig = sign_act(case.tags.clone(), case.target, case.id, &key).unwrap();
-            let tags: Vec<_> = case
-                .tags
-                .into_iter()
-                .filter(|(name, _)| n.strip_tag != Some(*name))
-                .collect();
+            let tags = n.tags_of(&case);
             let sig_tag = match n.swap_alg {
                 Some(alg) => {
                     let rest = real_sig.split_once(':').expect("alg:kid:sig").1;

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -287,6 +287,10 @@ mod tests {
     /// event id, exactly as a handoff's is.
     const BOUNTY_ID: &str = "01JBOUNTYEVENTID00000000B";
 
+    /// The bid on it, and so the value the award names in `act-accepts`: an
+    /// award takes an event, not a DID.
+    const BID_ID: &str = "01JBIDEVENTID00000000000B";
+
     /// The RFC's directed-offer example, as a wire tag map (plus tags that
     /// must NOT be covered as tags: sig, eventid, msgid, actor-class).
     fn offer_tags() -> Vec<(&'static str, &'static str)> {
@@ -782,13 +786,13 @@ mod tests {
                     ("+freeq.at/act-note", "two days, sources included"),
                 ],
                 target: "#swarm",
-                id: "01JBIDEVENTID00000000000B",
+                id: BID_ID,
             },
             Case {
-                // The award: the poster names a winner in act-to, and the
-                // view reads the assignee from that field rather than from
-                // the actor. Both are covered by the signature, so neither
-                // can be re-pointed in transit.
+                // The award: the poster takes one bid by naming its event id,
+                // and the view reads the assignee from that bid's author
+                // rather than from the actor. The pointer is covered by the
+                // signature, so it cannot be re-pointed in transit.
                 name: "bounty-award",
                 seed: 8,
                 tags: vec![
@@ -796,7 +800,7 @@ mod tests {
                     ("+freeq.at/act-verb", "award"),
                     ("+freeq.at/from", "did:plc:eliza"),
                     ("+freeq.at/act-id", BOUNTY_ID),
-                    ("+freeq.at/act-to", "did:plc:scholar"),
+                    ("+freeq.at/act-accepts", BID_ID),
                 ],
                 target: "#swarm",
                 id: "01JAWARDEVENTID000000000A",
@@ -926,16 +930,16 @@ mod tests {
                 swap_alg: None,
             },
             Negative {
-                // An award with its winner stripped. Unlike a missing
-                // envelope field this is strip-*detectable*: act-to is an act
-                // tag, so the sweep covered it and the document rebuilds
+                // An award with the bid it takes stripped. Unlike a missing
+                // envelope field this is strip-*detectable*: act-accepts is an
+                // act tag, so the sweep covered it and the document rebuilds
                 // without it into bytes the signature contradicts.
-                name: "award-with-its-winner-stripped",
+                name: "award-with-its-bid-stripped",
                 of: "bounty-award",
                 expected: "invalid",
                 target: "#swarm",
                 id: "01JAWARDEVENTID000000000A",
-                strip_tag: Some("+freeq.at/act-to"),
+                strip_tag: Some("+freeq.at/act-accepts"),
                 swap_tag: None,
                 swap_alg: None,
             },

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -765,6 +765,23 @@ mod tests {
                 id: "01KDEF0000000000000000000K",
             },
             Case {
+                // A re-offer naming the finished handoff it revives. Another
+                // tag the sweep covers by name and nothing else has to know
+                // about: the relation is signed because it is present, which
+                // is what stops a relay quietly re-pointing it.
+                name: "re-offer-replacing-a-failed-handoff",
+                seed: 6,
+                tags: vec![
+                    ("+freeq.at/act", "handoff"),
+                    ("+freeq.at/act-verb", "offer"),
+                    ("+freeq.at/from", "did:plc:eliza"),
+                    ("+freeq.at/act-title", "Cite 3 sources on X"),
+                    ("+freeq.at/act-replaces", OFFER_ID),
+                ],
+                target: OFFER_VENUE,
+                id: "01JREOFFEREVENTID000000000",
+            },
+            Case {
                 // The home's receipt for the accept below: same document as
                 // any other event, signed under the server's own DID, naming
                 // the confirmed event in `act-subject`. Nothing about the

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -283,6 +283,10 @@ mod tests {
     const OFFER_VENUE: &str = "#ops";
     const OFFER_ID: &str = "01JABCDEF000000000000000EF";
 
+    /// The bounty the bid and award vectors below are about — its opener's own
+    /// event id, exactly as a handoff's is.
+    const BOUNTY_ID: &str = "01JBOUNTYEVENTID00000000B";
+
     /// The RFC's directed-offer example, as a wire tag map (plus tags that
     /// must NOT be covered as tags: sig, eventid, msgid, actor-class).
     fn offer_tags() -> Vec<(&'static str, &'static str)> {
@@ -765,6 +769,39 @@ mod tests {
                 id: "01KDEF0000000000000000000K",
             },
             Case {
+                // A bid on a bounty. Additive and unremarkable to the
+                // canonical, which is the point: a second kind needed a row
+                // in the transitions file and nothing at all here.
+                name: "bounty-bid",
+                seed: 7,
+                tags: vec![
+                    ("+freeq.at/act", "bounty"),
+                    ("+freeq.at/act-verb", "bid"),
+                    ("+freeq.at/from", "did:plc:scholar"),
+                    ("+freeq.at/act-id", BOUNTY_ID),
+                    ("+freeq.at/act-note", "two days, sources included"),
+                ],
+                target: "#swarm",
+                id: "01JBIDEVENTID00000000000B",
+            },
+            Case {
+                // The award: the poster names a winner in act-to, and the
+                // view reads the assignee from that field rather than from
+                // the actor. Both are covered by the signature, so neither
+                // can be re-pointed in transit.
+                name: "bounty-award",
+                seed: 8,
+                tags: vec![
+                    ("+freeq.at/act", "bounty"),
+                    ("+freeq.at/act-verb", "award"),
+                    ("+freeq.at/from", "did:plc:eliza"),
+                    ("+freeq.at/act-id", BOUNTY_ID),
+                    ("+freeq.at/act-to", "did:plc:scholar"),
+                ],
+                target: "#swarm",
+                id: "01JAWARDEVENTID000000000A",
+            },
+            Case {
                 // A re-offer naming the finished handoff it revives. Another
                 // tag the sweep covers by name and nothing else has to know
                 // about: the relation is signed because it is present, which
@@ -886,6 +923,20 @@ mod tests {
                 id: "01JCONFIRMEVENTID000000000",
                 strip_tag: None,
                 swap_tag: Some(("+freeq.at/act-subject", "01JOTHEREVENTID00000000000")),
+                swap_alg: None,
+            },
+            Negative {
+                // An award with its winner stripped. Unlike a missing
+                // envelope field this is strip-*detectable*: act-to is an act
+                // tag, so the sweep covered it and the document rebuilds
+                // without it into bytes the signature contradicts.
+                name: "award-with-its-winner-stripped",
+                of: "bounty-award",
+                expected: "invalid",
+                target: "#swarm",
+                id: "01JAWARDEVENTID000000000A",
+                strip_tag: Some("+freeq.at/act-to"),
+                swap_tag: None,
                 swap_alg: None,
             },
             Negative {

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -160,7 +160,7 @@ pub struct Event<'a> {
 /// The bid an award named, as the caller's log answered for it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AcceptedBid<'a> {
-    /// Who wrote the bid. The assignee an award's `bid-author` row lands on.
+    /// Who wrote the bid. The assignee an award's `author_of` row lands on.
     pub author: &'a str,
 }
 
@@ -323,16 +323,22 @@ pub enum AssigneeSource {
     Actor,
     /// The act field named here, read off the event.
     Field(&'static str),
-    /// Whoever wrote the bid the event names in `act-accepts`: a bounty's
-    /// `award` takes one bid, and the terms live in it, so the poster names
-    /// the event rather than a DID. Resolving it is the caller's — this
+    /// The author of the event named in this act field: a bounty's `award`
+    /// takes one bid, and the terms live in it, so the poster names the event
+    /// in `act-accepts` rather than a DID. Resolving it is the caller's — this
     /// checker reads no log — and the answer arrives as
     /// [`Sender::accepted_bid`].
-    BidAuthor,
+    AuthorOf(&'static str),
 }
 
-/// The `assignee_from` value that means [`AssigneeSource::BidAuthor`].
-const BID_AUTHOR: &str = "bid-author";
+/// How a row spells `assignee_from`: a tag holding a DID, or the author of
+/// the event a tag names.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(untagged)]
+enum AssigneeFrom {
+    Field(String),
+    AuthorOf { author_of: String },
+}
 
 /// The verb the event an award names must carry.
 ///
@@ -381,10 +387,10 @@ pub fn assignee_source(kind: &str, verb: &str, from_state: &str) -> AssigneeSour
     k.transitions
         .iter()
         .find(|t| t.verb == verb && t.from.matches(from_state, k))
-        .and_then(|t| t.assignee_from.as_deref())
-        .map_or(AssigneeSource::Actor, |name| match name {
-            BID_AUTHOR => AssigneeSource::BidAuthor,
-            field => AssigneeSource::Field(field),
+        .and_then(|t| t.assignee_from.as_ref())
+        .map_or(AssigneeSource::Actor, |from| match from {
+            AssigneeFrom::Field(field) => AssigneeSource::Field(field),
+            AssigneeFrom::AuthorOf { author_of } => AssigneeSource::AuthorOf(author_of),
         })
 }
 
@@ -487,7 +493,7 @@ pub fn check(
     // here reads a log — and a name that found nothing named something that
     // is not a bid on this action. Alongside the requirement above for the
     // same reason: an award that takes no bid is malformed for everybody.
-    if row.assignee_from.as_deref() == Some(BID_AUTHOR)
+    if matches!(row.assignee_from, Some(AssigneeFrom::AuthorOf { .. }))
         && (event.accepts.is_none() || sender.accepted_bid.is_none())
     {
         return Err(Refusal::AcceptsNotABid);
@@ -594,9 +600,11 @@ struct Transition {
     /// code.
     #[serde(default)]
     before_bid_deadline: bool,
-    /// The field naming who this transition assigns. Absent = the actor.
+    /// Who this transition assigns. Absent = the actor; a tag name = the DID
+    /// in that tag; `{ "author_of": tag }` = the author of the event that tag
+    /// names.
     #[serde(default)]
-    assignee_from: Option<String>,
+    assignee_from: Option<AssigneeFrom>,
     /// Fields the transition is illegal without. Empty for almost every row,
     /// which is why an absent one has to change nothing.
     #[serde(default)]
@@ -1070,7 +1078,7 @@ mod tests {
     fn a_transition_says_where_its_assignee_comes_from() {
         assert_eq!(
             assignee_source("bounty", "award", "open"),
-            AssigneeSource::BidAuthor
+            AssigneeSource::AuthorOf("act-accepts")
         );
         for (kind, verb, from) in [
             ("handoff", "accept", "offered"),
@@ -1791,7 +1799,7 @@ mod tests {
                         assignee = Some(
                             match assignee_source(&seq.task.kind, &step.verb, &state) {
                                 AssigneeSource::Actor => step.sender.clone(),
-                                AssigneeSource::BidAuthor => step
+                                AssigneeSource::AuthorOf(_) => step
                                     .accepted_bid
                                     .clone()
                                     .unwrap_or_else(|| panic!("{where_}: this transition assigns the author of the bid it names, and none was resolved")),

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -66,6 +66,11 @@ pub enum Refusal {
     ReplacesMalformed,
     /// The action a revival names is on file and has not finished.
     ReplacesNotTerminal,
+    /// The transition requires a field the event does not carry, named here so
+    /// the sender is told which one. The name comes from the rules file, which
+    /// outlives every event — so carrying it costs nothing and saves a round
+    /// of guessing.
+    MissingRequirement(&'static str),
 }
 
 impl Refusal {
@@ -83,6 +88,7 @@ impl Refusal {
             Refusal::ReplacesNotOpener => "replaces-not-opener",
             Refusal::ReplacesMalformed => "replaces-malformed",
             Refusal::ReplacesNotTerminal => "replaces-not-terminal",
+            Refusal::MissingRequirement(_) => "missing-requirement",
         }
     }
 
@@ -130,6 +136,12 @@ pub struct Event<'a> {
     /// deadline is measured against — every verifier then compares the same
     /// number instead of its own wall clock.
     pub msgid: &'a str,
+    /// The act fields the event carries, by their document names (`act-to`,
+    /// `act-note`, …). Presence only: what a transition's `requires` is
+    /// checked against. Values are the caller's business — the one place this
+    /// checker points at a value is [`assignee_source`], which names the field
+    /// rather than reading it.
+    pub fields: &'a [&'a str],
 }
 
 /// Who sent it.
@@ -274,6 +286,34 @@ pub fn check_open(
     }
 }
 
+/// Who a transition assigns the work to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssigneeSource {
+    /// Whoever took the step — what `accept` and `claim` already mean.
+    Actor,
+    /// The act field named here, read off the event: a bounty's `award` names
+    /// its winner in `act-to`, because the poster picks rather than becomes.
+    Field(&'static str),
+}
+
+/// Where the assignee comes from when `verb` moves a `kind` task out of
+/// `from_state`.
+///
+/// Data, not code: a kind that assigns someone other than the actor says so in
+/// its row, and the view materializes it the same way for every kind. A verb
+/// with no row here answers `Actor`, which changes nothing for a transition
+/// that assigns nobody.
+pub fn assignee_source(kind: &str, verb: &str, from_state: &str) -> AssigneeSource {
+    let Some(k) = spec().kinds.get(kind) else {
+        return AssigneeSource::Actor;
+    };
+    k.transitions
+        .iter()
+        .find(|t| t.verb == verb && t.from.matches(from_state, k))
+        .and_then(|t| t.assignee_from.as_deref())
+        .map_or(AssigneeSource::Actor, AssigneeSource::Field)
+}
+
 /// Whether the rules file lists this kind at all.
 ///
 /// The question a server asks before anything else about a task event: a kind
@@ -355,6 +395,18 @@ pub fn check(
         .into_iter()
         .find(|t| t.from.matches(task.state, kind))
         .ok_or(Refusal::IllegalStep)?;
+
+    // What the move needs to be the move at all. Before authority for the
+    // same reason the state is: an award that names no winner is malformed
+    // for everybody, and "not you" would send the sender after the wrong
+    // problem.
+    if let Some(missing) = row
+        .requires
+        .iter()
+        .find(|f| !event.fields.contains(&f.as_str()))
+    {
+        return Err(Refusal::MissingRequirement(missing.as_str()));
+    }
 
     // Authority second: who the sender is only matters once the move itself
     // makes sense.
@@ -442,6 +494,13 @@ struct Transition {
     who: String,
     #[serde(default)]
     before_deadline: bool,
+    /// The field naming who this transition assigns. Absent = the actor.
+    #[serde(default)]
+    assignee_from: Option<String>,
+    /// Fields the transition is illegal without. Empty for almost every row,
+    /// which is why an absent one has to change nothing.
+    #[serde(default)]
+    requires: Vec<String>,
 }
 
 /// A transition's `from`: one state, several, or every non-terminal one.
@@ -504,7 +563,11 @@ mod tests {
     }
 
     fn ev(verb: &'static str) -> Event<'static> {
-        Event { verb, msgid: NOW }
+        Event {
+            verb,
+            msgid: NOW,
+            fields: &[],
+        }
     }
 
     fn who(did: &'static str) -> Sender<'static> {
@@ -520,7 +583,11 @@ mod tests {
     fn a_kind_names_its_two_initial_states() {
         assert_eq!(initial_state("handoff", true), Some("offered"));
         assert_eq!(initial_state("handoff", false), Some("open"));
-        assert_eq!(initial_state("bounty", false), None, "not a listed kind");
+        assert_eq!(initial_state("approval", false), None, "not a listed kind");
+        // A bounty opens to the room and nowhere else: it has no directed
+        // form, because a directed bounty is just a handoff.
+        assert_eq!(initial_state("bounty", false), Some("open"));
+        assert_eq!(initial_state("bounty", true), None);
     }
 
     // ── opening a task ──────────────────────────────────────────────────────
@@ -580,10 +647,23 @@ mod tests {
     #[test]
     fn opening_a_kind_the_file_does_not_list_is_refused() {
         assert_eq!(
-            check_open("bounty", "offer", false, false),
+            check_open("approval", "offer", false, false),
             Err(Refusal::UnknownKind)
         );
-        assert_eq!(opening_verb("bounty"), None);
+        assert_eq!(opening_verb("approval"), None);
+    }
+
+    /// A kind with no directed form cannot be opened to one recipient. The
+    /// answer is illegal-step and not unknown-verb: `offer` is exactly the
+    /// verb that opens a bounty, and naming a recipient is the part it cannot
+    /// do.
+    #[test]
+    fn a_bounty_cannot_be_opened_to_one_recipient() {
+        assert_eq!(check_open("bounty", "offer", false, false), Ok("open"));
+        assert_eq!(
+            check_open("bounty", "offer", true, false),
+            Err(Refusal::IllegalStep)
+        );
     }
 
     /// The states an opener lands in are the states the transitions move from
@@ -610,7 +690,7 @@ mod tests {
     #[test]
     fn a_kind_and_a_verb_can_be_recognized_without_a_task() {
         assert!(knows_kind("handoff"));
-        assert!(!knows_kind("bounty"), "a real kind this file does not list");
+        assert!(knows_kind("bounty"));
         assert!(!knows_kind("approval"), "deferred");
 
         for verb in [
@@ -622,7 +702,16 @@ mod tests {
             !knows_verb("handoff", "award"),
             "bounty's verb, not handoff's"
         );
-        assert!(!knows_verb("bounty", "award"), "no table, no verbs");
+        for verb in [
+            "bid", "award", "progress", "complete", "fail", "cancel", "expire",
+        ] {
+            assert!(knows_verb("bounty", verb), "{verb}");
+        }
+        assert!(
+            !knows_verb("bounty", "accept"),
+            "handoff's verb, not bounty's — a bounty has no offeree to accept"
+        );
+        assert!(!knows_verb("approval", "request"), "no table, no verbs");
     }
 
     #[test]
@@ -640,7 +729,7 @@ mod tests {
         // Deferred: it gets added as its own table if and when something needs
         // it. Until then an approval event is refused, not half-handled.
         assert!(spec().kinds.get("approval").is_none());
-        assert_eq!(spec().kinds.len(), 1, "handoff is the only kind so far");
+        assert_eq!(spec().kinds.len(), 2, "handoff and bounty");
     }
 
     // ── the receipt verb ────────────────────────────────────────────────────
@@ -747,6 +836,129 @@ mod tests {
         }
     }
 
+    // ── the two schema additions bounty needed ──────────────────────────────
+
+    fn bounty(state: &'static str) -> Task<'static> {
+        Task {
+            kind: "bounty",
+            state,
+            offerer: ELIZA,
+            offeree: None,
+            assignee: None,
+            deadline: None,
+        }
+    }
+
+    /// A transition is illegal without the fields its row names, and the
+    /// refusal says which one is missing. Checked before authority: an award
+    /// naming no winner is malformed for everybody.
+    #[test]
+    fn an_award_names_its_winner_or_it_is_no_award() {
+        let bare = Event {
+            verb: "award",
+            msgid: NOW,
+            fields: &[],
+        };
+        assert_eq!(
+            check(&bounty("open"), &bare, &who(ELIZA)),
+            Err(Refusal::MissingRequirement("act-to"))
+        );
+        assert_eq!(
+            check(&bounty("open"), &bare, &who(MALLORY)),
+            Err(Refusal::MissingRequirement("act-to")),
+            "malformed for everybody, so it does not read as 'not you'"
+        );
+        let named = Event {
+            verb: "award",
+            msgid: NOW,
+            fields: &["act-to"],
+        };
+        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+    }
+
+    /// The guard has to be free for every row that names nothing, which is
+    /// almost all of them — otherwise adding `requires` would have changed
+    /// handoff.
+    #[test]
+    fn a_transition_that_requires_nothing_is_unaffected_by_the_check() {
+        for verb in ["accept", "decline", "cancel"] {
+            let e = Event {
+                verb,
+                msgid: NOW,
+                fields: &[],
+            };
+            assert!(
+                check(&directed("offered"), &e, &who(SCHOLAR)).is_ok()
+                    || check(&directed("offered"), &e, &who(ELIZA)).is_ok(),
+                "{verb} carries no fields and is legal anyway"
+            );
+        }
+    }
+
+    /// Who a step assigns is data. Accept and claim mean the actor; a
+    /// bounty's award names its winner instead, and the poster does not become
+    /// the worker by picking one.
+    #[test]
+    fn a_transition_says_where_its_assignee_comes_from() {
+        assert_eq!(
+            assignee_source("bounty", "award", "open"),
+            AssigneeSource::Field("act-to")
+        );
+        for (kind, verb, from) in [
+            ("handoff", "accept", "offered"),
+            ("handoff", "claim", "open"),
+            ("bounty", "bid", "open"),
+            ("bounty", "complete", "assigned"),
+        ] {
+            assert_eq!(
+                assignee_source(kind, verb, from),
+                AssigneeSource::Actor,
+                "{kind}/{verb}"
+            );
+        }
+        // A row that does not exist grants nothing special either.
+        assert_eq!(
+            assignee_source("approval", "request", "open"),
+            AssigneeSource::Actor
+        );
+        assert_eq!(
+            assignee_source("bounty", "award", "assigned"),
+            AssigneeSource::Actor,
+            "no row matches from this state, so there is nothing to read"
+        );
+    }
+
+    /// The server never picks — which cuts both ways. Nothing here checks
+    /// that the awarded DID ever bid: the poster's signed choice is the
+    /// record, and a checker that second-guessed it would be picking.
+    #[test]
+    fn an_award_may_name_anyone_at_all() {
+        let named = Event {
+            verb: "award",
+            msgid: NOW,
+            fields: &["act-to"],
+        };
+        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+    }
+
+    /// Bids are additive: the state they leave is the state they found, so a
+    /// bounty takes as many as arrive until it is awarded.
+    #[test]
+    fn bids_are_additive_and_stop_when_the_work_is_awarded() {
+        assert_eq!(
+            check(&bounty("open"), &ev("bid"), &who(SCHOLAR)),
+            Ok("open")
+        );
+        assert_eq!(
+            check(&bounty("open"), &ev("bid"), &who(MALLORY)),
+            Ok("open")
+        );
+        assert_eq!(
+            check(&bounty("assigned"), &ev("bid"), &who(MALLORY)),
+            Err(Refusal::IllegalStep)
+        );
+    }
+
     #[test]
     fn every_refusal_reason_is_documented_in_the_file() {
         for r in [
@@ -760,6 +972,7 @@ mod tests {
             Refusal::ReplacesNotOpener,
             Refusal::ReplacesMalformed,
             Refusal::ReplacesNotTerminal,
+            Refusal::MissingRequirement("act-to"),
         ] {
             assert!(
                 spec().refusals.contains_key(r.code()),
@@ -956,17 +1169,17 @@ mod tests {
 
     #[test]
     fn a_kind_the_file_does_not_list_is_refused() {
-        let bounty = Task {
-            kind: "bounty",
+        let approval = Task {
+            kind: "approval",
             ..directed("open")
         };
         assert_eq!(
-            check(&bounty, &ev("bid"), &who(SCHOLAR)),
+            check(&approval, &ev("request"), &who(SCHOLAR)),
             Err(Refusal::UnknownKind)
         );
         // Even for a verb handoff does list — the kind is checked first.
         assert_eq!(
-            check(&bounty, &ev("cancel"), &who(ELIZA)),
+            check(&approval, &ev("cancel"), &who(ELIZA)),
             Err(Refusal::UnknownKind)
         );
     }
@@ -1065,6 +1278,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            fields: &[],
         };
         assert_eq!(
             check(&with_deadline(), &late, &who(SCHOLAR)),
@@ -1078,6 +1292,7 @@ mod tests {
             let e = Event {
                 verb: "accept",
                 msgid: id,
+                fields: &[],
             };
             assert_eq!(
                 check(&with_deadline(), &e, &who(SCHOLAR)),
@@ -1098,6 +1313,7 @@ mod tests {
         let late = Event {
             verb: "claim",
             msgid: TOO_LATE,
+            fields: &[],
         };
         assert_eq!(
             check(&open_with_deadline, &late, &who(SCHOLAR)),
@@ -1107,6 +1323,7 @@ mod tests {
             let e = Event {
                 verb: "claim",
                 msgid: id,
+                fields: &[],
             };
             assert_eq!(
                 check(&open_with_deadline, &e, &who(SCHOLAR)),
@@ -1123,6 +1340,7 @@ mod tests {
         let late = Event {
             verb: "decline",
             msgid: TOO_LATE,
+            fields: &[],
         };
         assert_eq!(
             check(&with_deadline(), &late, &who(SCHOLAR)),
@@ -1131,6 +1349,7 @@ mod tests {
         let late_cancel = Event {
             verb: "cancel",
             msgid: TOO_LATE,
+            fields: &[],
         };
         assert_eq!(
             check(&with_deadline(), &late_cancel, &who(ELIZA)),
@@ -1143,6 +1362,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            fields: &[],
         };
         assert_eq!(
             check(&directed("offered"), &late, &who(SCHOLAR)),
@@ -1157,6 +1377,7 @@ mod tests {
         let junk = Event {
             verb: "accept",
             msgid: "not-a-ulid",
+            fields: &[],
         };
         assert_eq!(
             check(&with_deadline(), &junk, &who(SCHOLAR)),
@@ -1196,6 +1417,13 @@ mod tests {
         event_id: Option<String>,
         #[serde(default)]
         system: bool,
+        /// The act fields the event carries, by document name. What a
+        /// transition's `requires` is checked against.
+        #[serde(default)]
+        tags: Vec<String>,
+        /// Who the step assigns, when it names someone other than its sender:
+        /// the value the transition's `assignee_from` field would hold.
+        assigns: Option<String>,
         expect: Option<String>,
         expect_refused: Option<String>,
     }
@@ -1228,9 +1456,11 @@ mod tests {
                 assignee: assignee.as_deref(),
                 deadline: seq.task.deadline,
             };
+            let fields: Vec<&str> = step.tags.iter().map(String::as_str).collect();
             let event = Event {
                 verb: &step.verb,
                 msgid: step.event_id.as_deref().unwrap_or(NOW),
+                fields: &fields,
             };
             let sender = Sender {
                 did: &step.sender,
@@ -1246,7 +1476,19 @@ mod tests {
                 (Ok(next), Some(want), None) => {
                     assert_eq!(next, want, "{where_}");
                     if assignee.is_none() && next == "assigned" {
-                        assignee = Some(step.sender.clone());
+                        // Who the step assigns is data: the actor by default,
+                        // and whoever the transition's field names otherwise.
+                        // A bounty's award names its winner rather than
+                        // becoming one, which is the whole difference.
+                        assignee = Some(
+                            match assignee_source(&seq.task.kind, &step.verb, &state) {
+                                AssigneeSource::Actor => step.sender.clone(),
+                                AssigneeSource::Field(name) => step
+                                    .assigns
+                                    .clone()
+                                    .unwrap_or_else(|| panic!("{where_}: assigns is not set, but this transition takes its assignee from {name}")),
+                            },
+                        );
                     }
                     state = next.to_string();
                 }

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -335,6 +335,33 @@ const BID_AUTHOR: &str = "bid-author";
 /// rules rather than spelling a kind's verb into itself.
 pub const BID_VERB: &str = "bid";
 
+/// The verb a home files when a review window runs out.
+///
+/// Distinct from `expire` on purpose: the log should say what happened, and
+/// "the review window closed and the work is deemed accepted" is not the same
+/// event as "nobody touched this for a month". A sweep that reused `expire`
+/// would tell every reader the worker dropped the job.
+pub const REVIEW_TIMEOUT_VERB: &str = "auto-accept";
+
+/// Every state some kind's review-timeout row moves a task out of.
+///
+/// The sweep asks this rather than knowing which kinds have a review window:
+/// a kind that writes the row is swept, a kind that does not is left to the
+/// neutral idle limit. Sorted and deduplicated, so two kinds naming the same
+/// state name it once.
+pub fn review_timeout_states() -> Vec<&'static str> {
+    let mut states: Vec<&'static str> = spec()
+        .kinds
+        .values()
+        .flat_map(|k| k.transitions.iter())
+        .filter(|t| t.verb == REVIEW_TIMEOUT_VERB)
+        .flat_map(|t| t.from.states())
+        .collect();
+    states.sort_unstable();
+    states.dedup();
+    states
+}
+
 /// Where the assignee comes from when `verb` moves a `kind` task out of
 /// `from_state`.
 ///
@@ -567,6 +594,16 @@ enum FromStates {
 const ANY_NONTERMINAL: &str = "*nonterminal";
 
 impl FromStates {
+    /// The states named outright. Empty for `*nonterminal`, which names none
+    /// of them: it is a rule about the kind's table rather than a list.
+    fn states(&'static self) -> Vec<&'static str> {
+        match self {
+            FromStates::One(s) if s == ANY_NONTERMINAL => Vec::new(),
+            FromStates::One(s) => vec![s.as_str()],
+            FromStates::Many(states) => states.iter().map(String::as_str).collect(),
+        }
+    }
+
     fn matches(&self, state: &str, kind: &Kind) -> bool {
         match self {
             FromStates::One(s) if s == ANY_NONTERMINAL => !kind.terminal.iter().any(|t| t == state),
@@ -1066,6 +1103,48 @@ mod tests {
         assert_eq!(
             check(&bounty("assigned"), &ev("bid"), &who(MALLORY)),
             Err(Refusal::IllegalStep)
+        );
+    }
+
+    /// The sweep reads which states have a review window off the tables, so a
+    /// kind that adds the row is swept and one that does not is left alone.
+    #[test]
+    fn the_review_timeout_states_come_from_the_tables() {
+        assert_eq!(REVIEW_TIMEOUT_VERB, "auto-accept");
+        assert_eq!(review_timeout_states(), vec!["under_review"]);
+        // Handoff has no review window, so none of its states are swept by
+        // this clock — its work ends when the assignee says so.
+        for state in ["offered", "open", "assigned"] {
+            assert!(!review_timeout_states().contains(&state), "{state}");
+        }
+    }
+
+    /// A bounty's review window is the server's to close, and only from the
+    /// state the work is actually sitting in.
+    #[test]
+    fn only_the_server_closes_a_review_window() {
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &who(ELIZA)),
+            Err(Refusal::WrongSender),
+            "not the poster whose silence started the clock"
+        );
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &who(SCHOLAR)),
+            Err(Refusal::WrongSender)
+        );
+        let system = Sender {
+            did: SERVER,
+            is_system: true,
+            accepted_bid: None,
+        };
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &system),
+            Ok("accepted")
+        );
+        assert_eq!(
+            check(&bounty("assigned"), &ev("auto-accept"), &system),
+            Err(Refusal::IllegalStep),
+            "there is no window until the work is in"
         );
     }
 

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -60,6 +60,12 @@ pub enum Refusal {
     DeadlinePassed,
     /// A sender wrote the confirmation verb. Receipts are the home's.
     ClientConfirm,
+    /// The revival relation rode an event that opens nothing.
+    ReplacesNotOpener,
+    /// The revival relation's value is not shaped like an action id.
+    ReplacesMalformed,
+    /// The action a revival names is on file and has not finished.
+    ReplacesNotTerminal,
 }
 
 impl Refusal {
@@ -74,6 +80,9 @@ impl Refusal {
             Refusal::WrongSender => "wrong-sender",
             Refusal::DeadlinePassed => "deadline-passed",
             Refusal::ClientConfirm => "client-confirm",
+            Refusal::ReplacesNotOpener => "replaces-not-opener",
+            Refusal::ReplacesMalformed => "replaces-malformed",
+            Refusal::ReplacesNotTerminal => "replaces-not-terminal",
         }
     }
 
@@ -168,6 +177,60 @@ pub fn confirmation_subject_tag() -> &'static str {
 /// invitation to add the row, and the row must not exist.
 pub fn is_confirmation(verb: &str) -> bool {
     verb == confirmation_verb()
+}
+
+/// The tag a new action names the finished one it revives in.
+pub fn revival_tag() -> &'static str {
+    spec().revival.tag.as_str()
+}
+
+/// What the caller's log knows about the action a revival names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Predecessor {
+    /// Never filed here. Accepted and annotated — see [`check_revival`].
+    Unknown,
+    /// On file, and still running.
+    Live,
+    /// On file, and finished.
+    Finished,
+}
+
+/// Whether `id` is shaped like an event id: a 26-character Crockford ULID.
+///
+/// Shape only. Whether anything was ever filed under it is the log's answer,
+/// not this one's.
+pub fn is_event_id(id: &str) -> bool {
+    const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    id.len() == 26 && id.bytes().all(|b| CROCKFORD.contains(&b))
+}
+
+/// Decide whether an event may carry the revival relation
+/// ([`revival_tag`]), given what the caller's log knows about the action it
+/// names.
+///
+/// Three rules, cheapest first. Only an opener revives anything: a step on an
+/// action that already exists names no other. The value names an action, so it
+/// is shaped like one. And the action it names must have finished — reviving
+/// something still running would leave two live actions each claiming to be
+/// the work.
+///
+/// [`Predecessor::Unknown`] is accepted, and that is the load-bearing part:
+/// receivers must tolerate a link to an action they never filed and annotate
+/// rather than refuse. On one server that is a client's typo; under federation
+/// it is the ordinary case, because the predecessor lived on somebody else's
+/// machine. A caller with no log at all — a bot pre-checking its own move —
+/// passes `Unknown` and gets the two rules a message decides on its own.
+pub fn check_revival(opens: bool, named: &str, predecessor: Predecessor) -> Result<(), Refusal> {
+    if !opens {
+        return Err(Refusal::ReplacesNotOpener);
+    }
+    if !is_event_id(named) {
+        return Err(Refusal::ReplacesMalformed);
+    }
+    match predecessor {
+        Predecessor::Live => Err(Refusal::ReplacesNotTerminal),
+        Predecessor::Unknown | Predecessor::Finished => Ok(()),
+    }
 }
 
 /// Decide whether an event may open a new task of `kind`.
@@ -331,6 +394,7 @@ pub fn check(
 struct Spec {
     kinds: BTreeMap<String, Kind>,
     confirmation: Confirmation,
+    revival: Revival,
     refusals: BTreeMap<String, String>,
     #[allow(dead_code)]
     deadline_rule: DeadlineRule,
@@ -342,6 +406,13 @@ struct Spec {
 struct Confirmation {
     verb: String,
     subject: String,
+}
+
+/// The tag a new action names the finished one it revives in. Outside `kinds`
+/// for the same reason: the relation is every kind's, so it is none's.
+#[derive(Deserialize)]
+struct Revival {
+    tag: String,
 }
 
 #[derive(Deserialize)]
@@ -626,6 +697,56 @@ mod tests {
         }
     }
 
+    // ── the revival relation ────────────────────────────────────────────────
+
+    /// The two rules a message decides on its own, and the one that needs the
+    /// log. An unknown predecessor is accepted on purpose — see
+    /// [`super::check_revival`].
+    #[test]
+    fn only_an_opener_revives_a_finished_action() {
+        const DEAD: &str = "01M16E7TC0ENDED00000000000";
+        assert_eq!(revival_tag(), "act-replaces");
+        assert_eq!(check_revival(true, DEAD, Predecessor::Finished), Ok(()));
+        assert_eq!(check_revival(true, DEAD, Predecessor::Unknown), Ok(()));
+        assert_eq!(
+            check_revival(true, DEAD, Predecessor::Live),
+            Err(Refusal::ReplacesNotTerminal)
+        );
+        assert_eq!(
+            check_revival(false, DEAD, Predecessor::Finished),
+            Err(Refusal::ReplacesNotOpener)
+        );
+        for bad in [
+            "",
+            "not-a-ulid",
+            "01M16E7TC0SHRT",
+            &format!("{DEAD}X"),
+            "01M16E7TC0ended00000000000",
+        ] {
+            assert_eq!(
+                check_revival(true, bad, Predecessor::Unknown),
+                Err(Refusal::ReplacesMalformed),
+                "{bad}"
+            );
+        }
+    }
+
+    /// Shape, and nothing about whether anything was filed under it.
+    #[test]
+    fn an_action_id_is_twenty_six_crockford_characters() {
+        assert!(is_event_id("01M16E7TC0ENDED00000000000"));
+        assert!(!is_event_id("01M16E7TC0ENDED0000000000"), "too short");
+        assert!(!is_event_id("01M16E7TC0ENDED000000000000"), "too long");
+        // I, L, O and U are not in the alphabet, which is what keeps a ULID
+        // from being confused for something typed by hand.
+        for c in ['I', 'L', 'O', 'U', 'a', '-'] {
+            assert!(
+                !is_event_id(&format!("01M16E7TC0ENDED0000000000{c}")),
+                "{c}"
+            );
+        }
+    }
+
     #[test]
     fn every_refusal_reason_is_documented_in_the_file() {
         for r in [
@@ -636,6 +757,9 @@ mod tests {
             Refusal::WrongSender,
             Refusal::DeadlinePassed,
             Refusal::ClientConfirm,
+            Refusal::ReplacesNotOpener,
+            Refusal::ReplacesMalformed,
+            Refusal::ReplacesNotTerminal,
         ] {
             assert!(
                 spec().refusals.contains_key(r.code()),
@@ -1157,6 +1281,55 @@ mod tests {
         file.opening_sequences
     }
 
+    #[derive(Deserialize)]
+    struct RevivalFile {
+        revival_sequences: Vec<RevivalCase>,
+    }
+
+    #[derive(Deserialize)]
+    struct RevivalCase {
+        name: String,
+        opens: bool,
+        names: String,
+        predecessor: String,
+        expect: Option<String>,
+        expect_refused: Option<String>,
+    }
+
+    fn revival_sequences() -> Vec<RevivalCase> {
+        let file: RevivalFile =
+            serde_json::from_str(include_str!("../../spec/act-transitions.json")).unwrap();
+        file.revival_sequences
+    }
+
+    #[test]
+    fn every_revival_sequence_in_the_rules_file_replays() {
+        let cases = revival_sequences();
+        assert!(cases.len() >= 5, "{}", cases.len());
+        for c in &cases {
+            let predecessor = match c.predecessor.as_str() {
+                "unknown" => Predecessor::Unknown,
+                "live" => Predecessor::Live,
+                "finished" => Predecessor::Finished,
+                other => panic!("{}: unknown predecessor {other}", c.name),
+            };
+            let got = check_revival(c.opens, &c.names, predecessor);
+            match (&c.expect, &c.expect_refused) {
+                (Some(word), None) => {
+                    assert_eq!(word, "accepted", "{}", c.name);
+                    assert_eq!(got, Ok(()), "{}", c.name);
+                }
+                (None, Some(reason)) => assert_eq!(
+                    got.map_err(|r| r.code()),
+                    Err(reason.as_str()),
+                    "{}",
+                    c.name
+                ),
+                _ => panic!("{}: set exactly one of expect / expect_refused", c.name),
+            }
+        }
+    }
+
     #[test]
     fn every_opening_sequence_in_the_rules_file_replays() {
         let openings = opening_sequences();
@@ -1218,7 +1391,8 @@ mod tests {
 
     /// The sequences have to exercise every refusal the checker can reach —
     /// otherwise the other implementation could pass them all and still get a
-    /// reason wrong. Both lists count: some reasons only an opener can earn.
+    /// reason wrong. Every list counts: some reasons only an opener can earn,
+    /// and some only a revival can.
     #[test]
     fn the_sequences_cover_every_refusal_reason() {
         let mut seen: Vec<String> = sequences()
@@ -1228,6 +1402,11 @@ mod tests {
                 opening_sequences()
                     .iter()
                     .filter_map(|o| o.expect_refused.clone()),
+            )
+            .chain(
+                revival_sequences()
+                    .iter()
+                    .filter_map(|r| r.expect_refused.clone()),
             )
             .collect();
         seen.sort();

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -71,6 +71,9 @@ pub enum Refusal {
     /// outlives every event — so carrying it costs nothing and saves a round
     /// of guessing.
     MissingRequirement(&'static str),
+    /// An award named an event that is not a bid on this action. The caller
+    /// resolved the name against its own log and found nothing to take.
+    AcceptsNotABid,
 }
 
 impl Refusal {
@@ -89,6 +92,7 @@ impl Refusal {
             Refusal::ReplacesMalformed => "replaces-malformed",
             Refusal::ReplacesNotTerminal => "replaces-not-terminal",
             Refusal::MissingRequirement(_) => "missing-requirement",
+            Refusal::AcceptsNotABid => "accepts-not-a-bid",
         }
     }
 
@@ -136,6 +140,10 @@ pub struct Event<'a> {
     /// deadline is measured against — every verifier then compares the same
     /// number instead of its own wall clock.
     pub msgid: &'a str,
+    /// `act-accepts`: the event an award takes. Named here rather than read
+    /// out of `fields` because it is the one act value a caller must resolve
+    /// before asking — see [`Sender::accepted_bid`].
+    pub accepts: Option<&'a str>,
     /// The act fields the event carries, by their document names (`act-to`,
     /// `act-note`, …). Presence only: what a transition's `requires` is
     /// checked against. Values are the caller's business — the one place this
@@ -144,13 +152,30 @@ pub struct Event<'a> {
     pub fields: &'a [&'a str],
 }
 
-/// Who sent it.
+/// The bid an award named, as the caller's log answered for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AcceptedBid<'a> {
+    /// Who wrote the bid. The assignee an award's `bid-author` row lands on.
+    pub author: &'a str,
+}
+
+/// Who sent it, and what their event resolved to.
 #[derive(Debug, Clone, Copy)]
 pub struct Sender<'a> {
     pub did: &'a str,
     /// The server itself, signing under its own identity — the only actor a
     /// `system` transition allows.
     pub is_system: bool,
+    /// The bid this event's `act-accepts` names, when the caller found one on
+    /// the action. `None` when it named something that is not a bid here —
+    /// including an id belonging to another action, and an id nobody filed.
+    ///
+    /// This checker reads no log, so the lookup is the caller's: it resolves
+    /// the named event among the action's own and hands back the bid's
+    /// author. A caller with no log — a bot pre-checking its own move —
+    /// passes `None` and is told its award takes nothing, which is the honest
+    /// answer from where it stands.
+    pub accepted_bid: Option<AcceptedBid<'a>>,
 }
 
 /// The state a new task of `kind` starts in.
@@ -291,10 +316,24 @@ pub fn check_open(
 pub enum AssigneeSource {
     /// Whoever took the step — what `accept` and `claim` already mean.
     Actor,
-    /// The act field named here, read off the event: a bounty's `award` names
-    /// its winner in `act-to`, because the poster picks rather than becomes.
+    /// The act field named here, read off the event.
     Field(&'static str),
+    /// Whoever wrote the bid the event names in `act-accepts`: a bounty's
+    /// `award` takes one bid, and the terms live in it, so the poster names
+    /// the event rather than a DID. Resolving it is the caller's — this
+    /// checker reads no log — and the answer arrives as
+    /// [`Sender::accepted_bid`].
+    BidAuthor,
 }
+
+/// The `assignee_from` value that means [`AssigneeSource::BidAuthor`].
+const BID_AUTHOR: &str = "bid-author";
+
+/// The verb the event an award names must carry.
+///
+/// Written down once, here, so a caller resolving `act-accepts` asks the
+/// rules rather than spelling a kind's verb into itself.
+pub const BID_VERB: &str = "bid";
 
 /// Where the assignee comes from when `verb` moves a `kind` task out of
 /// `from_state`.
@@ -311,7 +350,10 @@ pub fn assignee_source(kind: &str, verb: &str, from_state: &str) -> AssigneeSour
         .iter()
         .find(|t| t.verb == verb && t.from.matches(from_state, k))
         .and_then(|t| t.assignee_from.as_deref())
-        .map_or(AssigneeSource::Actor, AssigneeSource::Field)
+        .map_or(AssigneeSource::Actor, |name| match name {
+            BID_AUTHOR => AssigneeSource::BidAuthor,
+            field => AssigneeSource::Field(field),
+        })
 }
 
 /// Whether the rules file lists this kind at all.
@@ -406,6 +448,17 @@ pub fn check(
         .find(|f| !event.fields.contains(&f.as_str()))
     {
         return Err(Refusal::MissingRequirement(missing.as_str()));
+    }
+
+    // A row that takes its assignee from a named bid needs that bid. Whether
+    // the name found one is the caller's answer, not this checker's — nothing
+    // here reads a log — and a name that found nothing named something that
+    // is not a bid on this action. Alongside the requirement above for the
+    // same reason: an award that takes no bid is malformed for everybody.
+    if row.assignee_from.as_deref() == Some(BID_AUTHOR)
+        && (event.accepts.is_none() || sender.accepted_bid.is_none())
+    {
+        return Err(Refusal::AcceptsNotABid);
     }
 
     // Authority second: who the sender is only matters once the move itself
@@ -566,6 +619,7 @@ mod tests {
         Event {
             verb,
             msgid: NOW,
+            accepts: None,
             fields: &[],
         }
     }
@@ -574,6 +628,28 @@ mod tests {
         Sender {
             did,
             is_system: false,
+            accepted_bid: None,
+        }
+    }
+
+    /// A sender whose award named a bid the caller resolved to `author`.
+    fn who_took(did: &'static str, author: &'static str) -> Sender<'static> {
+        Sender {
+            accepted_bid: Some(AcceptedBid { author }),
+            ..who(did)
+        }
+    }
+
+    /// The bid an award names in these tests.
+    const BID: &str = "01M16E7TC0BDTAKEN000000000";
+
+    /// An award naming `BID`.
+    fn award() -> Event<'static> {
+        Event {
+            verb: "award",
+            msgid: NOW,
+            accepts: Some(BID),
+            fields: &["act-accepts"],
         }
     }
 
@@ -748,6 +824,7 @@ mod tests {
         let system = Sender {
             did: SERVER,
             is_system: true,
+            accepted_bid: None,
         };
         assert_eq!(
             check(&directed("offered"), &ev("confirm"), &system),
@@ -851,29 +928,45 @@ mod tests {
 
     /// A transition is illegal without the fields its row names, and the
     /// refusal says which one is missing. Checked before authority: an award
-    /// naming no winner is malformed for everybody.
+    /// naming no bid is malformed for everybody.
     #[test]
-    fn an_award_names_its_winner_or_it_is_no_award() {
+    fn an_award_names_the_bid_it_takes_or_it_is_no_award() {
         let bare = Event {
             verb: "award",
             msgid: NOW,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
-            check(&bounty("open"), &bare, &who(ELIZA)),
-            Err(Refusal::MissingRequirement("act-to"))
+            check(&bounty("open"), &bare, &who_took(ELIZA, SCHOLAR)),
+            Err(Refusal::MissingRequirement("act-accepts"))
         );
         assert_eq!(
-            check(&bounty("open"), &bare, &who(MALLORY)),
-            Err(Refusal::MissingRequirement("act-to")),
+            check(&bounty("open"), &bare, &who_took(MALLORY, SCHOLAR)),
+            Err(Refusal::MissingRequirement("act-accepts")),
             "malformed for everybody, so it does not read as 'not you'"
         );
-        let named = Event {
-            verb: "award",
-            msgid: NOW,
-            fields: &["act-to"],
-        };
-        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+        assert_eq!(
+            check(&bounty("open"), &award(), &who_took(ELIZA, SCHOLAR)),
+            Ok("assigned")
+        );
+    }
+
+    /// The award names one event and the caller resolves it. A name that
+    /// found no bid on this action — the bounty's own opener, a bid filed
+    /// against something else, an id nobody ever used — takes nothing, and
+    /// says so rather than assigning the poster's own choice of stranger.
+    #[test]
+    fn an_award_naming_something_that_is_not_a_bid_takes_nothing() {
+        assert_eq!(
+            check(&bounty("open"), &award(), &who(ELIZA)),
+            Err(Refusal::AcceptsNotABid)
+        );
+        // Before authority, like the requirement above.
+        assert_eq!(
+            check(&bounty("open"), &award(), &who(MALLORY)),
+            Err(Refusal::AcceptsNotABid)
+        );
     }
 
     /// The guard has to be free for every row that names nothing, which is
@@ -885,6 +978,7 @@ mod tests {
             let e = Event {
                 verb,
                 msgid: NOW,
+                accepts: None,
                 fields: &[],
             };
             assert!(
@@ -902,7 +996,7 @@ mod tests {
     fn a_transition_says_where_its_assignee_comes_from() {
         assert_eq!(
             assignee_source("bounty", "award", "open"),
-            AssigneeSource::Field("act-to")
+            AssigneeSource::BidAuthor
         );
         for (kind, verb, from) in [
             ("handoff", "accept", "offered"),
@@ -928,17 +1022,18 @@ mod tests {
         );
     }
 
-    /// The server never picks — which cuts both ways. Nothing here checks
-    /// that the awarded DID ever bid: the poster's signed choice is the
-    /// record, and a checker that second-guessed it would be picking.
+    /// The server still never picks. It checks only that the named event is a
+    /// bid on this action; which of the bids on the table is worth taking is
+    /// the poster's to decide and nothing here second-guesses it.
     #[test]
-    fn an_award_may_name_anyone_at_all() {
-        let named = Event {
-            verb: "award",
-            msgid: NOW,
-            fields: &["act-to"],
-        };
-        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+    fn the_poster_takes_whichever_bid_they_name() {
+        for author in [SCHOLAR, MALLORY, "did:plc:nobody"] {
+            assert_eq!(
+                check(&bounty("open"), &award(), &who_took(ELIZA, author)),
+                Ok("assigned"),
+                "{author}"
+            );
+        }
     }
 
     /// Bids are additive: the state they leave is the state they found, so a
@@ -972,7 +1067,8 @@ mod tests {
             Refusal::ReplacesNotOpener,
             Refusal::ReplacesMalformed,
             Refusal::ReplacesNotTerminal,
-            Refusal::MissingRequirement("act-to"),
+            Refusal::MissingRequirement("act-accepts"),
+            Refusal::AcceptsNotABid,
         ] {
             assert!(
                 spec().refusals.contains_key(r.code()),
@@ -1097,6 +1193,7 @@ mod tests {
         let system = Sender {
             did: SERVER,
             is_system: true,
+            accepted_bid: None,
         };
         assert_eq!(
             check(&directed("assigned"), &ev("expire"), &system),
@@ -1150,6 +1247,7 @@ mod tests {
             let system = Sender {
                 did: SERVER,
                 is_system: true,
+                accepted_bid: None,
             };
             assert_eq!(
                 check(&done, &ev("expire"), &system),
@@ -1278,6 +1376,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1292,6 +1391,7 @@ mod tests {
             let e = Event {
                 verb: "accept",
                 msgid: id,
+                accepts: None,
                 fields: &[],
             };
             assert_eq!(
@@ -1313,6 +1413,7 @@ mod tests {
         let late = Event {
             verb: "claim",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1323,6 +1424,7 @@ mod tests {
             let e = Event {
                 verb: "claim",
                 msgid: id,
+                accepts: None,
                 fields: &[],
             };
             assert_eq!(
@@ -1340,6 +1442,7 @@ mod tests {
         let late = Event {
             verb: "decline",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1349,6 +1452,7 @@ mod tests {
         let late_cancel = Event {
             verb: "cancel",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1362,6 +1466,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1377,6 +1482,7 @@ mod tests {
         let junk = Event {
             verb: "accept",
             msgid: "not-a-ulid",
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1424,6 +1530,11 @@ mod tests {
         /// Who the step assigns, when it names someone other than its sender:
         /// the value the transition's `assignee_from` field would hold.
         assigns: Option<String>,
+        /// `act-accepts`: the event an award takes.
+        accepts: Option<String>,
+        /// Who wrote the bid that event turned out to be. Absent when the
+        /// name found no bid on this action.
+        accepted_bid: Option<String>,
         expect: Option<String>,
         expect_refused: Option<String>,
     }
@@ -1460,11 +1571,20 @@ mod tests {
             let event = Event {
                 verb: &step.verb,
                 msgid: step.event_id.as_deref().unwrap_or(NOW),
+                accepts: step.accepts.as_deref(),
                 fields: &fields,
             };
             let sender = Sender {
                 did: &step.sender,
                 is_system: step.system,
+                // What the caller's log made of the event this one names. A
+                // step that sets nothing named nothing, or named something
+                // that is not a bid — the file does not distinguish, because
+                // neither does the checker.
+                accepted_bid: step
+                    .accepted_bid
+                    .as_deref()
+                    .map(|author| AcceptedBid { author }),
             };
             let where_ = format!("{} — step {} ({})", seq.name, i + 1, step.verb);
 
@@ -1483,6 +1603,10 @@ mod tests {
                         assignee = Some(
                             match assignee_source(&seq.task.kind, &step.verb, &state) {
                                 AssigneeSource::Actor => step.sender.clone(),
+                                AssigneeSource::BidAuthor => step
+                                    .accepted_bid
+                                    .clone()
+                                    .unwrap_or_else(|| panic!("{where_}: this transition assigns the author of the bid it names, and none was resolved")),
                                 AssigneeSource::Field(name) => step
                                     .assigns
                                     .clone()

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -779,7 +779,16 @@ mod tests {
             "bounty's verb, not handoff's"
         );
         for verb in [
-            "bid", "award", "progress", "complete", "fail", "cancel", "expire",
+            "bid",
+            "award",
+            "progress",
+            "submit",
+            "revise",
+            "accept-work",
+            "forfeit",
+            "auto-accept",
+            "cancel",
+            "expire",
         ] {
             assert!(knows_verb("bounty", verb), "{verb}");
         }
@@ -787,6 +796,12 @@ mod tests {
             !knows_verb("bounty", "accept"),
             "handoff's verb, not bounty's — a bounty has no offeree to accept"
         );
+        for verb in ["complete", "fail"] {
+            assert!(
+                !knows_verb("bounty", verb),
+                "{verb}: a bounty ends on the poster's word, not the worker's"
+            );
+        }
         assert!(!knows_verb("approval", "request"), "no table, no verbs");
     }
 

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -58,6 +58,8 @@ pub enum Refusal {
     WrongSender,
     /// The event was minted past the offer's deadline, beyond the tolerance.
     DeadlinePassed,
+    /// A sender wrote the confirmation verb. Receipts are the home's.
+    ClientConfirm,
 }
 
 impl Refusal {
@@ -71,6 +73,7 @@ impl Refusal {
             Refusal::IllegalStep => "illegal-step",
             Refusal::WrongSender => "wrong-sender",
             Refusal::DeadlinePassed => "deadline-passed",
+            Refusal::ClientConfirm => "client-confirm",
         }
     }
 
@@ -146,6 +149,27 @@ pub fn opening_verb(kind: &str) -> Option<&'static str> {
     spec().kinds.get(kind).map(|k| k.opens.verb.as_str())
 }
 
+/// The verb an action's home writes its receipts under.
+pub fn confirmation_verb() -> &'static str {
+    spec().confirmation.verb.as_str()
+}
+
+/// The tag a receipt names the event it confirms in.
+pub fn confirmation_subject_tag() -> &'static str {
+    spec().confirmation.subject.as_str()
+}
+
+/// Whether this verb is the home's receipt verb.
+///
+/// Asked before any kind's table is consulted, by every caller that reads a
+/// verb at all. A receipt is a statement about an event, not a move on a task:
+/// no kind lists `confirm`, and letting one fall through to the per-kind
+/// lookup would answer "that kind has no such step" — which reads as an
+/// invitation to add the row, and the row must not exist.
+pub fn is_confirmation(verb: &str) -> bool {
+    verb == confirmation_verb()
+}
+
 /// Decide whether an event may open a new task of `kind`.
 ///
 /// The move the transitions table cannot describe, because there is no task
@@ -163,6 +187,11 @@ pub fn check_open(
     directed: bool,
     names_task: bool,
 ) -> Result<&'static str, Refusal> {
+    // Before the kind is even looked up: a receipt opens nothing, and the
+    // answer must not depend on which kind it named.
+    if is_confirmation(verb) {
+        return Err(Refusal::ClientConfirm);
+    }
     let k = spec().kinds.get(kind).ok_or(Refusal::UnknownKind)?;
     if k.opens.verb != verb {
         // A verb the kind moves tasks with is known but cannot start one;
@@ -234,6 +263,12 @@ pub fn check(
     event: &Event<'_>,
     sender: &Sender<'_>,
 ) -> Result<&'static str, Refusal> {
+    // The receipt verb, before the kind lookup and before anything about this
+    // task: a confirmation is not a move, and no table has a row for it. The
+    // home files its own receipts past this checker entirely.
+    if is_confirmation(event.verb) {
+        return Err(Refusal::ClientConfirm);
+    }
     let kind = spec().kinds.get(task.kind).ok_or(Refusal::UnknownKind)?;
 
     // Is this a move the kind has at all? Asked before anything about this
@@ -295,9 +330,18 @@ pub fn check(
 #[derive(Deserialize)]
 struct Spec {
     kinds: BTreeMap<String, Kind>,
+    confirmation: Confirmation,
     refusals: BTreeMap<String, String>,
     #[allow(dead_code)]
     deadline_rule: DeadlineRule,
+}
+
+/// The receipt verb, and the tag a receipt names its subject in. Outside
+/// `kinds` because it belongs to none of them.
+#[derive(Deserialize)]
+struct Confirmation {
+    verb: String,
+    subject: String,
 }
 
 #[derive(Deserialize)]
@@ -528,6 +572,60 @@ mod tests {
         assert_eq!(spec().kinds.len(), 1, "handoff is the only kind so far");
     }
 
+    // ── the receipt verb ────────────────────────────────────────────────────
+
+    /// A receipt is the home's word about an event, so a sender's `confirm`
+    /// is refused wherever it appears — opening or moving, whatever kind it
+    /// names, and even when the sender claims to be the server. The home
+    /// files its own past this checker.
+    #[test]
+    fn a_sender_never_writes_a_confirmation() {
+        assert_eq!(confirmation_verb(), "confirm");
+        assert_eq!(
+            check(&directed("offered"), &ev("confirm"), &who(SCHOLAR)),
+            Err(Refusal::ClientConfirm)
+        );
+        let system = Sender {
+            did: SERVER,
+            is_system: true,
+        };
+        assert_eq!(
+            check(&directed("offered"), &ev("confirm"), &system),
+            Err(Refusal::ClientConfirm)
+        );
+        assert_eq!(
+            check_open("handoff", "confirm", false, false),
+            Err(Refusal::ClientConfirm)
+        );
+    }
+
+    /// The answer must not read as "this kind has no such row yet", which
+    /// would say a kind could add one. It cannot: the verb is recognized
+    /// before any kind is consulted, unlisted kinds included.
+    #[test]
+    fn a_confirmation_never_reads_as_a_verb_a_kind_could_add() {
+        let unlisted = Task {
+            kind: "no-such-kind",
+            ..directed("offered")
+        };
+        assert_eq!(
+            check(&unlisted, &ev("confirm"), &who(SCHOLAR)),
+            Err(Refusal::ClientConfirm),
+            "not unknown-kind either — the verb is answered first"
+        );
+        assert_eq!(
+            check_open("no-such-kind", "confirm", false, false),
+            Err(Refusal::ClientConfirm)
+        );
+        for (name, kind) in &spec().kinds {
+            assert!(
+                !kind.transitions.iter().any(|t| is_confirmation(&t.verb)),
+                "{name} claims the receipt verb, which belongs to no kind"
+            );
+            assert!(!is_confirmation(&kind.opens.verb), "{name}");
+        }
+    }
+
     #[test]
     fn every_refusal_reason_is_documented_in_the_file() {
         for r in [
@@ -537,6 +635,7 @@ mod tests {
             Refusal::IllegalStep,
             Refusal::WrongSender,
             Refusal::DeadlinePassed,
+            Refusal::ClientConfirm,
         ] {
             assert!(
                 spec().refusals.contains_key(r.code()),
@@ -1119,12 +1218,17 @@ mod tests {
 
     /// The sequences have to exercise every refusal the checker can reach —
     /// otherwise the other implementation could pass them all and still get a
-    /// reason wrong.
+    /// reason wrong. Both lists count: some reasons only an opener can earn.
     #[test]
     fn the_sequences_cover_every_refusal_reason() {
         let mut seen: Vec<String> = sequences()
             .iter()
             .flat_map(|s| s.steps.iter().filter_map(|st| st.expect_refused.clone()))
+            .chain(
+                opening_sequences()
+                    .iter()
+                    .filter_map(|o| o.expect_refused.clone()),
+            )
             .collect();
         seen.sort();
         seen.dedup();

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -130,6 +130,11 @@ pub struct Task<'a> {
     pub offeree: Option<&'a str>,
     pub assignee: Option<&'a str>,
     pub deadline: Option<i64>,
+    /// The offer's `act-bid-deadline` in unix seconds, empty when it named
+    /// none. A second time on the same opener, compared the same way: it
+    /// bounds how long a bounty collects bids, which is a shorter question
+    /// than how long the offer stands.
+    pub bid_deadline: Option<i64>,
 }
 
 /// The event being checked.
@@ -503,8 +508,18 @@ pub fn check(
         _ => return Err(Refusal::WrongSender),
     }
 
-    if row.before_deadline
-        && let Some(deadline) = task.deadline
+    // Two deadlines, one comparison. A row declares which of the offer's
+    // times bounds it: how long the offer stands, or — on a kind that
+    // collects them — how long it takes bids. A time the offer never named
+    // bounds nothing.
+    for deadline in [
+        row.before_deadline.then_some(task.deadline).flatten(),
+        row.before_bid_deadline
+            .then_some(task.bid_deadline)
+            .flatten(),
+    ]
+    .into_iter()
+    .flatten()
     {
         let limit = deadline
             .saturating_mul(1_000)
@@ -574,6 +589,11 @@ struct Transition {
     who: String,
     #[serde(default)]
     before_deadline: bool,
+    /// Bounded by the offer's `act-bid-deadline` rather than its
+    /// `act-deadline`. Data, like its sibling; the comparison is the same
+    /// code.
+    #[serde(default)]
+    before_bid_deadline: bool,
     /// The field naming who this transition assigns. Absent = the actor.
     #[serde(default)]
     assignee_from: Option<String>,
@@ -649,6 +669,7 @@ mod tests {
             offeree: Some(SCHOLAR),
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -975,6 +996,7 @@ mod tests {
             offeree: None,
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -1386,6 +1408,7 @@ mod tests {
             offeree: None,
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -1569,6 +1592,73 @@ mod tests {
         );
     }
 
+    /// A bounty takes bids until its own cutoff, which is a shorter question
+    /// than how long the offer stands. Both times sit on the same opener and
+    /// are compared the same way.
+    #[test]
+    fn a_bid_is_bound_by_the_offers_bid_deadline() {
+        let taking_bids = Task {
+            bid_deadline: Some(DEADLINE),
+            ..bounty("open")
+        };
+        let late = Event {
+            verb: "bid",
+            msgid: TOO_LATE,
+            accepts: None,
+            fields: &[],
+        };
+        assert_eq!(
+            check(&taking_bids, &late, &who(SCHOLAR)),
+            Err(Refusal::DeadlinePassed)
+        );
+        for id in [IN_TIME, AT_EDGE] {
+            let e = Event {
+                verb: "bid",
+                msgid: id,
+                accepts: None,
+                fields: &[],
+            };
+            assert_eq!(check(&taking_bids, &e, &who(SCHOLAR)), Ok("open"), "{id}");
+        }
+    }
+
+    /// The two times are separate: bidding may close long before the offer
+    /// does, and a bounty that named no bid cutoff takes bids for as long as
+    /// it stands.
+    #[test]
+    fn the_two_deadlines_bound_different_moves() {
+        // Bidding closed; the offer has not.
+        let closed = Task {
+            deadline: None,
+            bid_deadline: Some(DEADLINE),
+            ..bounty("open")
+        };
+        let late = Event {
+            verb: "bid",
+            msgid: TOO_LATE,
+            accepts: None,
+            fields: &[],
+        };
+        assert_eq!(
+            check(&closed, &late, &who(SCHOLAR)),
+            Err(Refusal::DeadlinePassed)
+        );
+        // The award is bound by the offer's own deadline, not by the bid one.
+        let award_late = Event {
+            verb: "award",
+            msgid: TOO_LATE,
+            accepts: Some(BID),
+            fields: &["act-accepts"],
+        };
+        assert_eq!(
+            check(&closed, &award_late, &who_took(ELIZA, SCHOLAR)),
+            Ok("assigned"),
+            "bidding closing does not stop the poster picking"
+        );
+        // …and no bid cutoff means no bid cutoff.
+        assert_eq!(check(&bounty("open"), &late, &who(SCHOLAR)), Ok("open"));
+    }
+
     /// Fail closed: an id whose clock cannot be read cannot be shown to be
     /// inside the deadline, so it is treated as outside it.
     #[test]
@@ -1608,6 +1698,9 @@ mod tests {
         offerer: String,
         offeree: Option<String>,
         deadline: Option<i64>,
+        /// `act-bid-deadline`: how long the offer takes bids, when it named a
+        /// second time.
+        bid_deadline: Option<i64>,
     }
 
     #[derive(Deserialize)]
@@ -1660,6 +1753,7 @@ mod tests {
                 offeree: seq.task.offeree.as_deref(),
                 assignee: assignee.as_deref(),
                 deadline: seq.task.deadline,
+                bid_deadline: seq.task.bid_deadline,
             };
             let fields: Vec<&str> = step.tags.iter().map(String::as_str).collect();
             let event = Event {

--- a/freeq-server/src/config.rs
+++ b/freeq-server/src/config.rs
@@ -132,6 +132,17 @@ pub struct ServerConfig {
     #[arg(long, default_value = "604800")]
     pub act_expiry_secs: u64,
 
+    /// How long submitted work may wait on the poster before it is deemed
+    /// accepted, in seconds. Separate from the abandonment limit because it
+    /// does the opposite job: that one is neutral and catches work nobody is
+    /// doing, this one favours the worker and catches a poster who took
+    /// delivery and then went quiet. Measured from the last movement, so
+    /// asking for changes stops the clock and a fresh submission starts a new
+    /// one. Fixed and documented rather than per-task, so every bidder knows
+    /// the window before they bid. 0 = never auto-accept.
+    #[arg(long, default_value = "1209600")]
+    pub act_review_secs: u64,
+
     /// Message of the Day text. If not set, no MOTD is sent.
     #[arg(long)]
     pub motd: Option<String>,
@@ -307,6 +318,7 @@ impl Default for ServerConfig {
             did_resolver_static: vec![],
             max_messages_per_channel: 10000,
             act_expiry_secs: 604_800,
+            act_review_secs: 1_209_600,
             motd: None,
             motd_file: None,
             web_static_dir: None,
@@ -441,6 +453,7 @@ struct FileConfig {
     did_resolver_static: Option<MapOrPairs>,
     max_messages_per_channel: Option<usize>,
     act_expiry_secs: Option<u64>,
+    act_review_secs: Option<u64>,
     motd: Option<String>,
     motd_file: Option<String>,
     web_static_dir: Option<String>,
@@ -558,6 +571,7 @@ fn apply_file(cfg: &mut ServerConfig, matches: &clap::ArgMatches, file: FileConf
         s2s_allowed_peers,
         max_messages_per_channel,
         act_expiry_secs,
+        act_review_secs,
         plugins,
         require_did_for_ops,
         oper_dids,
@@ -613,6 +627,7 @@ mod tests {
                 max_messages_per_channel = 42
                 iroh = true
                 act_expiry_secs = 120
+                act_review_secs = 240
                 s2s_peer_api = ["abcd=https://irc.example.com"]
                 "#,
             ),
@@ -623,6 +638,7 @@ mod tests {
         assert_eq!(c.max_messages_per_channel, 42);
         assert!(c.iroh);
         assert_eq!(c.act_expiry_secs, 120);
+        assert_eq!(c.act_review_secs, 240);
         assert_eq!(c.s2s_peer_api, vec!["abcd=https://irc.example.com"]);
     }
 

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -973,6 +973,10 @@ pub(super) fn gate(
         }
         Some(crate::db::ActWrite::Refused(reason)) => {
             use freeq_sdk::act_transitions::Refusal;
+            // Every other sentence is a constant; this one names the field the
+            // step is missing, so it needs somewhere to live as long as the
+            // borrow.
+            let missing;
             let (code, sentence) = match reason {
                 Refusal::TerminalTask => (
                     "TERMINAL_TASK",
@@ -1000,6 +1004,14 @@ pub(super) fn gate(
                     "REPLACES_NOT_TERMINAL",
                     "The action it replaces is not finished",
                 ),
+                // The sentence names the field rather than the verb: which
+                // field a step needs is the rules file's to say, and a
+                // sentence per verb would be a kind's behaviour written into
+                // this server.
+                Refusal::MissingRequirement(field) => {
+                    missing = format!("That step must carry {field}");
+                    ("MISSING_REQUIREMENT", missing.as_str())
+                }
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -1012,6 +1012,10 @@ pub(super) fn gate(
                     missing = format!("That step must carry {field}");
                     ("MISSING_REQUIREMENT", missing.as_str())
                 }
+                Refusal::AcceptsNotABid => (
+                    "ACCEPTS_NOT_A_BID",
+                    "The award names an event that is not a bid on this action",
+                ),
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -1063,10 +1063,9 @@ pub(super) fn gate(
                     missing = format!("That step must carry {field}");
                     ("MISSING_REQUIREMENT", missing.as_str())
                 }
-                Refusal::AcceptsNotABid => (
-                    "ACCEPTS_NOT_A_BID",
-                    "The award names an event that is not a bid on this action",
-                ),
+                Refusal::AcceptsNotABid => {
+                    ("ACCEPTS_NOT_A_BID", "That award names no bid on this task")
+                }
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -32,10 +32,22 @@ const VERB_TAG_BARE: &str = "act-verb";
 pub(super) enum Gate {
     /// No act tags: not a task message, and none of this applies.
     NotATaskMessage,
-    /// A task message that passed every check.
-    Accepted,
+    /// A task message that passed every check, and the receipt this server
+    /// owes for it — `None` when the event moved nothing.
+    Accepted(Option<Receipt>),
     /// Refused. The `FAIL` has already been sent.
     Refused,
+}
+
+/// A receipt this server has already filed, on its way to the room.
+///
+/// Minted, signed and filed inside the gate beside the event it confirms, so
+/// the log holds one for every move whether or not delivery reaches anybody;
+/// handed back rather than sent, so it goes out *after* the event it names and
+/// a reader sees the move before the confirmation of it.
+pub(super) struct Receipt {
+    tags: HashMap<String, String>,
+    venue: String,
 }
 
 /// Whether any tag on this message is one the act canonical covers.
@@ -134,28 +146,37 @@ pub(super) fn refuse_body_with_act_tags(
     );
 }
 
-/// Expire one abandoned task: sign the event, run it through the same check
-/// and storage every other event goes through, and announce it.
+/// Mint, sign and file one event of this server's own.
 ///
-/// The sweep has no client connection, which is why this is separate from the
-/// gate above — but it is not a separate path. The event is built the way a
-/// sender would build it, signed with this server's own key under its own
-/// identity, and applied through `apply_act_event` like anything else, so it
-/// lands in the log, the view and replay identically.
+/// The shape every server-authored event shares — the expiry sweep's and the
+/// receipt path's alike. The document is built the way a sender builds one:
+/// this server's DID in `from`, a fresh ULID for the id, the standard act
+/// canonical over whatever act tags the caller named, signed with this
+/// server's own key and applied through `apply_act_event` like anything else,
+/// so it lands in the log, the view and replay identically.
 ///
-/// Returns whether the task was expired.
-pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
+/// The caller names only what is particular to its event; `from`, the kind,
+/// the verb and the task are the shape. Returns the wire tag map — the act
+/// tags plus the id and the signature, ready to put on a line — and what the
+/// log made of it.
+fn file_own_event(
+    state: &Arc<SharedState>,
+    kind: &str,
+    verb: &str,
+    act_id: &str,
+    extra: &[(&str, &str)],
+    venue: &str,
+) -> Option<(HashMap<String, String>, crate::db::ActWrite)> {
     let did = crate::server::server_did(&state.server_name);
     let event_id = freeq_sdk::chatsig::new_event_id();
-    let tags = vec![
-        ("+freeq.at/act", task.kind.as_str()),
-        ("+freeq.at/act-verb", "expire"),
+    let mut pairs: Vec<(&str, &str)> = vec![
+        (KIND_TAG, kind),
+        (VERB_TAG, verb),
         ("+freeq.at/from", did.as_str()),
-        ("+freeq.at/act-id", task.act_id.as_str()),
+        ("+freeq.at/act-id", act_id),
     ];
-    let Ok(canonical) = freeq_sdk::act::act_canonical(tags, &task.venue, &event_id) else {
-        return false;
-    };
+    pairs.extend_from_slice(extra);
+    let canonical = freeq_sdk::act::act_canonical(pairs.clone(), venue, &event_id).ok()?;
     let signature = freeq_sdk::sigtag::sign_canonical(&canonical, &state.msg_signing_key);
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -167,21 +188,47 @@ pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -
             canonical: &canonical,
             signature: Some(&signature),
             event_id: &event_id,
-            act_id: &task.act_id,
+            act_id,
             opens: false,
-            venue: &task.venue,
+            venue,
             actor: &did,
-            // Only the server may expire, and this is the server.
+            // This is the server, signing under its own identity — the only
+            // actor a `system` transition allows, and the only one that may
+            // write a receipt.
             from_system: true,
             origin: None,
             timestamp: now,
         })
-    });
+    })?;
+
+    let mut tags: HashMap<String, String> = pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    tags.insert(
+        freeq_sdk::chatsig::EVENT_ID_TAG.to_string(),
+        event_id.clone(),
+    );
+    tags.insert("msgid".to_string(), event_id);
+    tags.insert("+freeq.at/sig".to_string(), signature);
+    Some((tags, written))
+}
+
+/// Expire one abandoned task: sign the event, run it through the same check
+/// and storage every other event goes through, and announce it.
+///
+/// The sweep has no client connection, which is why this is separate from the
+/// gate above — but it is not a separate path.
+///
+/// Returns whether the task was expired.
+pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
+    let written = file_own_event(state, &task.kind, "expire", &task.act_id, &[], &task.venue);
     match written {
-        Some(crate::db::ActWrite::Filed { .. }) => {}
+        Some((_, crate::db::ActWrite::Filed { .. })) => {}
         other => {
             tracing::warn!(
-                act_id = %task.act_id, venue = %task.venue, outcome = ?other,
+                act_id = %task.act_id, venue = %task.venue,
+                outcome = ?other.map(|(_, w)| w),
                 "Expiry sweep could not file its own event"
             );
             return false;
@@ -223,19 +270,10 @@ fn title_for_wire(title: &str) -> String {
 /// Long enough for any real task name, short enough that no notice is a wall.
 const MAX_TITLE_CHARS: usize = 200;
 
-/// Tell the room — or the two people in the conversation — that a task ended
-/// without finishing.
-fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
-    // A title of nothing but stripped bytes would announce a task by no name at
-    // all, so it falls back the same way a missing title does.
-    let cleaned = title_for_wire(title);
-    let shown = match cleaned.trim().is_empty() {
-        true => task.act_id.as_str(),
-        false => cleaned.as_str(),
-    };
-    let text = format!("Task expired without completion: {shown}");
-    let sessions: Vec<String> = match task.venue.strip_prefix("dm:") {
-        // A DM task belongs to two people and nobody else hears about it.
+/// Every local session that should hear about something happening in a venue:
+/// a channel's members, or both ends of a direct conversation and nobody else.
+fn venue_sessions(state: &Arc<SharedState>, venue: &str) -> Vec<String> {
+    match venue.strip_prefix("dm:") {
         Some(pair) => {
             let dids: Vec<&str> = pair.split(',').collect();
             let by_did = state.did_sessions.lock();
@@ -247,10 +285,24 @@ fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &
         None => state
             .channels
             .lock()
-            .get(&task.venue)
+            .get(venue)
             .map(|ch| ch.members.iter().cloned().collect())
             .unwrap_or_default(),
+    }
+}
+
+/// Tell the room — or the two people in the conversation — that a task ended
+/// without finishing.
+fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
+    // A title of nothing but stripped bytes would announce a task by no name at
+    // all, so it falls back the same way a missing title does.
+    let cleaned = title_for_wire(title);
+    let shown = match cleaned.trim().is_empty() {
+        true => task.act_id.as_str(),
+        false => cleaned.as_str(),
     };
+    let text = format!("Task expired without completion: {shown}");
+    let sessions = venue_sessions(state, &task.venue);
     let target = match task.venue.starts_with("dm:") {
         true => None,
         false => Some(task.venue.as_str()),
@@ -262,6 +314,101 @@ fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &
             // channel, so a client files it where the conversation is.
             let to = target.unwrap_or("*");
             let _ = tx.try_send(format!(":{} NOTICE {to} :{text}\r\n", state.server_name));
+        }
+    }
+}
+
+/// Mint the home's receipt for an event it has just filed.
+///
+/// The RFC leaves the trigger open — "an action other servers are involved
+/// in" — and this server resolves it the only way one server can answer it:
+/// **always emit**. Receipts are small, replay is free, and a rule with no
+/// condition cannot be implemented wrong. When federation lands, a
+/// condition can be added; a missing receipt could never be added back.
+///
+/// Called for a step that moved the task and nothing else. An opener is not
+/// confirmed (nothing raced it — opening *is* the action), a report that
+/// leaves the task where it stood is not confirmed (there is no move to
+/// confirm), and this server's own events are not confirmed (they are already
+/// home-signed, which is the degenerate case the RFC names).
+///
+/// A failure to file is logged and swallowed: the event this would have
+/// confirmed is already on file, and refusing it after the fact would be a
+/// second wrong.
+fn mint_receipt(
+    state: &Arc<SharedState>,
+    kind: &str,
+    act_id: &str,
+    subject: &str,
+    venue: &str,
+) -> Option<Receipt> {
+    let subject_tag = format!(
+        "+freeq.at/{}",
+        freeq_sdk::act_transitions::confirmation_subject_tag()
+    );
+    let (tags, written) = file_own_event(
+        state,
+        kind,
+        freeq_sdk::act_transitions::confirmation_verb(),
+        act_id,
+        &[(subject_tag.as_str(), subject)],
+        venue,
+    )?;
+    match written {
+        crate::db::ActWrite::Recorded => Some(Receipt {
+            tags,
+            venue: venue.to_string(),
+        }),
+        other => {
+            tracing::warn!(
+                act_id = %act_id, subject = %subject, venue = %venue, outcome = ?other,
+                "Could not file the receipt for a task event"
+            );
+            None
+        }
+    }
+}
+
+/// Put a filed receipt on the wire, to the same people the event it confirms
+/// reached.
+///
+/// Gated exactly as every act event is: a connection that did not ask for
+/// `freeq.at/act` gets no receipts either. There is no companion PRIVMSG — the
+/// confirmed event's companion already told the humans, and a receipt is
+/// machine record.
+///
+/// `target` is the one the confirmed event arrived on, so both lines are filed
+/// in the same place by whatever renders them. In a direct conversation that
+/// target is whatever the sender addressed, which is the known limitation the
+/// expiry notice states too: a server-authored line in a DM names the thread
+/// from the sender's side, and the reader's client has to know that.
+pub(super) fn broadcast_receipt(state: &Arc<SharedState>, receipt: &Receipt, target: &str) {
+    let did = crate::server::server_did(&state.server_name);
+    let time_tag = chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S.000Z")
+        .to_string();
+    // Spoken by the server under its own name, the way a NOTICE from the
+    // expiry sweep is: the receipt's authorship is the whole point of it.
+    let lines = super::messaging::TagmsgLines::build(
+        &receipt.tags,
+        &state.server_name,
+        target,
+        &time_tag,
+        Some(&did),
+    );
+    let sessions = venue_sessions(state, &receipt.venue);
+    let tag_caps = state.cap_message_tags.lock();
+    let time_caps = state.cap_server_time.lock();
+    let acct_caps = state.cap_account_tag.lock();
+    let act_caps = state.cap_act.lock();
+    let conns = state.connections.lock();
+    for session in &sessions {
+        if !tag_caps.contains(session) || !act_caps.contains(session) {
+            continue;
+        }
+        if let Some(tx) = conns.get(session) {
+            let line = lines.pick(time_caps.contains(session), acct_caps.contains(session));
+            let _ = tx.try_send(line.to_string());
         }
     }
 }
@@ -665,6 +812,29 @@ pub(super) fn gate(
         .map(String::as_str)
         .unwrap_or("");
 
+    // ── The one verb no sender writes ──
+    //
+    // A receipt is this server's record of an event it filed, so a client
+    // sending one is answered before the kind's table is consulted at all.
+    // Falling through to UNKNOWN_VERB would say the kind is merely missing a
+    // row for `confirm` — and a kind adding its own is the thing the RFC
+    // forbids. The code is the one every wrong-hands refusal uses; only the
+    // sentence is particular.
+    if freeq_sdk::act_transitions::is_confirmation(verb) {
+        tracing::debug!(
+            session = %conn.id, did = %did, kind = %kind,
+            "Refused a confirmation from a sender"
+        );
+        refuse(
+            conn,
+            "TAGMSG",
+            "WRONG_SENDER",
+            "Only the action's home confirms it",
+            state,
+        );
+        return Gate::Refused;
+    }
+
     // Opening a task and moving one are different questions. The opener is
     // the only move that can be judged in full here: it needs no prior state,
     // because there is no prior task. For everything else this step can only
@@ -755,11 +925,28 @@ pub(super) fn gate(
         })
     });
 
+    // The receipt this server owes for the event, if the event moved the task.
+    let mut receipt = None;
     match written {
         // No database attached: nothing to referee against, and nothing to
         // store. The message is still checked and delivered.
         None => {}
-        Some(crate::db::ActWrite::Filed { .. }) => {}
+        Some(crate::db::ActWrite::Filed { was: None, .. }) => {}
+        Some(crate::db::ActWrite::Filed {
+            was: Some(was),
+            state: landed,
+        }) => {
+            // A move, or a report that left the task where it stood. Only the
+            // first is confirmed: a receipt says "this is where the action now
+            // stands, and this server says so", and there is nothing to say
+            // when nothing changed.
+            if was != landed {
+                receipt = mint_receipt(state, kind, &act_id, &msgid, &venue);
+            }
+        }
+        // Not reachable from here — a sender's confirm was refused above —
+        // but the log's answer for one, and nothing to deliver either way.
+        Some(crate::db::ActWrite::Recorded) => {}
         Some(crate::db::ActWrite::UnknownTask) => {
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id,
@@ -801,6 +988,7 @@ pub(super) fn gate(
                     ("UNKNOWN_KIND", "This server does not know that task kind")
                 }
                 Refusal::UnknownVerb => ("UNKNOWN_VERB", "That task kind has no such step"),
+                Refusal::ClientConfirm => ("WRONG_SENDER", "Only the action's home confirms it"),
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,
@@ -834,7 +1022,7 @@ pub(super) fn gate(
         kind = %kind, verb = %verb, msgid = %msgid, act_id = %act_id,
         "Accepted a task message"
     );
-    Gate::Accepted
+    Gate::Accepted(receipt)
 }
 
 #[cfg(test)]

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -989,6 +989,17 @@ pub(super) fn gate(
                 }
                 Refusal::UnknownVerb => ("UNKNOWN_VERB", "That task kind has no such step"),
                 Refusal::ClientConfirm => ("WRONG_SENDER", "Only the action's home confirms it"),
+                Refusal::ReplacesNotOpener => (
+                    "REPLACES_NOT_OPENER",
+                    "Only a new action replaces an earlier one",
+                ),
+                Refusal::ReplacesMalformed => {
+                    ("REPLACES_MALFORMED", "That is not the id of an action")
+                }
+                Refusal::ReplacesNotTerminal => (
+                    "REPLACES_NOT_TERMINAL",
+                    "The action it replaces is not finished",
+                ),
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -251,6 +251,41 @@ pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -
     true
 }
 
+/// Close the review window on one task: sign the event, run it through the
+/// same check and storage every other event goes through, and let it go out.
+///
+/// The other clock, and the mirror of `expire_task` — the difference is what
+/// the log ends up saying. Work that was handed in and never answered is
+/// deemed accepted, under a verb of its own, because "the window you were
+/// told about closed" and "nobody touched this for a month" are different
+/// things to have on the record.
+///
+/// No notice to the room. The expiry sweep announces because a task ending
+/// unfinished is news nobody asked for; an acceptance is the ordinary end of
+/// the work, and the event itself is what says so.
+///
+/// Returns whether the task was accepted.
+pub(crate) fn auto_accept_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
+    let verb = freeq_sdk::act_transitions::REVIEW_TIMEOUT_VERB;
+    match file_own_event(state, &task.kind, verb, &task.act_id, &[], &task.venue) {
+        Some((_, crate::db::ActWrite::Filed { .. })) => {
+            tracing::info!(
+                act_id = %task.act_id, venue = %task.venue, state = %task.state,
+                "Review window closed; the work is accepted"
+            );
+            true
+        }
+        other => {
+            tracing::warn!(
+                act_id = %task.act_id, venue = %task.venue,
+                outcome = ?other.map(|(_, w)| w),
+                "Review sweep could not file its own event"
+            );
+            false
+        }
+    }
+}
+
 /// A title is text its sender chose, and this notice is built as a wire line
 /// rather than through `Message`, which escapes tag values on the way out. So
 /// the bytes that end a line — and every other control byte — come out here,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -260,15 +260,20 @@ pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -
 /// told about closed" and "nobody touched this for a month" are different
 /// things to have on the record.
 ///
-/// No notice to the room. The expiry sweep announces because a task ending
-/// unfinished is news nobody asked for; an acceptance is the ordinary end of
-/// the work, and the event itself is what says so.
+/// Announced to the room the way an expiry is: the event is the record, and
+/// the notice is how the people in the conversation hear that the window
+/// closed and the work stands accepted.
 ///
 /// Returns whether the task was accepted.
 pub(crate) fn auto_accept_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
     let verb = freeq_sdk::act_transitions::REVIEW_TIMEOUT_VERB;
     match file_own_event(state, &task.kind, verb, &task.act_id, &[], &task.venue) {
         Some((_, crate::db::ActWrite::Filed { .. })) => {
+            let title = state
+                .with_db(|db| db.act_task_title(&task.act_id))
+                .flatten()
+                .unwrap_or_else(|| task.act_id.clone());
+            announce_auto_accept(state, task, &title);
             tracing::info!(
                 act_id = %task.act_id, venue = %task.venue, state = %task.state,
                 "Review window closed; the work is accepted"
@@ -329,6 +334,17 @@ fn venue_sessions(state: &Arc<SharedState>, venue: &str) -> Vec<String> {
 /// Tell the room — or the two people in the conversation — that a task ended
 /// without finishing.
 fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
+    announce_ending(state, task, title, "Task expired without completion");
+}
+
+/// Tell the room the review window closed and the work stands accepted —
+/// the same line the expiry sweep speaks, with a different ending.
+fn announce_auto_accept(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
+    announce_ending(state, task, title, "Task accepted without review");
+}
+
+/// One notice, two endings: `what` is the sentence up to the colon.
+fn announce_ending(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str, what: &str) {
     // A title of nothing but stripped bytes would announce a task by no name at
     // all, so it falls back the same way a missing title does.
     let cleaned = title_for_wire(title);
@@ -336,7 +352,7 @@ fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &
         true => task.act_id.as_str(),
         false => cleaned.as_str(),
     };
-    let text = format!("Task expired without completion: {shown}");
+    let text = format!("{what}: {shown}");
     let sessions = venue_sessions(state, &task.venue);
     let target = match task.venue.starts_with("dm:") {
         true => None,

--- a/freeq-server/src/connection/messaging.rs
+++ b/freeq-server/src/connection/messaging.rs
@@ -671,7 +671,7 @@ pub(crate) fn verify_commit_reveal(
 ///
 /// The account forms are `None` for a guest — no DID, nothing to name — and
 /// such a sender's events fall back to the forms without it.
-struct TagmsgLines {
+pub(super) struct TagmsgLines {
     plain: String,
     with_time: String,
     account: Option<String>,
@@ -679,7 +679,7 @@ struct TagmsgLines {
 }
 
 impl TagmsgLines {
-    fn build(
+    pub(super) fn build(
         tags: &std::collections::HashMap<String, String>,
         hostmask: &str,
         target: &str,
@@ -711,7 +711,7 @@ impl TagmsgLines {
     }
 
     /// The form this receiver negotiated.
-    fn pick(&self, has_time: bool, wants_account: bool) -> &str {
+    pub(super) fn pick(&self, has_time: bool, wants_account: bool) -> &str {
         match (has_time, wants_account) {
             (true, true) => self.time_account.as_deref().unwrap_or(&self.with_time),
             (true, false) => &self.with_time,
@@ -1095,9 +1095,12 @@ pub(super) fn handle_tagmsg(
     // the mutation path does — otherwise a mix reads as a bad delete rather
     // than as the two documents it is. An accepted task message falls through
     // to the fan-out below, which sends it only where it was asked for.
-    let is_act = match super::act::gate(conn, target, tags, state) {
-        super::act::Gate::NotATaskMessage => false,
-        super::act::Gate::Accepted => true,
+    // A receipt travels with the event it confirms: filed by the gate beside
+    // it, and put on the wire after it, so a reader sees the move before this
+    // server's word about the move.
+    let (is_act, receipt) = match super::act::gate(conn, target, tags, state) {
+        super::act::Gate::NotATaskMessage => (false, None),
+        super::act::Gate::Accepted(receipt) => (true, receipt),
         super::act::Gate::Refused => return,
     };
 
@@ -1692,6 +1695,10 @@ pub(super) fn handle_tagmsg(
                 account: conn.authenticated_did.clone(),
             },
         );
+    }
+
+    if let Some(receipt) = receipt {
+        super::act::broadcast_receipt(state, &receipt, target);
     }
 }
 

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -6636,21 +6636,77 @@ impl Db {
         rows.collect()
     }
 
-    /// Live tasks whose last movement is older than `cutoff` — the sweep's
-    /// candidates.
+    /// Live tasks whose last movement is older than `cutoff` and whose state
+    /// is one of `states` — the review sweep's candidates.
     ///
     /// `updated` is what is measured, so a task that anyone touched recently
-    /// is not abandoned however old its opener is.
-    pub fn act_tasks_idle_since(&self, cutoff: i64, limit: usize) -> SqlResult<Vec<ActTask>> {
-        let mut stmt = self.conn.prepare(
+    /// is not abandoned however old its opener is. On a review window that is
+    /// exactly the behaviour wanted: asking for changes moves the task, which
+    /// stops the clock, and the next submission starts a fresh one.
+    pub fn act_tasks_idle_in_states(
+        &self,
+        states: &[&str],
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        self.act_tasks_idle(states, true, cutoff, limit)
+    }
+
+    /// Live tasks idle since `cutoff` whose state is **not** one of `states` —
+    /// the expiry sweep's candidates.
+    ///
+    /// The complement of the query above, so the two clocks cannot both claim
+    /// a task. They pull in opposite directions: a review window favours the
+    /// worker and the idle limit is neutral, so a task sitting inside its
+    /// review window must not be expired out from under it by whichever of
+    /// the two numbers an operator happened to set lower.
+    pub fn act_tasks_idle_outside_states(
+        &self,
+        states: &[&str],
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        self.act_tasks_idle(states, false, cutoff, limit)
+    }
+
+    fn act_tasks_idle(
+        &self,
+        states: &[&str],
+        within: bool,
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        // A state name is a rules-file constant, never anything a sender
+        // wrote, but the list is built at runtime — so the placeholders are
+        // counted rather than the values interpolated. Numbered rather than
+        // bare: SQLite numbers a bare `?` from the highest index it has seen,
+        // which would collide with the `?2` the LIMIT further down already
+        // holds.
+        let holes = (0..states.len())
+            .map(|i| format!("?{}", i + 3))
+            .collect::<Vec<_>>()
+            .join(",");
+        let test = match (states.is_empty(), within) {
+            // Nothing to be within, and everything is outside nothing.
+            (true, true) => "0".to_string(),
+            (true, false) => "1".to_string(),
+            (false, true) => format!("state IN ({holes})"),
+            (false, false) => format!("state NOT IN ({holes})"),
+        };
+        let mut stmt = self.conn.prepare(&format!(
             "SELECT act_id, kind, venue, origin, state, offerer, offeree, assignee,
                     caps, deadline, replaces, updated
                FROM act_actions
-              WHERE updated < ?1
+              WHERE updated < ?1 AND {test}
               ORDER BY updated
-              LIMIT ?2",
-        )?;
-        let rows = stmt.query_map(params![cutoff, limit as i64], |row| {
+              LIMIT ?2"
+        ))?;
+        let limit = limit as i64;
+        let mut args: Vec<&dyn rusqlite::ToSql> = vec![&cutoff, &limit];
+        for state in states {
+            args.push(state);
+        }
+        let rows = stmt.query_map(rusqlite::params_from_iter(args), |row| {
             Ok(ActTask {
                 act_id: row.get(0)?,
                 kind: row.get(1)?,

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3164,7 +3164,7 @@ mod tests {
         assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
     }
 
-    /// The loser bid and was not taken, so the work is not theirs to finish.
+    /// The loser bid and was not taken, so the work is not theirs to hand in.
     #[test]
     fn the_loser_of_a_bounty_cannot_finish_the_work() {
         let db = Db::open_memory().unwrap();
@@ -3174,7 +3174,7 @@ mod tests {
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 20);
 
         assert_eq!(
-            bounty_step(&db, "complete", MALLORY, "B1", "C1", None, "#ops", 21),
+            bounty_step(&db, "submit", MALLORY, "B1", "C1", None, "#ops", 21),
             ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender)
         );
         assert_eq!(
@@ -3183,10 +3183,165 @@ mod tests {
             "an awarded bounty takes no further bids"
         );
         assert!(matches!(
-            bounty_step(&db, "complete", SCHOLAR, "B1", "C2", None, "#ops", 23),
+            bounty_step(&db, "submit", SCHOLAR, "B1", "C2", None, "#ops", 23),
             ActWrite::Filed { .. }
         ));
-        assert_eq!(db.act_task("B1").unwrap(), None, "completed and gone");
+        assert!(matches!(
+            bounty_step(&db, "accept-work", ELIZA, "B1", "C3", None, "#ops", 24),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(db.act_task("B1").unwrap(), None, "accepted and gone");
+    }
+
+    /// The difference between this kind and a handoff: the worker says the
+    /// work is in, and the poster says whether it is done. A submission
+    /// parks the bounty in review and moves nothing else.
+    #[test]
+    fn a_bounty_ends_on_the_posters_word_and_not_the_workers() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 12);
+
+        assert_eq!(
+            bounty_step(&db, "submit", SCHOLAR, "B1", "S1", None, "#ops", 13),
+            ActWrite::Filed {
+                was: Some("assigned".into()),
+                state: "under_review".into()
+            }
+        );
+        assert_eq!(
+            bounty_step(&db, "accept-work", SCHOLAR, "B1", "A1", None, "#ops", 14),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender),
+            "the worker cannot sign off on their own work"
+        );
+        // Sent back, worked again, handed in again.
+        assert_eq!(
+            bounty_step(&db, "revise", ELIZA, "B1", "R1", None, "#ops", 15),
+            ActWrite::Filed {
+                was: Some("under_review".into()),
+                state: "assigned".into()
+            }
+        );
+        assert!(matches!(
+            bounty_step(&db, "submit", SCHOLAR, "B1", "S2", None, "#ops", 16),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            bounty_step(&db, "accept-work", ELIZA, "B1", "A2", None, "#ops", 17),
+            ActWrite::Filed {
+                was: Some("under_review".into()),
+                state: "accepted".into()
+            }
+        );
+        assert_eq!(
+            db.act_task("B1").unwrap(),
+            None,
+            "accepted is the end of it"
+        );
+    }
+
+    /// Once work is in, the poster's only moves are taking it and sending it
+    /// back. Cancelling delivered work is the cheap unfairness the table
+    /// closes: the row simply does not reach under_review.
+    #[test]
+    fn delivered_work_is_not_something_the_poster_can_cancel() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 12);
+        // Before it lands, cancelling is the poster's to do.
+        assert!(matches!(
+            bounty_step(&db, "cancel", ELIZA, "B1", "X0", None, "#ops", 13),
+            ActWrite::Filed { .. }
+        ));
+
+        bounty_offer(&db, "B2", "#ops", 20);
+        bounty_step(&db, "bid", SCHOLAR, "B2", "BID1", None, "#ops", 21);
+        bounty_step(&db, "award", ELIZA, "B2", "AW2", Some("BID1"), "#ops", 22);
+        bounty_step(&db, "submit", SCHOLAR, "B2", "S1", None, "#ops", 23);
+        assert_eq!(
+            bounty_step(&db, "cancel", ELIZA, "B2", "X1", None, "#ops", 24),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::IllegalStep)
+        );
+        assert_eq!(db.act_task("B2").unwrap().unwrap().state, "under_review");
+    }
+
+    /// The worker's exit, from either state they may hold the work in. It is
+    /// terminal, so re-running the job is a new bounty naming this one.
+    #[test]
+    fn the_worker_forfeits_work_they_hold_before_or_after_handing_it_in() {
+        let db = Db::open_memory().unwrap();
+        for (task, submit_first) in [("B1", false), ("B2", true)] {
+            bounty_offer(&db, task, "#ops", 10);
+            bounty_step(
+                &db,
+                "bid",
+                SCHOLAR,
+                task,
+                &format!("{task}BID"),
+                None,
+                "#ops",
+                11,
+            );
+            bounty_step(
+                &db,
+                "award",
+                ELIZA,
+                task,
+                &format!("{task}AW"),
+                Some(&format!("{task}BID")),
+                "#ops",
+                12,
+            );
+            if submit_first {
+                bounty_step(
+                    &db,
+                    "submit",
+                    SCHOLAR,
+                    task,
+                    &format!("{task}S"),
+                    None,
+                    "#ops",
+                    13,
+                );
+            }
+            assert_eq!(
+                bounty_step(
+                    &db,
+                    "forfeit",
+                    ELIZA,
+                    task,
+                    &format!("{task}FE"),
+                    None,
+                    "#ops",
+                    14
+                ),
+                ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender),
+                "{task}: the poster does not forfeit the worker's work"
+            );
+            assert_eq!(
+                bounty_step(
+                    &db,
+                    "forfeit",
+                    SCHOLAR,
+                    task,
+                    &format!("{task}F"),
+                    None,
+                    "#ops",
+                    15
+                ),
+                ActWrite::Filed {
+                    was: Some(match submit_first {
+                        true => "under_review".to_string(),
+                        false => "assigned".to_string(),
+                    }),
+                    state: "forfeited".into()
+                },
+                "{task}"
+            );
+            assert_eq!(db.act_task(task).unwrap(), None, "{task}: terminal");
+        }
     }
 
     /// An award points at one event, and only a bid on this action answers.
@@ -3402,6 +3557,11 @@ mod tests {
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
         bounty_step(&db, "progress", MALLORY, "B1", "PR", None, "#ops", 54);
+        // …and into review and back out again, so the rebuild replays the
+        // states only a bounty has.
+        bounty_step(&db, "submit", MALLORY, "B1", "SB", None, "#ops", 55);
+        bounty_step(&db, "revise", ELIZA, "B1", "RV", None, "#ops", 56);
+        bounty_step(&db, "submit", MALLORY, "B1", "SB2", None, "#ops", 57);
 
         let venues = vec!["#ops".to_string(), "#other".to_string()];
         let mut live = db.act_tasks(&venues, None, None, None, 100).unwrap();

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3038,6 +3038,173 @@ mod tests {
         );
     }
 
+    // ── bounty: the second kind, and no code of its own ───────────────────
+
+    fn bounty_offer(db: &Db, id: &str, venue: &str, ts: i64) -> ActWrite {
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "bounty"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-title", "index the archive"),
+            ],
+            venue,
+            id,
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: id,
+            opens: true,
+            venue,
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
+    /// A bounty step. `to` is the winner an award names — the field the rules
+    /// file points `assignee_from` at.
+    fn bounty_step(
+        db: &Db,
+        verb: &str,
+        actor: &str,
+        task: &str,
+        id: &str,
+        to: Option<&str>,
+        venue: &str,
+        ts: i64,
+    ) -> ActWrite {
+        let mut tags = vec![
+            ("+freeq.at/act", "bounty"),
+            ("+freeq.at/act-verb", verb),
+            ("+freeq.at/from", actor),
+            ("+freeq.at/act-id", task),
+        ];
+        if let Some(to) = to {
+            tags.push(("+freeq.at/act-to", to));
+        }
+        let canonical = act_doc(&tags, venue, id);
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: task,
+            opens: false,
+            venue,
+            actor,
+            from_system: false,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
+    /// The whole point of the second kind: bids pile up without moving
+    /// anything, and the award assigns the DID it names rather than the one
+    /// who sent it.
+    #[test]
+    fn a_bounty_takes_bids_and_the_award_assigns_the_did_it_names() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        for (i, bidder) in [SCHOLAR, MALLORY].iter().enumerate() {
+            assert_eq!(
+                bounty_step(
+                    &db,
+                    "bid",
+                    bidder,
+                    "B1",
+                    &format!("BID{i}"),
+                    None,
+                    "#ops",
+                    11 + i as i64
+                ),
+                ActWrite::Filed {
+                    was: Some("open".into()),
+                    state: "open".into()
+                },
+                "a bid is additive: it leaves the bounty exactly where it was"
+            );
+        }
+        assert_eq!(db.act_task_events("B1").unwrap().len(), 3, "all on file");
+
+        assert_eq!(
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20),
+            ActWrite::Filed {
+                was: Some("open".into()),
+                state: "assigned".into()
+            }
+        );
+        let task = db.act_task("B1").unwrap().unwrap();
+        assert_eq!(
+            task.assignee.as_deref(),
+            Some(SCHOLAR),
+            "the winner the poster named, not the poster who named them"
+        );
+        assert_eq!(task.offerer, ELIZA);
+    }
+
+    /// An award naming nobody assigns nobody, so the transition is illegal
+    /// without the field its row requires.
+    #[test]
+    fn an_award_that_names_no_winner_is_refused() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        assert_eq!(
+            bounty_step(&db, "award", ELIZA, "B1", "AW", None, "#ops", 20),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::MissingRequirement(
+                "act-to"
+            ))
+        );
+        assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
+    }
+
+    /// The loser bid and did not win, so the work is not theirs to finish.
+    #[test]
+    fn the_loser_of_a_bounty_cannot_finish_the_work() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 12);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20);
+
+        assert_eq!(
+            bounty_step(&db, "complete", MALLORY, "B1", "C1", None, "#ops", 21),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender)
+        );
+        assert_eq!(
+            bounty_step(&db, "bid", MALLORY, "B1", "BID2", None, "#ops", 22),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::IllegalStep),
+            "an awarded bounty takes no further bids"
+        );
+        assert!(matches!(
+            bounty_step(&db, "complete", SCHOLAR, "B1", "C2", None, "#ops", 23),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(db.act_task("B1").unwrap(), None, "completed and gone");
+    }
+
+    /// The server never picks, and that cuts both ways: nothing here checks
+    /// that the awarded DID ever bid. The poster's signed choice is the
+    /// record.
+    #[test]
+    fn an_award_may_name_someone_who_never_bid() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        assert!(matches!(
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(MALLORY), "#ops", 20),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            db.act_task("B1").unwrap().unwrap().assignee.as_deref(),
+            Some(MALLORY)
+        );
+    }
+
     // ── the revival relation ──────────────────────────────────────────────
 
     /// An opener that names a finished action it revives.
@@ -3190,6 +3357,13 @@ mod tests {
 
         offer(&db, "T4", "#ops", None, 40);
 
+        // A bounty too: its award assigns the DID it names rather than the
+        // sender, and a rebuild that read the sender would disagree with the
+        // live row on exactly that column.
+        bounty_offer(&db, "B1", "#ops", 50);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID0", None, "#ops", 51);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 52);
+
         let venues = vec!["#ops".to_string(), "#other".to_string()];
         let mut live = db.act_tasks(&venues, None, None, None, 100).unwrap();
         live.sort_by(|a, b| a.act_id.cmp(&b.act_id));
@@ -3198,8 +3372,8 @@ mod tests {
 
         assert_eq!(
             live.len(),
-            4,
-            "the declined one left the view; its revival did not"
+            5,
+            "the declined one left the view; its revival and the bounty did not"
         );
         assert_eq!(rebuilt, live);
     }
@@ -5962,7 +6136,14 @@ impl Db {
 
         // What the event does to the task, where the task stood before it, and
         // what it looks like now.
+        //
+        // `kind` is the *task's*, which for an opener is the one the event
+        // declares and for a follow-up is the one already on file. They should
+        // agree, and nothing downstream depends on their agreeing: a step that
+        // named the wrong kind is refereed by the task's rules and
+        // materialized by them too, rather than by whatever the sender wrote.
         let mut was: Option<String> = None;
+        let mut kind = view.kind.clone();
         let landed = if ev.opens {
             // The opener's own id is the task's id. A second opener under the
             // same id is the log's duplicate case, handled by the write below.
@@ -5987,9 +6168,11 @@ impl Db {
             if task.venue != ev.venue {
                 return Ok(ActWrite::WrongVenue);
             }
+            let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
             let event = rules::Event {
                 verb: &view.verb,
                 msgid: ev.event_id,
+                fields: &present,
             };
             let sender = rules::Sender {
                 did: ev.actor,
@@ -6006,6 +6189,7 @@ impl Db {
             match rules::check(&checked, &event, &sender) {
                 Ok(state) => {
                     was = Some(task.state.clone());
+                    kind = task.kind.clone();
                     state.to_string()
                 }
                 Err(refusal) => return Ok(ActWrite::Refused(refusal)),
@@ -6024,7 +6208,7 @@ impl Db {
         if !self.insert_event(&record)? {
             return Ok(ActWrite::Duplicate);
         }
-        self.materialize_act(ev, &view, &landed)?;
+        self.materialize_act(ev, &view, &kind, was.as_deref(), &landed)?;
         tx.commit()?;
         Ok(ActWrite::Filed { was, state: landed })
     }
@@ -6032,16 +6216,21 @@ impl Db {
     /// Move the view to match an event that was just accepted.
     ///
     /// The rules, in full: an opener creates the row and sets what the offer
-    /// declared; whoever moves a task into `assigned` becomes its assignee;
+    /// declared; a step that moves a task into `assigned` names its assignee;
     /// a terminal state removes the row, because the view holds live tasks and
     /// the log holds the history.
+    ///
+    /// `was` is the state the task came from — what the rules file is asked
+    /// about when it says where a transition's assignee comes from.
     fn materialize_act(
         &self,
         ev: &ActEvent<'_>,
         view: &crate::events::ActView,
+        kind: &str,
+        was: Option<&str>,
         landed: &str,
     ) -> SqlResult<()> {
-        if freeq_sdk::act_transitions::is_terminal(&view.kind, landed) {
+        if freeq_sdk::act_transitions::is_terminal(kind, landed) {
             self.conn.execute(
                 "DELETE FROM act_actions WHERE act_id = ?1",
                 params![ev.act_id],
@@ -6056,7 +6245,7 @@ impl Db {
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
                 params![
                     ev.act_id,
-                    view.kind,
+                    kind,
                     ev.venue,
                     ev.origin.unwrap_or(""),
                     landed,
@@ -6070,9 +6259,26 @@ impl Db {
             )?;
             return Ok(());
         }
-        // Whoever moves a task into `assigned` becomes its assignee — and only
-        // the first one does, so a progress report does not reassign the work
-        // it is reporting on.
+        // A step that moves a task into `assigned` names its assignee — and
+        // only the first one does, so a progress report does not reassign the
+        // work it is reporting on.
+        //
+        // Who it names is data. Accepting and claiming make the actor the
+        // assignee; a bounty's award names a winner in `act-to`, because the
+        // poster picks rather than becomes. A row whose field is absent names
+        // nobody and leaves the work unassigned — fail closed, though a
+        // `requires` on the same row is what actually keeps that from
+        // happening.
+        let assignee: Option<&str> = match freeq_sdk::act_transitions::assignee_source(
+            kind,
+            &view.verb,
+            was.unwrap_or_default(),
+        ) {
+            freeq_sdk::act_transitions::AssigneeSource::Actor => Some(ev.actor),
+            freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
+                view.fields.get(name).map(String::as_str)
+            }
+        };
         self.conn.execute(
             "UPDATE act_actions
                 SET state = ?2,
@@ -6080,7 +6286,7 @@ impl Db {
                                     THEN ?4 ELSE assignee END,
                     updated = ?5
               WHERE act_id = ?1",
-            params![ev.act_id, landed, landed, ev.actor, ev.timestamp],
+            params![ev.act_id, landed, landed, assignee, ev.timestamp],
         )?;
         Ok(())
     }
@@ -6382,6 +6588,8 @@ impl Db {
             }
             let act_id = row.subject.clone().unwrap_or_else(|| row.event_id.clone());
             let opens = row.subject.is_none();
+            let mut was: Option<String> = None;
+            let mut kind = view.kind.clone();
             let landed = if opens {
                 match freeq_sdk::act_transitions::check_open(
                     &view.kind,
@@ -6396,6 +6604,9 @@ impl Db {
                 let Some(task) = live.get(&act_id) else {
                     continue;
                 };
+                was = Some(task.state.clone());
+                kind = task.kind.clone();
+                let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
                 match freeq_sdk::act_transitions::check(
                     &freeq_sdk::act_transitions::Task {
                         kind: &task.kind,
@@ -6408,6 +6619,7 @@ impl Db {
                     &freeq_sdk::act_transitions::Event {
                         verb: &view.verb,
                         msgid: &row.event_id,
+                        fields: &present,
                     },
                     &freeq_sdk::act_transitions::Sender {
                         did: &row.actor,
@@ -6421,7 +6633,7 @@ impl Db {
                     Err(_) => continue,
                 }
             };
-            if freeq_sdk::act_transitions::is_terminal(&view.kind, &landed) {
+            if freeq_sdk::act_transitions::is_terminal(&kind, &landed) {
                 live.remove(&act_id);
                 continue;
             }
@@ -6430,7 +6642,7 @@ impl Db {
                     act_id.clone(),
                     ActTask {
                         act_id,
-                        kind: view.kind.clone(),
+                        kind: kind.clone(),
                         venue: row.venue.clone(),
                         origin: row.origin.clone().unwrap_or_default(),
                         state: landed,
@@ -6445,7 +6657,21 @@ impl Db {
                 );
             } else if let Some(task) = live.get_mut(&act_id) {
                 if task.assignee.is_none() && landed == "assigned" {
-                    task.assignee = Some(row.actor.clone());
+                    // The same reading ingress does: who a step assigns is
+                    // what the rules file says — the actor unless a row names
+                    // a field instead.
+                    task.assignee = match freeq_sdk::act_transitions::assignee_source(
+                        &kind,
+                        &view.verb,
+                        was.as_deref().unwrap_or_default(),
+                    ) {
+                        freeq_sdk::act_transitions::AssigneeSource::Actor => {
+                            Some(row.actor.clone())
+                        }
+                        freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
+                            view.fields.get(name).cloned()
+                        }
+                    };
                 }
                 task.state = landed;
                 task.updated = row.timestamp;

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -6635,7 +6635,7 @@ impl Db {
             was.unwrap_or_default(),
         ) {
             freeq_sdk::act_transitions::AssigneeSource::Actor => Some(ev.actor),
-            freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named,
+            freeq_sdk::act_transitions::AssigneeSource::AuthorOf(_) => named,
             freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                 view.fields.get(name).map(String::as_str)
             }
@@ -7168,7 +7168,7 @@ impl Db {
                         freeq_sdk::act_transitions::AssigneeSource::Actor => {
                             Some(row.actor.clone())
                         }
-                        freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named.clone(),
+                        freeq_sdk::act_transitions::AssigneeSource::AuthorOf(_) => named.clone(),
                         freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                             view.fields.get(name).cloned()
                         }

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3066,6 +3066,35 @@ mod tests {
         .unwrap()
     }
 
+    /// A bounty whose offer names how long it takes bids.
+    fn bounty_offer_with_cutoff(db: &Db, id: &str, venue: &str, cutoff: i64, ts: i64) -> ActWrite {
+        let cutoff = cutoff.to_string();
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "bounty"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-title", "index the archive"),
+                ("+freeq.at/act-bid-deadline", &cutoff),
+            ],
+            venue,
+            id,
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: id,
+            opens: true,
+            venue,
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
     /// A bounty step. `accepts` is the bid an award takes — the event the
     /// rules file points `assignee_from` at, whose author gets the work.
     fn bounty_step(
@@ -3344,6 +3373,92 @@ mod tests {
         }
     }
 
+    /// A bounty takes bids until its own cutoff, which is read back out of
+    /// the opener's bytes like every other tag the view has no column for.
+    #[test]
+    fn a_bounty_stops_taking_bids_at_the_cutoff_its_offer_named() {
+        let db = Db::open_memory().unwrap();
+        // 1788000000 unix seconds, as the fixtures use it, and the two ids
+        // that sit either side of the tolerance around it.
+        const TOO_LATE: &str = "01M16HSC58ACCEPTTOOLATE000";
+        const AT_EDGE: &str = "01M16HSB60ACCEPTATEDGE0000";
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "bounty"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-title", "index the archive"),
+                ("+freeq.at/act-bid-deadline", "1788000000"),
+            ],
+            "#ops",
+            "B1",
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: "B1",
+            act_id: "B1",
+            opens: true,
+            venue: "#ops",
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: 10,
+        })
+        .unwrap();
+        assert_eq!(db.act_task_bid_deadline("B1").unwrap(), Some(1_788_000_000));
+
+        assert_eq!(
+            bounty_step(&db, "bid", SCHOLAR, "B1", TOO_LATE, None, "#ops", 11),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::DeadlinePassed)
+        );
+        assert!(matches!(
+            bounty_step(&db, "bid", SCHOLAR, "B1", AT_EDGE, None, "#ops", 12),
+            ActWrite::Filed { .. }
+        ));
+        // Bidding closing does not stop the poster picking: the award is
+        // bound by act-deadline, which this offer never named.
+        assert!(matches!(
+            bounty_step(
+                &db,
+                "award",
+                ELIZA,
+                "B1",
+                TOO_LATE,
+                Some(AT_EDGE),
+                "#ops",
+                13
+            ),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            db.act_task("B1").unwrap().unwrap().assignee.as_deref(),
+            Some(SCHOLAR)
+        );
+    }
+
+    /// A bounty whose offer named no cutoff takes bids for as long as it
+    /// stands.
+    #[test]
+    fn a_bounty_with_no_cutoff_takes_bids_whenever_they_arrive() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        assert_eq!(db.act_task_bid_deadline("B1").unwrap(), None);
+        assert!(matches!(
+            bounty_step(
+                &db,
+                "bid",
+                SCHOLAR,
+                "B1",
+                "01M16HSC58ACCEPTTOOLATE000",
+                None,
+                "#ops",
+                11
+            ),
+            ActWrite::Filed { .. }
+        ));
+    }
+
     /// An award points at one event, and only a bid on this action answers.
     /// The bounty's own opener is not one, whatever else it is.
     #[test]
@@ -3553,6 +3668,19 @@ mod tests {
         // sender, or the first bid, would disagree with the live row on
         // exactly that column — so there are two bids and the second is taken.
         bounty_offer(&db, "B1", "#ops", 50);
+        // …and one whose offer named a bid cutoff, which the rebuild has to
+        // read back out of the opener exactly as ingress did.
+        bounty_offer_with_cutoff(&db, "B3", "#ops", 1_788_000_000, 50);
+        bounty_step(
+            &db,
+            "bid",
+            SCHOLAR,
+            "B3",
+            "01M16HSB60ACCEPTATEDGE0000",
+            None,
+            "#ops",
+            51,
+        );
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 51);
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
@@ -3571,8 +3699,8 @@ mod tests {
 
         assert_eq!(
             live.len(),
-            5,
-            "the declined one left the view; its revival and the bounty did not"
+            6,
+            "the declined one left the view; its revival and the bounties did not"
         );
         assert_eq!(rebuilt, live);
     }
@@ -6401,6 +6529,11 @@ impl Db {
                 offeree: task.offeree.as_deref(),
                 assignee: task.assignee.as_deref(),
                 deadline: task.deadline,
+                // Read back out of the opener rather than carried in a
+                // column: it is one of the open set of act tags, and the view
+                // holds only what it needs to referee. The bytes are the
+                // record and they still have it.
+                bid_deadline: self.act_task_bid_deadline(ev.act_id)?,
             };
             match rules::check(&checked, &event, &sender) {
                 Ok(state) => {
@@ -6748,6 +6881,32 @@ impl Db {
         }))
     }
 
+    /// The bid cutoff an offer declared, read back out of the opener's bytes.
+    ///
+    /// The same reading `act_task_title` does, for the same reason: a second
+    /// deadline is one of the open set of act tags, and the view carries only
+    /// the columns it referees on. A value nobody can read as a number is a
+    /// cutoff this server cannot enforce, so it answers as absent — the tag
+    /// stays in the canonical either way.
+    pub fn act_task_bid_deadline(&self, act_id: &str) -> SqlResult<Option<i64>> {
+        let canonical: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT canonical FROM events WHERE kind = 'act' AND event_id = ?1",
+                params![act_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(canonical.and_then(|c| {
+            serde_json::from_str::<serde_json::Value>(&c)
+                .ok()?
+                .get("act-bid-deadline")
+                .and_then(|v| v.as_str())?
+                .parse::<i64>()
+                .ok()
+        }))
+    }
+
     /// Every venue that currently holds a live task.
     ///
     /// The listing endpoint runs each of these through the same authorization
@@ -6888,6 +7047,11 @@ impl Db {
         // replayed its bid is here.
         let mut bids: std::collections::BTreeMap<(String, String), String> =
             std::collections::BTreeMap::new();
+        // And each opener's bid cutoff, which ingress reads back out of the
+        // opener's bytes. Kept here rather than looked up, because the bytes
+        // in question are the ones this replay has already passed.
+        let mut bid_deadlines: std::collections::BTreeMap<String, i64> =
+            std::collections::BTreeMap::new();
         for row in rows {
             let Some(view) = crate::events::derive_act_view(&row.canonical) else {
                 continue;
@@ -6935,6 +7099,7 @@ impl Db {
                         offeree: task.offeree.as_deref(),
                         assignee: task.assignee.as_deref(),
                         deadline: task.deadline,
+                        bid_deadline: bid_deadlines.get(&act_id).copied(),
                     },
                     &freeq_sdk::act_transitions::Event {
                         verb: &view.verb,
@@ -6966,6 +7131,13 @@ impl Db {
                 continue;
             }
             if opens {
+                if let Some(cutoff) = view
+                    .fields
+                    .get("act-bid-deadline")
+                    .and_then(|v| v.parse::<i64>().ok())
+                {
+                    bid_deadlines.insert(act_id.clone(), cutoff);
+                }
                 live.insert(
                     act_id.clone(),
                     ActTask {

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3066,15 +3066,15 @@ mod tests {
         .unwrap()
     }
 
-    /// A bounty step. `to` is the winner an award names — the field the rules
-    /// file points `assignee_from` at.
+    /// A bounty step. `accepts` is the bid an award takes — the event the
+    /// rules file points `assignee_from` at, whose author gets the work.
     fn bounty_step(
         db: &Db,
         verb: &str,
         actor: &str,
         task: &str,
         id: &str,
-        to: Option<&str>,
+        accepts: Option<&str>,
         venue: &str,
         ts: i64,
     ) -> ActWrite {
@@ -3084,8 +3084,8 @@ mod tests {
             ("+freeq.at/from", actor),
             ("+freeq.at/act-id", task),
         ];
-        if let Some(to) = to {
-            tags.push(("+freeq.at/act-to", to));
+        if let Some(accepts) = accepts {
+            tags.push(("+freeq.at/act-accepts", accepts));
         }
         let canonical = act_doc(&tags, venue, id);
         db.apply_act_event(&ActEvent {
@@ -3104,10 +3104,10 @@ mod tests {
     }
 
     /// The whole point of the second kind: bids pile up without moving
-    /// anything, and the award assigns the DID it names rather than the one
-    /// who sent it.
+    /// anything, and the award assigns whoever wrote the bid it names rather
+    /// than the one who sent it.
     #[test]
-    fn a_bounty_takes_bids_and_the_award_assigns_the_did_it_names() {
+    fn a_bounty_award_assigns_the_author_of_the_bid_it_names() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         for (i, bidder) in [SCHOLAR, MALLORY].iter().enumerate() {
@@ -3131,8 +3131,10 @@ mod tests {
         }
         assert_eq!(db.act_task_events("B1").unwrap().len(), 3, "all on file");
 
+        // The second bid, so the answer cannot come from "the first one" or
+        // from the sender.
         assert_eq!(
-            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20),
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 20),
             ActWrite::Filed {
                 was: Some("open".into()),
                 state: "assigned".into()
@@ -3141,35 +3143,35 @@ mod tests {
         let task = db.act_task("B1").unwrap().unwrap();
         assert_eq!(
             task.assignee.as_deref(),
-            Some(SCHOLAR),
-            "the winner the poster named, not the poster who named them"
+            Some(MALLORY),
+            "whoever wrote the bid the poster took, not the poster who took it"
         );
         assert_eq!(task.offerer, ELIZA);
     }
 
-    /// An award naming nobody assigns nobody, so the transition is illegal
+    /// An award naming no bid takes nothing, so the transition is illegal
     /// without the field its row requires.
     #[test]
-    fn an_award_that_names_no_winner_is_refused() {
+    fn an_award_that_names_no_bid_is_refused() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         assert_eq!(
             bounty_step(&db, "award", ELIZA, "B1", "AW", None, "#ops", 20),
             ActWrite::Refused(freeq_sdk::act_transitions::Refusal::MissingRequirement(
-                "act-to"
+                "act-accepts"
             ))
         );
         assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
     }
 
-    /// The loser bid and did not win, so the work is not theirs to finish.
+    /// The loser bid and was not taken, so the work is not theirs to finish.
     #[test]
     fn the_loser_of_a_bounty_cannot_finish_the_work() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 12);
-        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 20);
 
         assert_eq!(
             bounty_step(&db, "complete", MALLORY, "B1", "C1", None, "#ops", 21),
@@ -3187,16 +3189,49 @@ mod tests {
         assert_eq!(db.act_task("B1").unwrap(), None, "completed and gone");
     }
 
-    /// The server never picks, and that cuts both ways: nothing here checks
-    /// that the awarded DID ever bid. The poster's signed choice is the
-    /// record.
+    /// An award points at one event, and only a bid on this action answers.
+    /// The bounty's own opener is not one, whatever else it is.
     #[test]
-    fn an_award_may_name_someone_who_never_bid() {
+    fn an_award_naming_the_bounty_itself_is_refused() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        assert_eq!(
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("B1"), "#ops", 20),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::AcceptsNotABid)
+        );
+        assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
+    }
+
+    /// A bid is a bid on one bounty. Naming another bounty's — or one nobody
+    /// ever filed — takes nothing here.
+    #[test]
+    fn an_award_naming_a_bid_on_another_bounty_is_refused() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_offer(&db, "B2", "#ops", 11);
+        bounty_step(&db, "bid", SCHOLAR, "B2", "ELSEWHERE", None, "#ops", 12);
+        for named in ["ELSEWHERE", "NEVERFILED"] {
+            assert_eq!(
+                bounty_step(&db, "award", ELIZA, "B1", "AW", Some(named), "#ops", 20),
+                ActWrite::Refused(freeq_sdk::act_transitions::Refusal::AcceptsNotABid),
+                "{named}"
+            );
+        }
+        assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
+    }
+
+    /// The server still never picks: it checks that the named event is a bid
+    /// on this action and nothing further. A bid nobody would have taken is
+    /// still one the poster may take.
+    #[test]
+    fn the_poster_takes_whichever_bid_they_name() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 12);
         assert!(matches!(
-            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(MALLORY), "#ops", 20),
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 20),
             ActWrite::Filed { .. }
         ));
         assert_eq!(
@@ -3357,12 +3392,16 @@ mod tests {
 
         offer(&db, "T4", "#ops", None, 40);
 
-        // A bounty too: its award assigns the DID it names rather than the
-        // sender, and a rebuild that read the sender would disagree with the
-        // live row on exactly that column.
+        // A bounty too: its award assigns the author of the bid it names
+        // rather than the sender, and that is a fact the rebuild has to look
+        // up in the log exactly as ingress did. A rebuild that read the
+        // sender, or the first bid, would disagree with the live row on
+        // exactly that column — so there are two bids and the second is taken.
         bounty_offer(&db, "B1", "#ops", 50);
-        bounty_step(&db, "bid", MALLORY, "B1", "BID0", None, "#ops", 51);
-        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 52);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 51);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
+        bounty_step(&db, "progress", MALLORY, "B1", "PR", None, "#ops", 54);
 
         let venues = vec!["#ops".to_string(), "#other".to_string()];
         let mut live = db.act_tasks(&venues, None, None, None, 100).unwrap();
@@ -6144,6 +6183,9 @@ impl Db {
         // materialized by them too, rather than by whatever the sender wrote.
         let mut was: Option<String> = None;
         let mut kind = view.kind.clone();
+        // Who the step assigns, when the row takes its assignee from the bid
+        // the event names rather than from the actor.
+        let mut assignee_named: Option<String> = None;
         let landed = if ev.opens {
             // The opener's own id is the task's id. A second opener under the
             // same id is the log's duplicate case, handled by the write below.
@@ -6169,14 +6211,28 @@ impl Db {
                 return Ok(ActWrite::WrongVenue);
             }
             let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
+            // The bid an award takes, resolved before the checker is asked:
+            // the checker reads no log, so the lookup is ours. Only a bid
+            // filed against this same action answers, which is what makes an
+            // award naming the opener — or a bid on somebody else's bounty —
+            // take nothing.
+            let accepts = view.fields.get("act-accepts").map(String::as_str);
+            let bid_author = match accepts {
+                Some(named) => self.act_bid_author(ev.act_id, named)?,
+                None => None,
+            };
             let event = rules::Event {
                 verb: &view.verb,
                 msgid: ev.event_id,
+                accepts,
                 fields: &present,
             };
             let sender = rules::Sender {
                 did: ev.actor,
                 is_system: ev.from_system,
+                accepted_bid: bid_author
+                    .as_deref()
+                    .map(|author| rules::AcceptedBid { author }),
             };
             let checked = rules::Task {
                 kind: &task.kind,
@@ -6190,6 +6246,7 @@ impl Db {
                 Ok(state) => {
                     was = Some(task.state.clone());
                     kind = task.kind.clone();
+                    assignee_named = bid_author;
                     state.to_string()
                 }
                 Err(refusal) => return Ok(ActWrite::Refused(refusal)),
@@ -6208,7 +6265,14 @@ impl Db {
         if !self.insert_event(&record)? {
             return Ok(ActWrite::Duplicate);
         }
-        self.materialize_act(ev, &view, &kind, was.as_deref(), &landed)?;
+        self.materialize_act(
+            ev,
+            &view,
+            &kind,
+            was.as_deref(),
+            &landed,
+            assignee_named.as_deref(),
+        )?;
         tx.commit()?;
         Ok(ActWrite::Filed { was, state: landed })
     }
@@ -6221,7 +6285,9 @@ impl Db {
     /// the log holds the history.
     ///
     /// `was` is the state the task came from — what the rules file is asked
-    /// about when it says where a transition's assignee comes from.
+    /// about when it says where a transition's assignee comes from, and
+    /// `named` is who the caller resolved the event's `act-accepts` to when
+    /// the row takes its assignee from a bid.
     fn materialize_act(
         &self,
         ev: &ActEvent<'_>,
@@ -6229,6 +6295,7 @@ impl Db {
         kind: &str,
         was: Option<&str>,
         landed: &str,
+        named: Option<&str>,
     ) -> SqlResult<()> {
         if freeq_sdk::act_transitions::is_terminal(kind, landed) {
             self.conn.execute(
@@ -6264,17 +6331,18 @@ impl Db {
         // work it is reporting on.
         //
         // Who it names is data. Accepting and claiming make the actor the
-        // assignee; a bounty's award names a winner in `act-to`, because the
-        // poster picks rather than becomes. A row whose field is absent names
-        // nobody and leaves the work unassigned — fail closed, though a
-        // `requires` on the same row is what actually keeps that from
-        // happening.
+        // assignee; a bounty's award takes the bid it names, and the work goes
+        // to whoever wrote that bid, because the poster picks rather than
+        // becomes. A row whose source resolves to nobody leaves the work
+        // unassigned — fail closed, though the checker refusing the step is
+        // what actually keeps that from happening.
         let assignee: Option<&str> = match freeq_sdk::act_transitions::assignee_source(
             kind,
             &view.verb,
             was.unwrap_or_default(),
         ) {
             freeq_sdk::act_transitions::AssigneeSource::Actor => Some(ev.actor),
+            freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named,
             freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                 view.fields.get(name).map(String::as_str)
             }
@@ -6517,6 +6585,28 @@ impl Db {
         Ok(events)
     }
 
+    /// Who wrote the bid `event_id` names on this action, or `None` when it
+    /// names something else.
+    ///
+    /// What an award's `act-accepts` resolves to, and the reason the checker
+    /// can stay a function of its arguments: the log answers here, once, and
+    /// hands the checker a fact. The search runs over the action's own events,
+    /// so an id filed against another action answers `None` for the same
+    /// reason a non-bid does — this award has nothing to take.
+    fn act_bid_author(&self, act_id: &str, event_id: &str) -> SqlResult<Option<String>> {
+        Ok(self
+            .act_task_events(act_id)?
+            .into_iter()
+            .find(|e| e.event_id == event_id)
+            .and_then(|e| {
+                let view = crate::events::derive_act_view(&e.canonical)?;
+                match view.verb == freeq_sdk::act_transitions::BID_VERB {
+                    true => e.actor_did,
+                    false => None,
+                }
+            }))
+    }
+
     /// Every stored event of one task, oldest first: the opener, then each
     /// follow-up. This is the history a reader gets, and it outlives the view.
     pub fn act_task_events(&self, act_id: &str) -> SqlResult<Vec<ActLoggedEvent>> {
@@ -6575,6 +6665,13 @@ impl Db {
 
         let mut live: std::collections::BTreeMap<String, ActTask> =
             std::collections::BTreeMap::new();
+        // The bids replayed so far, by the action they were filed against and
+        // their own id. This is the rebuild's copy of the lookup ingress does
+        // against the log: events come back in id order and a bid is always
+        // filed before the award that names it, so by the time an award is
+        // replayed its bid is here.
+        let mut bids: std::collections::BTreeMap<(String, String), String> =
+            std::collections::BTreeMap::new();
         for row in rows {
             let Some(view) = crate::events::derive_act_view(&row.canonical) else {
                 continue;
@@ -6590,6 +6687,9 @@ impl Db {
             let opens = row.subject.is_none();
             let mut was: Option<String> = None;
             let mut kind = view.kind.clone();
+            // The same fact ingress resolves before it asks the checker: who
+            // wrote the bid this event names, when it names one.
+            let mut named: Option<String> = None;
             let landed = if opens {
                 match freeq_sdk::act_transitions::check_open(
                     &view.kind,
@@ -6607,6 +6707,10 @@ impl Db {
                 was = Some(task.state.clone());
                 kind = task.kind.clone();
                 let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
+                let accepts = view.fields.get("act-accepts").map(String::as_str);
+                named = accepts
+                    .and_then(|id| bids.get(&(act_id.clone(), id.to_string())))
+                    .cloned();
                 match freeq_sdk::act_transitions::check(
                     &freeq_sdk::act_transitions::Task {
                         kind: &task.kind,
@@ -6619,6 +6723,7 @@ impl Db {
                     &freeq_sdk::act_transitions::Event {
                         verb: &view.verb,
                         msgid: &row.event_id,
+                        accepts,
                         fields: &present,
                     },
                     &freeq_sdk::act_transitions::Sender {
@@ -6627,12 +6732,19 @@ impl Db {
                         // it accepted this one — including an expiry it signed
                         // itself, whose sender check already passed.
                         is_system: true,
+                        accepted_bid: named
+                            .as_deref()
+                            .map(|author| freeq_sdk::act_transitions::AcceptedBid { author }),
                     },
                 ) {
                     Ok(s) => s.to_string(),
                     Err(_) => continue,
                 }
             };
+            // Filed, so it is one of the action's bids from here on.
+            if view.verb == freeq_sdk::act_transitions::BID_VERB {
+                bids.insert((act_id.clone(), row.event_id.clone()), row.actor.clone());
+            }
             if freeq_sdk::act_transitions::is_terminal(&kind, &landed) {
                 live.remove(&act_id);
                 continue;
@@ -6668,6 +6780,7 @@ impl Db {
                         freeq_sdk::act_transitions::AssigneeSource::Actor => {
                             Some(row.actor.clone())
                         }
+                        freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named.clone(),
                         freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                             view.fields.get(name).cloned()
                         }

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -205,6 +205,9 @@ pub struct ActTask {
     pub assignee: Option<String>,
     pub caps: Option<String>,
     pub deadline: Option<i64>,
+    /// The finished action this one revives, when its opener named one. An
+    /// annotation: the named action may be one this server never filed.
+    pub replaces: Option<String>,
     pub updated: i64,
 }
 
@@ -2714,6 +2717,12 @@ mod tests {
     const ELIZA: &str = "did:plc:eliza";
     const SCHOLAR: &str = "did:plc:scholar";
     const MALLORY: &str = "did:plc:mallory";
+    /// Action ids, in the shape the revival relation insists on: a real ULID.
+    /// The short ids elsewhere in these tests are fine — nothing else reads an
+    /// id's shape — but `act-replaces` refuses a value that names no action.
+    const ONE: &str = "01M16E7TC00000000000000001";
+    const TWO: &str = "01M16E7TC00000000000000002";
+    const NEVER_SEEN: &str = "01M16E7TC0NEVERSEEN0000000";
 
     /// Build a task event's canonical the way a signer would.
     fn act_doc(tags: &[(&str, &str)], venue: &str, id: &str) -> String {
@@ -3029,6 +3038,132 @@ mod tests {
         );
     }
 
+    // ── the revival relation ──────────────────────────────────────────────
+
+    /// An opener that names a finished action it revives.
+    fn re_offer(db: &Db, id: &str, venue: &str, replaces: &str, ts: i64) -> ActWrite {
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "handoff"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-replaces", replaces),
+            ],
+            venue,
+            id,
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: id,
+            opens: true,
+            venue,
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
+    /// A dead handoff, re-offered. The link is on the new action; the old one
+    /// is untouched, because nothing un-applies.
+    #[test]
+    fn a_re_offer_carries_the_link_to_the_action_it_revives() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, ONE, "#ops", Some(SCHOLAR), 10);
+        follow_up(&db, "accept", SCHOLAR, ONE, "E1", "#ops", 11);
+        follow_up(&db, "fail", SCHOLAR, ONE, "E2", "#ops", 12);
+        assert_eq!(db.act_task(ONE).unwrap(), None, "the first one is finished");
+
+        assert!(matches!(
+            re_offer(&db, TWO, "#ops", ONE, 20),
+            ActWrite::Filed { .. }
+        ));
+        let revived = db.act_task(TWO).unwrap().unwrap();
+        assert_eq!(revived.replaces.as_deref(), Some(ONE));
+        assert_eq!(
+            db.act_task_events(ONE).unwrap().len(),
+            3,
+            "and the action it replaces keeps exactly the history it had"
+        );
+    }
+
+    /// Reviving something still running would leave two live actions each
+    /// claiming to be the work.
+    #[test]
+    fn an_action_still_running_is_not_something_to_revive() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, ONE, "#ops", Some(SCHOLAR), 10);
+        assert_eq!(
+            re_offer(&db, TWO, "#ops", ONE, 20),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::ReplacesNotTerminal)
+        );
+        assert_eq!(db.act_task(TWO).unwrap(), None, "and nothing was filed");
+    }
+
+    /// The rule that is load-bearing for federation: a link to an action this
+    /// server never filed is annotation, not a claim to check.
+    #[test]
+    fn a_link_to_an_action_this_server_never_saw_is_annotated_not_refused() {
+        let db = Db::open_memory().unwrap();
+        assert!(matches!(
+            re_offer(&db, ONE, "#ops", NEVER_SEEN, 10),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            db.act_task(ONE).unwrap().unwrap().replaces.as_deref(),
+            Some(NEVER_SEEN)
+        );
+    }
+
+    #[test]
+    fn a_step_on_an_action_revives_nothing() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, ONE, "#ops", Some(SCHOLAR), 10);
+        offer(&db, TWO, "#ops", None, 11);
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "handoff"),
+                ("+freeq.at/act-verb", "accept"),
+                ("+freeq.at/from", SCHOLAR),
+                ("+freeq.at/act-id", ONE),
+                ("+freeq.at/act-replaces", TWO),
+            ],
+            "#ops",
+            "E1",
+        );
+        let written = db
+            .apply_act_event(&ActEvent {
+                canonical: &canonical,
+                signature: Some("ed25519:kid:sig"),
+                event_id: "E1",
+                act_id: ONE,
+                opens: false,
+                venue: "#ops",
+                actor: SCHOLAR,
+                from_system: false,
+                origin: None,
+                timestamp: 12,
+            })
+            .unwrap();
+        assert_eq!(
+            written,
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::ReplacesNotOpener)
+        );
+        assert_eq!(db.act_task(ONE).unwrap().unwrap().state, "offered");
+    }
+
+    #[test]
+    fn a_value_that_is_not_an_action_id_names_no_action() {
+        let db = Db::open_memory().unwrap();
+        assert_eq!(
+            re_offer(&db, ONE, "#ops", "not-a-ulid", 10),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::ReplacesMalformed)
+        );
+    }
+
     /// The whole point of deriving the view: replaying the log reproduces it.
     /// A mismatch means something wrote the view without going through the
     /// log, and the log would have stopped being the record.
@@ -3043,12 +3178,15 @@ mod tests {
         offer(&db, "T2", "#ops", None, 20);
         follow_up(&db, "claim", MALLORY, "T2", "E3", "#ops", 21);
 
-        offer(&db, "T3", "#other", Some(SCHOLAR), 30);
-        follow_up(&db, "decline", SCHOLAR, "T3", "E4", "#other", 31);
+        offer(&db, ONE, "#other", Some(SCHOLAR), 30);
+        follow_up(&db, "decline", SCHOLAR, ONE, "E4", "#other", 31);
         // A receipt for the event that ended a task — the rebuild has to pass
         // over it exactly as ingress did, or the replay would try to apply a
         // verb no kind has.
-        receipt(&db, "T3", "E4", "R2", "#other", true, 31);
+        receipt(&db, ONE, "E4", "R2", "#other", true, 31);
+        // …and the declined one re-offered, so the rebuild has to reproduce
+        // the link as well as the row.
+        re_offer(&db, "T5", "#other", ONE, 32);
 
         offer(&db, "T4", "#ops", None, 40);
 
@@ -3058,7 +3196,11 @@ mod tests {
         let mut rebuilt = db.rebuild_act_actions().unwrap();
         rebuilt.sort_by(|a, b| a.act_id.cmp(&b.act_id));
 
-        assert_eq!(live.len(), 3, "T3 declined, so it left the view");
+        assert_eq!(
+            live.len(),
+            4,
+            "the declined one left the view; its revival did not"
+        );
         assert_eq!(rebuilt, live);
     }
 
@@ -4315,7 +4457,7 @@ mod tests {
                 db.conn
                     .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
                     .unwrap(),
-                6,
+                crate::migrations::ladder_top() as i64,
                 "first open stamps the schema"
             );
         }
@@ -4327,7 +4469,7 @@ mod tests {
             db.conn
                 .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
                 .unwrap(),
-            6
+            crate::migrations::ladder_top() as i64
         );
         assert_eq!(db.root_of("id-2"), "id-1");
         assert_eq!(db.current_revision("id-1").unwrap().unwrap().text, "v2");
@@ -4357,7 +4499,7 @@ mod tests {
             db.conn
                 .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
                 .unwrap(),
-            6
+            crate::migrations::ladder_top() as i64
         );
     }
 
@@ -4400,7 +4542,7 @@ mod tests {
             db.conn
                 .query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
                 .unwrap(),
-            6
+            crate::migrations::ladder_top() as i64
         );
     }
 
@@ -5797,6 +5939,27 @@ impl Db {
             return Ok(ActWrite::Recorded);
         }
 
+        // ── The revival relation ──
+        //
+        // Answered before the move itself, because it is a claim about a
+        // *different* action: whether this event may carry the link at all,
+        // and whether the action it names is in a fit state to be revived. An
+        // action nobody here ever filed is accepted and annotated — a client's
+        // typo today, and under federation the ordinary case, since the
+        // predecessor lived on another machine.
+        if let Some(named) = view.replaces.as_deref() {
+            let predecessor = match self.act_task(named)? {
+                Some(_) => rules::Predecessor::Live,
+                None => match self.act_task_is_on_file(named)? {
+                    true => rules::Predecessor::Finished,
+                    false => rules::Predecessor::Unknown,
+                },
+            };
+            if let Err(refusal) = rules::check_revival(ev.opens, named, predecessor) {
+                return Ok(ActWrite::Refused(refusal));
+            }
+        }
+
         // What the event does to the task, where the task stood before it, and
         // what it looks like now.
         let mut was: Option<String> = None;
@@ -5888,8 +6051,9 @@ impl Db {
         if ev.opens {
             self.conn.execute(
                 "INSERT OR REPLACE INTO act_actions
-                     (act_id, kind, venue, origin, state, offerer, offeree, caps, deadline, updated)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                     (act_id, kind, venue, origin, state, offerer, offeree, caps, deadline,
+                      replaces, updated)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
                 params![
                     ev.act_id,
                     view.kind,
@@ -5900,6 +6064,7 @@ impl Db {
                     view.to,
                     view.caps,
                     view.deadline,
+                    view.replaces,
                     ev.timestamp,
                 ],
             )?;
@@ -5956,7 +6121,7 @@ impl Db {
         self.conn
             .query_row(
                 "SELECT act_id, kind, venue, origin, state, offerer, offeree, assignee,
-                        caps, deadline, updated
+                        caps, deadline, replaces, updated
                  FROM act_actions WHERE act_id = ?1",
                 params![act_id],
                 |row| {
@@ -5971,7 +6136,8 @@ impl Db {
                         assignee: row.get(7)?,
                         caps: row.get(8)?,
                         deadline: row.get(9)?,
-                        updated: row.get(10)?,
+                        replaces: row.get(10)?,
+                        updated: row.get(11)?,
                     })
                 },
             )
@@ -5994,7 +6160,7 @@ impl Db {
         let places = venues.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!(
             "SELECT act_id, kind, venue, origin, state, offerer, offeree, assignee,
-                    caps, deadline, updated
+                    caps, deadline, replaces, updated
                FROM act_actions
               WHERE venue IN ({places})
                 AND (?{k} IS NULL OR kind = ?{k})
@@ -6029,7 +6195,8 @@ impl Db {
                 assignee: row.get(7)?,
                 caps: row.get(8)?,
                 deadline: row.get(9)?,
-                updated: row.get(10)?,
+                replaces: row.get(10)?,
+                updated: row.get(11)?,
             })
         })?;
         rows.collect()
@@ -6043,7 +6210,7 @@ impl Db {
     pub fn act_tasks_idle_since(&self, cutoff: i64, limit: usize) -> SqlResult<Vec<ActTask>> {
         let mut stmt = self.conn.prepare(
             "SELECT act_id, kind, venue, origin, state, offerer, offeree, assignee,
-                    caps, deadline, updated
+                    caps, deadline, replaces, updated
                FROM act_actions
               WHERE updated < ?1
               ORDER BY updated
@@ -6061,7 +6228,8 @@ impl Db {
                 assignee: row.get(7)?,
                 caps: row.get(8)?,
                 deadline: row.get(9)?,
-                updated: row.get(10)?,
+                replaces: row.get(10)?,
+                updated: row.get(11)?,
             })
         })?;
         rows.collect()
@@ -6271,6 +6439,7 @@ impl Db {
                         assignee: None,
                         caps: view.caps.clone(),
                         deadline: view.deadline,
+                        replaces: view.replaces.clone(),
                         updated: row.timestamp,
                     },
                 );

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -243,8 +243,16 @@ pub struct ActEvent<'a> {
 /// What happened to a task event offered to the log.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActWrite {
-    /// Filed, and the task now sits in this state.
-    Filed { state: String },
+    /// Filed, and the task now sits in this state. `was` is the state it
+    /// came from — `None` for the event that opened it, which came from
+    /// nowhere. The two together are what tells a step that moved the task
+    /// from one that only reported on it, which is the question a receipt
+    /// answers.
+    Filed { was: Option<String>, state: String },
+    /// Filed as a record, with the view left where it stood: a receipt. The
+    /// state it names was moved by the event it confirms, and confirming
+    /// something twice must not move anything twice.
+    Recorded,
     /// The rules refused the move.
     Refused(freeq_sdk::act_transitions::Refusal),
     /// The event names a task this server has never filed — including any
@@ -2777,6 +2785,7 @@ mod tests {
         assert_eq!(
             offer(&db, "T1", "#ops", Some(SCHOLAR), 10),
             ActWrite::Filed {
+                was: None,
                 state: "offered".into()
             }
         );
@@ -2846,6 +2855,7 @@ mod tests {
         assert_eq!(
             first,
             ActWrite::Filed {
+                was: Some("open".into()),
                 state: "assigned".into()
             }
         );
@@ -2908,6 +2918,117 @@ mod tests {
         );
     }
 
+    // ── receipts ──────────────────────────────────────────────────────────
+
+    const HOME: &str = "did:web:test";
+
+    /// A receipt, filed the way the home files one: its own event id, the
+    /// task in `act-id`, and the confirmed event in `act-subject`.
+    fn receipt(
+        db: &Db,
+        task: &str,
+        subject: &str,
+        id: &str,
+        venue: &str,
+        from_system: bool,
+        ts: i64,
+    ) -> ActWrite {
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "handoff"),
+                ("+freeq.at/act-verb", "confirm"),
+                ("+freeq.at/from", HOME),
+                ("+freeq.at/act-id", task),
+                ("+freeq.at/act-subject", subject),
+            ],
+            venue,
+            id,
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: task,
+            opens: false,
+            venue,
+            actor: HOME,
+            from_system,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
+    /// A receipt is an appended record and nothing else: the state it names
+    /// was moved by the event it confirms, and confirming that twice must not
+    /// move anything twice.
+    #[test]
+    fn a_receipt_is_filed_without_moving_the_view() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, "T1", "#ops", Some(SCHOLAR), 10);
+        follow_up(&db, "accept", SCHOLAR, "T1", "E1", "#ops", 11);
+        let before = db.act_task("T1").unwrap().unwrap();
+
+        assert_eq!(
+            receipt(&db, "T1", "E1", "R1", "#ops", true, 11),
+            ActWrite::Recorded
+        );
+        assert_eq!(db.act_task("T1").unwrap().unwrap(), before);
+        assert_eq!(
+            db.act_task_events("T1").unwrap().len(),
+            3,
+            "the offer, the accept, and the home's word about the accept"
+        );
+    }
+
+    /// A receipt confirming the event that ended a task is still filed: the
+    /// row is gone, the log is the record, and the receipt belongs to it.
+    #[test]
+    fn a_receipt_outlives_the_task_it_confirms() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, "T1", "#ops", Some(SCHOLAR), 10);
+        follow_up(&db, "accept", SCHOLAR, "T1", "E1", "#ops", 11);
+        follow_up(&db, "complete", SCHOLAR, "T1", "E2", "#ops", 12);
+        assert_eq!(db.act_task("T1").unwrap(), None);
+
+        assert_eq!(
+            receipt(&db, "T1", "E2", "R1", "#ops", true, 12),
+            ActWrite::Recorded
+        );
+        assert_eq!(db.act_task("T1").unwrap(), None, "and nothing came back");
+        assert_eq!(db.act_task_events("T1").unwrap().len(), 4);
+    }
+
+    /// The verb is the home's. Bytes arriving from anywhere else carrying it
+    /// are refused here as well as at the gate — this path is reachable from a
+    /// rebuild and, later, from a peer.
+    #[test]
+    fn only_the_home_writes_a_receipt() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, "T1", "#ops", Some(SCHOLAR), 10);
+        assert_eq!(
+            receipt(&db, "T1", "T1", "R1", "#ops", false, 11),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::ClientConfirm)
+        );
+        assert_eq!(
+            db.act_task_events("T1").unwrap().len(),
+            1,
+            "a refused receipt is not filed"
+        );
+    }
+
+    #[test]
+    fn a_second_receipt_under_one_id_is_a_duplicate() {
+        let db = Db::open_memory().unwrap();
+        offer(&db, "T1", "#ops", Some(SCHOLAR), 10);
+        follow_up(&db, "accept", SCHOLAR, "T1", "E1", "#ops", 11);
+        receipt(&db, "T1", "E1", "R1", "#ops", true, 11);
+        assert_eq!(
+            receipt(&db, "T1", "E1", "R1", "#ops", true, 11),
+            ActWrite::Duplicate
+        );
+    }
+
     /// The whole point of deriving the view: replaying the log reproduces it.
     /// A mismatch means something wrote the view without going through the
     /// log, and the log would have stopped being the record.
@@ -2916,6 +3037,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         offer(&db, "T1", "#ops", Some(SCHOLAR), 10);
         follow_up(&db, "accept", SCHOLAR, "T1", "E1", "#ops", 11);
+        receipt(&db, "T1", "E1", "R1", "#ops", true, 11);
         follow_up(&db, "progress", SCHOLAR, "T1", "E2", "#ops", 12);
 
         offer(&db, "T2", "#ops", None, 20);
@@ -2923,6 +3045,10 @@ mod tests {
 
         offer(&db, "T3", "#other", Some(SCHOLAR), 30);
         follow_up(&db, "decline", SCHOLAR, "T3", "E4", "#other", 31);
+        // A receipt for the event that ended a task — the rebuild has to pass
+        // over it exactly as ingress did, or the replay would try to apply a
+        // verb no kind has.
+        receipt(&db, "T3", "E4", "R2", "#other", true, 31);
 
         offer(&db, "T4", "#ops", None, 40);
 
@@ -5646,7 +5772,34 @@ impl Db {
             return Ok(ActWrite::NotATaskEvent);
         };
 
-        // What the event does to the task, and what the task looks like now.
+        // ── A receipt ──
+        //
+        // Recognized before the task is read, because it asks nothing of the
+        // task: the home writes it about an event it has already refereed and
+        // filed, and the state that event landed in was set then. Filing a
+        // receipt appends a row and stops. Only the home writes one, so a
+        // sender's confirm is refused here as it is at the gate — this path
+        // is also reachable from a rebuild and from a peer.
+        if rules::is_confirmation(&view.verb) {
+            if !ev.from_system {
+                return Ok(ActWrite::Refused(rules::Refusal::ClientConfirm));
+            }
+            let record = EventRecord {
+                shape: EventShape::Document(ev.canonical),
+                signature: ev.signature,
+                ctx: crate::events::EventContext::verified(),
+                timestamp: ev.timestamp as u64,
+            };
+            if !self.insert_event(&record)? {
+                return Ok(ActWrite::Duplicate);
+            }
+            tx.commit()?;
+            return Ok(ActWrite::Recorded);
+        }
+
+        // What the event does to the task, where the task stood before it, and
+        // what it looks like now.
+        let mut was: Option<String> = None;
         let landed = if ev.opens {
             // The opener's own id is the task's id. A second opener under the
             // same id is the log's duplicate case, handled by the write below.
@@ -5688,7 +5841,10 @@ impl Db {
                 deadline: task.deadline,
             };
             match rules::check(&checked, &event, &sender) {
-                Ok(state) => state.to_string(),
+                Ok(state) => {
+                    was = Some(task.state.clone());
+                    state.to_string()
+                }
                 Err(refusal) => return Ok(ActWrite::Refused(refusal)),
             }
         };
@@ -5707,7 +5863,7 @@ impl Db {
         }
         self.materialize_act(ev, &view, &landed)?;
         tx.commit()?;
-        Ok(ActWrite::Filed { state: landed })
+        Ok(ActWrite::Filed { was, state: landed })
     }
 
     /// Move the view to match an event that was just accepted.
@@ -6049,6 +6205,13 @@ impl Db {
             let Some(view) = crate::events::derive_act_view(&row.canonical) else {
                 continue;
             };
+            // A receipt moves nothing — the event it names did the moving, and
+            // is in this same log. A rebuild passes over it exactly as the
+            // ingress path does, or replaying the log would try to apply a
+            // verb no kind has.
+            if freeq_sdk::act_transitions::is_confirmation(&view.verb) {
+                continue;
+            }
             let act_id = row.subject.clone().unwrap_or_else(|| row.event_id.clone());
             let opens = row.subject.is_none();
             let landed = if opens {

--- a/freeq-server/src/events.rs
+++ b/freeq-server/src/events.rs
@@ -240,6 +240,15 @@ pub struct ActView {
     /// annotation, and possibly one naming an action this server never filed —
     /// which is the case the rule is written for.
     pub replaces: Option<String>,
+    /// Every `act-*` field the document carries, by its document name.
+    ///
+    /// The named fields above are the ones the view has columns for; this is
+    /// the whole set, and it exists because the rules file points at fields by
+    /// name: a transition's `requires` asks which are present, and its
+    /// `assignee_from` asks what one holds. Neither can be served by a fixed
+    /// list, which is the same reason the signature covers the tags by prefix
+    /// rather than by enumeration.
+    pub fields: std::collections::BTreeMap<String, String>,
 }
 
 /// Read a task event's view fields out of its canonical.
@@ -248,7 +257,17 @@ pub struct ActView {
 pub fn derive_act_view(canonical: &str) -> Option<ActView> {
     let doc: serde_json::Value = serde_json::from_str(canonical).ok()?;
     let get = |k: &str| doc.get(k).and_then(|v| v.as_str()).map(str::to_string);
+    // The same rule the signer's sweep used, read back: a document key is an
+    // act field when it is `act` or starts with `act-`. The envelope fields
+    // (`from`, `id`, `target`) are not, and never collide with one.
+    let fields = doc
+        .as_object()?
+        .iter()
+        .filter(|(k, _)| k.as_str() == "act" || k.starts_with("act-"))
+        .filter_map(|(k, v)| Some((k.clone(), v.as_str()?.to_string())))
+        .collect();
     Some(ActView {
+        fields,
         kind: get("act")?,
         verb: get("act-verb")?,
         to: get("act-to"),

--- a/freeq-server/src/events.rs
+++ b/freeq-server/src/events.rs
@@ -236,6 +236,10 @@ pub struct ActView {
     /// `act-deadline` in unix seconds, when the offer named one this server
     /// can read as a number.
     pub deadline: Option<i64>,
+    /// The revival relation: the finished action this one replaces. An
+    /// annotation, and possibly one naming an action this server never filed —
+    /// which is the case the rule is written for.
+    pub replaces: Option<String>,
 }
 
 /// Read a task event's view fields out of its canonical.
@@ -253,6 +257,9 @@ pub fn derive_act_view(canonical: &str) -> Option<ActView> {
         // cannot enforce, so it is stored as absent rather than as a guess.
         // The value stays in the canonical either way.
         deadline: get("act-deadline").and_then(|d| d.parse::<i64>().ok()),
+        // Read under the name the rules file gives the relation, so the tag
+        // is spelled in one place across all three implementations.
+        replaces: get(freeq_sdk::act_transitions::revival_tag()),
     })
 }
 

--- a/freeq-server/src/migrations/007_act_replaces.rs
+++ b/freeq-server/src/migrations/007_act_replaces.rs
@@ -1,0 +1,140 @@
+//! Migration 7: the revival relation becomes a column of the live-task view.
+//!
+//! `act-replaces` names the finished action a new one revives — a failed
+//! handoff re-offered, a forfeited bounty re-listed. The link is the opener's,
+//! signed like every other act tag, and the log has held it since the tag
+//! existed. This lifts it into the view so a reader can ask what an action
+//! revives without reopening the opener's bytes, exactly as `offeree` and
+//! `caps` are already lifted.
+//!
+//! Nullable, because most actions revive nothing, and derived like every other
+//! column here: the rebuild fills it from the same bytes ingress reads, and the
+//! rebuild-matches test covers it.
+//!
+//! A hook rather than plain SQL, for the reason migration 5 states: SQLite has
+//! no `ADD COLUMN IF NOT EXISTS`, and this rung has to survive being re-run
+//! against a database whose schema is already converged but whose stamp was
+//! lost. So the ALTER runs and its "duplicate column" error is the success
+//! case.
+//!
+//! Down: drop the column. Nothing is lost that the log cannot rebuild — the
+//! link is in the opener's signed bytes either way.
+
+use rusqlite::Transaction;
+use rusqlite_migration::{HookResult, M};
+
+pub(super) fn migration() -> M<'static> {
+    M::up_with_hook("", |tx: &Transaction| -> HookResult {
+        match tx.execute("ALTER TABLE act_actions ADD COLUMN replaces TEXT", []) {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    })
+    .down("ALTER TABLE act_actions DROP COLUMN replaces;")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::migration_ladder;
+    use rusqlite::Connection;
+
+    fn columns(conn: &Connection) -> Vec<String> {
+        let mut cols: Vec<String> = conn
+            .prepare("SELECT name FROM pragma_table_info('act_actions')")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        cols.sort();
+        cols
+    }
+
+    #[test]
+    fn the_view_gains_the_link_and_keeps_every_column_it_had() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 6).unwrap();
+        assert!(!columns(&conn).iter().any(|c| c == "replaces"));
+
+        migration_ladder().to_version(&mut conn, 7).unwrap();
+        assert_eq!(
+            columns(&conn),
+            vec![
+                "act_id", "assignee", "caps", "deadline", "kind", "offeree", "offerer", "origin",
+                "replaces", "state", "updated", "venue",
+            ]
+        );
+    }
+
+    /// An action already on file revives nothing, which is what the column
+    /// says about it — no backfill, because the answer for a row that never
+    /// carried the tag is the empty one.
+    #[test]
+    fn a_row_that_predates_the_column_revives_nothing() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 6).unwrap();
+        conn.execute(
+            "INSERT INTO act_actions (act_id, kind, venue, state, offerer, updated)
+             VALUES ('A1', 'handoff', '#c', 'open', 'did:plc:a', 10)",
+            [],
+        )
+        .unwrap();
+
+        migration_ladder().to_version(&mut conn, 7).unwrap();
+
+        let replaces: Option<String> = conn
+            .query_row(
+                "SELECT replaces FROM act_actions WHERE act_id = 'A1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(replaces, None);
+    }
+
+    /// The rung survives a re-run against a database that already has the
+    /// column — an older build's file whose stamp was lost still climbs.
+    #[test]
+    fn the_rung_survives_a_database_that_already_has_the_column() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 7).unwrap();
+        conn.execute_batch("PRAGMA user_version = 6").unwrap();
+        migration_ladder()
+            .to_version(&mut conn, 7)
+            .expect("a converged schema with a lost stamp climbs anyway");
+    }
+
+    /// Down leaves a pre-7 shape behind, and the log — the record — keeps the
+    /// link in the bytes it always had it in.
+    #[test]
+    fn migrating_down_drops_the_column_and_keeps_the_log() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 7).unwrap();
+        conn.execute(
+            "INSERT INTO events (event_id, canonical, sig_state, kind, venue, timestamp)
+             VALUES ('A2', '{\"act-replaces\":\"A1\"}', 'unsigned', 'act', '#c', 10)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO act_actions (act_id, kind, venue, state, offerer, replaces, updated)
+             VALUES ('A2', 'handoff', '#c', 'open', 'did:plc:a', 'A1', 10)",
+            [],
+        )
+        .unwrap();
+
+        migration_ladder().to_version(&mut conn, 6).unwrap();
+
+        assert!(!columns(&conn).iter().any(|c| c == "replaces"));
+        let canonical: String = conn
+            .query_row(
+                "SELECT canonical FROM events WHERE event_id = 'A2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(canonical.contains("act-replaces"), "{canonical}");
+    }
+}

--- a/freeq-server/src/migrations/mod.rs
+++ b/freeq-server/src/migrations/mod.rs
@@ -41,6 +41,8 @@ mod m004_events_log;
 mod m005_event_emoji;
 #[path = "006_act_actions.rs"]
 mod m006_act_actions;
+#[path = "007_act_replaces.rs"]
+mod m007_act_replaces;
 
 // db.rs unit tests exercise the backfill directly against hand-built rows.
 // Production reaches it only as a rung of the ladder below.
@@ -57,6 +59,7 @@ fn rungs() -> Vec<rusqlite_migration::M<'static>> {
         m004_events_log::migration(),
         m005_event_emoji::migration(),
         m006_act_actions::migration(),
+        m007_act_replaces::migration(),
     ]
 }
 
@@ -196,6 +199,7 @@ mod tests {
         migration_ladder().to_version(&mut stepped, 4).unwrap();
         migration_ladder().to_version(&mut stepped, 5).unwrap();
         migration_ladder().to_version(&mut stepped, 6).unwrap();
+        migration_ladder().to_version(&mut stepped, 7).unwrap();
 
         let mut direct = Connection::open_in_memory().unwrap();
         migration_ladder().to_latest(&mut direct).unwrap();
@@ -244,7 +248,7 @@ mod tests {
         migration_ladder().to_latest(&mut conn).unwrap();
         let before = tables(&conn);
         migration_ladder().to_latest(&mut conn).unwrap();
-        assert_eq!(version(&conn), 6);
+        assert_eq!(version(&conn), ladder_top());
         assert_eq!(tables(&conn), before);
     }
 }

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2149,6 +2149,7 @@ impl Server {
         }
 
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         // Heartbeat expiry: check agent liveness every 15 seconds.
         // Agents that miss their TTL transition to degraded, then offline, then disconnect.
@@ -2487,6 +2488,7 @@ impl Server {
         // is consistent.
         spawn_phantom_sweeper(Arc::clone(&state));
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         let handle = tokio::spawn(async move {
             loop {
@@ -2534,6 +2536,7 @@ impl Server {
         // Phantom-session sweeper (defense-in-depth).
         spawn_phantom_sweeper(Arc::clone(&state));
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         let web_state = Arc::clone(&state);
         let router = crate::web::router(web_state);
@@ -2699,10 +2702,47 @@ fn spawn_act_expiry_sweep(state: Arc<SharedState>, limit_secs: u64) {
             // Bounded per pass: a server that was down for a month should not
             // try to expire everything in one breath.
             let stale = state
-                .with_db(|db| db.act_tasks_idle_since(cutoff, 100))
+                .with_db(|db| {
+                    db.act_tasks_idle_outside_states(
+                        &freeq_sdk::act_transitions::review_timeout_states(),
+                        cutoff,
+                        100,
+                    )
+                })
                 .unwrap_or_default();
             for task in &stale {
                 crate::connection::act::expire_task(&state, task);
+            }
+        }
+    });
+}
+
+/// Close review windows: work that was handed in and left unanswered for
+/// longer than the limit is deemed accepted, under the home's own signature.
+///
+/// A second clock rather than a case of the first, because it does the
+/// opposite job. The abandonment sweep is neutral and catches work nobody is
+/// doing; this one favours the worker and catches a poster who took delivery
+/// and then went quiet — and the two would otherwise race, so the states this
+/// one owns are the states the other skips. `0` disables it.
+fn spawn_act_review_sweep(state: Arc<SharedState>, limit_secs: u64) {
+    let states = freeq_sdk::act_transitions::review_timeout_states();
+    if limit_secs == 0 || states.is_empty() {
+        return;
+    }
+    let limit = limit_secs as i64;
+    tokio::spawn(async move {
+        let every = (limit_secs / 2).clamp(1, 60);
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(every));
+        interval.tick().await; // skip first tick
+        loop {
+            interval.tick().await;
+            let cutoff = chrono::Utc::now().timestamp() - limit;
+            let waiting = state
+                .with_db(|db| db.act_tasks_idle_in_states(&states, cutoff, 100))
+                .unwrap_or_default();
+            for task in &waiting {
+                crate::connection::act::auto_accept_task(&state, task);
             }
         }
     });

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -2781,8 +2781,8 @@ async fn client_metadata(headers: axum::http::HeaderMap) -> Json<serde_json::Val
         "client_name": "freeq",
         "client_uri": web_origin,
         "logo_uri": format!("{web_origin}/freeq.png"),
-        "tos_uri": format!("{web_origin}"),
-        "policy_uri": format!("{web_origin}"),
+        "tos_uri": web_origin,
+        "policy_uri": web_origin,
         "redirect_uris": [redirect_uri],
         // Advertise the union of scopes any flow may request. The AT
         // Proto OAuth spec requires that scopes used at /authorize time

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -856,6 +856,10 @@ fn act_task_json(task: &crate::db::ActTask) -> serde_json::Value {
         "assignee": task.assignee,
         "caps": task.caps,
         "deadline": task.deadline,
+        // The finished action this one revives, when its opener named one.
+        // Null otherwise, and null is the honest answer for an action that
+        // revives nothing — the same shape `offeree` and `caps` already have.
+        "replaces": task.replaces,
         "updated": task.updated,
     })
 }

--- a/freeq-server/tests/act_api.rs
+++ b/freeq-server/tests/act_api.rs
@@ -498,6 +498,128 @@ async fn a_task_event_moves_the_counter_on_the_metrics_endpoint() {
     );
 }
 
+/// The revival relation is a fact about the new action, so it reads off the
+/// action rather than out of the opener's bytes — in the listing and on the
+/// single fetch alike. An action that revives nothing says so.
+#[tokio::test]
+async fn a_revived_action_shows_what_it_replaces_on_both_endpoints() {
+    let k = PrivateKey::generate_ed25519();
+    let (irc, web, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    let (dead, revived, unrelated) = tokio::task::spawn_blocking(move || {
+        let signing = SigningKey::from_bytes(&[21u8; 32]);
+        let mut a = C::authenticated(irc, "alice", DID_ALICE, k);
+        a.msgsig(&signing);
+        a.join("#work");
+
+        let venue = channel_venue("#work");
+        let dead = a.offer("#work", &venue, DID_ALICE, &signing);
+        // The poster withdraws it, which finishes it.
+        let ev = freeq_sdk::chatsig::new_event_id();
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "cancel".into()),
+            ("+freeq.at/from".into(), DID_ALICE.into()),
+            ("+freeq.at/act-id".into(), dead.clone()),
+        ];
+        let pairs: Vec<(&str, &str)> = tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &venue, &ev, &signing).unwrap();
+        let mut wire: Vec<String> = tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={ev}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        a.tx(&format!("@{} TAGMSG #work", wire.join(";")));
+        a.rx(|l| l.contains(&ev), "the cancel is accepted");
+
+        // Re-listed, naming what it revives.
+        let revived = freeq_sdk::chatsig::new_event_id();
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "offer".into()),
+            ("+freeq.at/from".into(), DID_ALICE.into()),
+            ("+freeq.at/act-replaces".into(), dead.clone()),
+        ];
+        let pairs: Vec<(&str, &str)> = tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &venue, &revived, &signing).unwrap();
+        let mut wire: Vec<String> = tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={revived}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        a.tx(&format!("@{} TAGMSG #work", wire.join(";")));
+        a.rx(|l| l.contains(&revived), "the re-offer is accepted");
+
+        let unrelated = a.offer("#work", &venue, DID_ALICE, &signing);
+        (dead, revived, unrelated)
+    })
+    .await
+    .unwrap();
+
+    let (_, listing) = get(web, "/api/v1/actions", None).await;
+    let rows = listing["tasks"].as_array().unwrap();
+    let row = rows
+        .iter()
+        .find(|t| t["act_id"] == serde_json::json!(revived))
+        .expect("the revived action is live");
+    assert_eq!(row["replaces"], serde_json::json!(dead));
+    let other = rows
+        .iter()
+        .find(|t| t["act_id"] == serde_json::json!(unrelated))
+        .unwrap();
+    assert!(
+        other["replaces"].is_null(),
+        "an action that revives nothing says so: {other}"
+    );
+
+    let (status, one) = get(web, &format!("/api/v1/actions/{revived}"), None).await;
+    assert_eq!(status, 200);
+    assert_eq!(one["task"]["replaces"], serde_json::json!(dead));
+
+    // …and the action it replaces is exactly as it ended.
+    let (_, old) = get(web, &format!("/api/v1/actions/{dead}"), None).await;
+    assert!(old["task"].is_null(), "cancelled, so it left the view");
+    assert_eq!(
+        old["events"].as_array().unwrap().len(),
+        3,
+        "the offer, the cancel, and the receipt for the cancel — nothing added \
+         by the revival"
+    );
+}
+
+/// The rule that is load-bearing for federation: a link to an action this
+/// server never filed is annotated, not refused, and the annotation is served.
+#[tokio::test]
+async fn a_link_to_an_action_this_server_never_saw_is_annotated_and_served() {
+    const NEVER_SEEN: &str = "01M16E7TC0NEVERSEEN0000000";
+    let k = PrivateKey::generate_ed25519();
+    let (irc, web, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    let revived = tokio::task::spawn_blocking(move || {
+        let signing = SigningKey::from_bytes(&[21u8; 32]);
+        let mut a = C::authenticated(irc, "alice", DID_ALICE, k);
+        a.msgsig(&signing);
+        a.join("#work");
+
+        let venue = channel_venue("#work");
+        let id = freeq_sdk::chatsig::new_event_id();
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "offer".into()),
+            ("+freeq.at/from".into(), DID_ALICE.into()),
+            ("+freeq.at/act-replaces".into(), NEVER_SEEN.into()),
+        ];
+        let pairs: Vec<(&str, &str)> = tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &venue, &id, &signing).unwrap();
+        let mut wire: Vec<String> = tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={id}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        a.tx(&format!("@{} TAGMSG #work", wire.join(";")));
+        a.rx(|l| l.contains(&id), "the re-offer is accepted anyway");
+        id
+    })
+    .await
+    .unwrap();
+
+    let (_, listing) = get(web, "/api/v1/actions", None).await;
+    assert_eq!(ids(&listing), vec![revived.clone()]);
+    assert_eq!(listing["tasks"][0]["replaces"], NEVER_SEEN);
+}
+
 #[tokio::test]
 async fn a_task_nobody_ever_opened_is_not_found() {
     let k = PrivateKey::generate_ed25519();

--- a/freeq-server/tests/act_api.rs
+++ b/freeq-server/tests/act_api.rs
@@ -336,8 +336,9 @@ async fn one_task_comes_back_with_its_whole_event_history() {
     assert_eq!(status, 200);
     assert_eq!(
         body["events"].as_array().unwrap().len(),
-        4,
-        "the offer and its three follow-ups"
+        6,
+        "the offer, its three follow-ups, and a receipt for each of the two \
+         that moved the task"
     );
     assert!(
         body["events"][0]["canonical"]
@@ -355,6 +356,85 @@ async fn one_task_comes_back_with_its_whole_event_history() {
     // …and it is gone from the open-work listing.
     let (_, listing) = get(web, "/api/v1/actions", None).await;
     assert!(ids(&listing).is_empty());
+}
+
+/// A receipt is served from the log like any other event, and the bytes served
+/// are the bytes signed: this checks the stored canonical against the very key
+/// the server publishes as its own, which is the whole worth of a receipt.
+#[tokio::test]
+async fn the_event_list_carries_the_receipts_and_their_signatures_verify() {
+    use base64::Engine;
+
+    let ka = PrivateKey::generate_ed25519();
+    let kb = PrivateKey::generate_ed25519();
+    let (irc, web, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    let (task, accept_id) = tokio::task::spawn_blocking(move || {
+        let alice_key = SigningKey::from_bytes(&[21u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[22u8; 32]);
+        let mut a = C::authenticated(irc, "alice", DID_ALICE, ka);
+        a.msgsig(&alice_key);
+        a.join("#work");
+        let mut b = C::authenticated(irc, "bob", DID_BOB, kb);
+        b.msgsig(&bob_key);
+        b.join("#work");
+
+        let id = a.offer("#work", &channel_venue("#work"), DID_ALICE, &alice_key);
+        let ev = freeq_sdk::chatsig::new_event_id();
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "claim".into()),
+            ("+freeq.at/from".into(), DID_BOB.into()),
+            ("+freeq.at/act-id".into(), id.clone()),
+        ];
+        let pairs: Vec<(&str, &str)> = tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &channel_venue("#work"), &ev, &bob_key).unwrap();
+        let mut wire: Vec<String> = tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={ev}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        b.tx(&format!("@{} TAGMSG #work", wire.join(";")));
+        b.rx(|l| l.contains(&ev), "the claim is accepted");
+        (id, ev)
+    })
+    .await
+    .unwrap();
+
+    let (_, own) = get(web, "/api/v1/signing-key", None).await;
+    let published = own["publicKey"]
+        .as_str()
+        .or_else(|| own["public_key"].as_str())
+        .or_else(|| own["pubkey"].as_str())
+        .expect("the server publishes its key");
+    let raw = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(published)
+        .expect("base64url");
+    let key = ed25519_dalek::VerifyingKey::from_bytes(&raw.try_into().unwrap()).unwrap();
+
+    let (_, body) = get(web, &format!("/api/v1/actions/{task}"), None).await;
+    let events = body["events"].as_array().unwrap();
+    let receipt = events
+        .iter()
+        .find(|e| {
+            e["canonical"]
+                .as_str()
+                .is_some_and(|c| c.contains(r#""act-verb":"confirm""#))
+        })
+        .expect("the receipt is on file and served");
+
+    let canonical = receipt["canonical"].as_str().unwrap();
+    assert!(
+        canonical.contains(&format!(r#""act-subject":"{accept_id}""#)),
+        "it names the event it confirms: {canonical}"
+    );
+    assert!(
+        canonical.contains(r#""from":"did:web:test-act-api""#),
+        "signed under the server's own identity: {canonical}"
+    );
+    freeq_sdk::sigtag::verify_canonical(
+        canonical,
+        receipt["signature"].as_str().expect("a receipt is signed"),
+        &key,
+    )
+    .expect("the receipt verifies against the key the server publishes");
 }
 
 /// The server signs the expiry events it makes, and a signature is only worth

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -860,6 +860,256 @@ async fn a_task_runs_from_offer_to_completion() {
     .await;
 }
 
+// ── receipts ────────────────────────────────────────────────────────────────
+
+/// The `act-subject` of a receipt line, if the line is one.
+fn receipt_subject(line: &str) -> Option<String> {
+    if !line.contains("+freeq.at/act-verb=confirm") {
+        return None;
+    }
+    line.trim_start_matches('@')
+        .split(&[' ', ';'][..])
+        .find_map(|t| t.strip_prefix("+freeq.at/act-subject="))
+        .map(str::to_string)
+}
+
+/// The home's word about a move it filed: signed under `did:web:`, naming the
+/// event it confirms, and verifying against the key that server publishes.
+#[tokio::test]
+async fn a_state_transition_earns_a_receipt_the_home_signed() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        let task = open_task(&mut a, &alice_key, "#ops", Some(DID_BOB));
+        let accept_id = fresh_id();
+        b.tx(&follow_up_line(
+            "accept", DID_BOB, &task, "#ops", &accept_id, &bob_key,
+        ));
+
+        let receipt = b
+            .maybe(|l| l.contains("+freeq.at/act-verb=confirm"), 3_000)
+            .expect("the home confirms a move it filed");
+        assert_eq!(
+            receipt_subject(&receipt).as_deref(),
+            Some(accept_id.as_str()),
+            "the receipt names the event it confirms: {receipt}"
+        );
+        assert!(
+            receipt.contains(&format!("+freeq.at/act-id={task}")),
+            "and the action it belongs to: {receipt}"
+        );
+        assert!(
+            receipt.contains("+freeq.at/from=did:web:test-act"),
+            "signed under this server's own identity: {receipt}"
+        );
+        assert!(
+            receipt.contains("+freeq.at/sig=ed25519:"),
+            "with a signature: {receipt}"
+        );
+    })
+    .await;
+}
+
+/// One receipt per move, and none for anything that moved nothing: an opener
+/// (opening is the action), a progress report (`from` and `to` are the same
+/// state), or the server's own expiry (home-signed already).
+#[tokio::test]
+async fn only_a_move_earns_a_receipt_and_it_earns_exactly_one() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        // The offer opens the task; nothing raced it, so nothing confirms it.
+        let task = open_task(&mut a, &alice_key, "#ops", Some(DID_BOB));
+        assert!(
+            b.maybe(|l| l.contains("act-verb=confirm"), 600).is_none(),
+            "an opener is not confirmed"
+        );
+
+        let mut confirmed: Vec<String> = Vec::new();
+        for (verb, expect_receipt) in [("accept", true), ("progress", false), ("complete", true)] {
+            let id = fresh_id();
+            b.tx(&follow_up_line(verb, DID_BOB, &task, "#ops", &id, &bob_key));
+            match expect_receipt {
+                true => {
+                    let line = b
+                        .maybe(|l| l.contains("act-verb=confirm"), 3_000)
+                        .unwrap_or_else(|| panic!("{verb} moved the task and earns a receipt"));
+                    assert_eq!(receipt_subject(&line).as_deref(), Some(id.as_str()));
+                    confirmed.push(id);
+                }
+                // A report that leaves the task where it stood has no move to
+                // confirm. Waited out against the *next* step's receipt, which
+                // is what would arrive if this one were wrong.
+                false => assert!(
+                    b.maybe(|l| l.contains("act-verb=confirm"), 800).is_none(),
+                    "{verb} leaves the task where it stood and earns no receipt"
+                ),
+            }
+        }
+        assert_eq!(confirmed.len(), 2, "one receipt each, and no more");
+    })
+    .await;
+}
+
+/// A sender writing the home's verb is refused before any kind's table is
+/// consulted — not with UNKNOWN_VERB, which would say the kind is merely
+/// missing a row for it.
+#[tokio::test]
+async fn a_confirmation_from_a_sender_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        let task = open_task(&mut a, &signing, "#ops", None);
+
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "confirm".into()),
+            ("+freeq.at/from".into(), DID_ALICE.into()),
+            ("+freeq.at/act-id".into(), task.clone()),
+            ("+freeq.at/act-subject".into(), task.clone()),
+        ];
+        a.tx(&signed_line(&tags, "#ops", &fresh_id(), &signing));
+        let line = a.fail();
+        assert!(line.contains(" WRONG_SENDER "), "{line}");
+        assert!(
+            line.ends_with("Only the action's home confirms it"),
+            "the approved sentence: {line}"
+        );
+    })
+    .await;
+}
+
+/// A task in a direct conversation is confirmed too, and to both ends of it.
+/// The line names the thread from the sender's side — the same limitation the
+/// expiry notice carries, since a server-authored line has only the one target
+/// to write.
+#[tokio::test]
+async fn a_receipt_in_a_direct_conversation_reaches_both_participants() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+
+        let venue = freeq_sdk::chatsig::dm_venue(DID_ALICE, DID_BOB);
+        let id = fresh_id();
+        let tags = offer_tags();
+        let pairs: Vec<(&str, &str)> = tags.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &venue, &id, &alice_key).unwrap();
+        let mut wire: Vec<String> = tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={id}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        a.tx(&format!("@{} TAGMSG {DID_BOB}", wire.join(";")));
+        b.rx(|l| l.contains("+freeq.at/act="), "the DM task reaches bob");
+
+        // Bob accepts, in the same conversation, addressing alice.
+        let accept_id = fresh_id();
+        let steps: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "accept".into()),
+            ("+freeq.at/from".into(), DID_BOB.into()),
+            ("+freeq.at/act-id".into(), id.clone()),
+        ];
+        let pairs: Vec<(&str, &str)> = steps
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let sig = freeq_sdk::act::sign_act(pairs, &venue, &accept_id, &bob_key).unwrap();
+        let mut wire: Vec<String> = steps.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        wire.push(format!("{EVENT_ID_TAG}={accept_id}"));
+        wire.push(format!("+freeq.at/sig={sig}"));
+        b.tx(&format!("@{} TAGMSG {DID_ALICE}", wire.join(";")));
+
+        for c in [&mut a, &mut b] {
+            let line = c
+                .maybe(|l| l.contains("act-verb=confirm"), 3_000)
+                .expect("both ends of the conversation hear the receipt");
+            assert_eq!(receipt_subject(&line).as_deref(), Some(accept_id.as_str()));
+        }
+    })
+    .await;
+}
+
+/// Replay is where a late arrival learns what happened, receipts included —
+/// and a connection that did not ask for the capability gets none of it.
+#[tokio::test]
+async fn replay_carries_the_receipts_to_capability_holders_only() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let task = open_task(&mut a, &alice_key, "#ops", None);
+        let claim_id = fresh_id();
+        a.tx(&follow_up_line(
+            "claim", DID_ALICE, &task, "#ops", &claim_id, &alice_key,
+        ));
+        a.maybe(|l| l.contains("act-verb=confirm"), 3_000)
+            .expect("the claim is confirmed");
+        // A message too: the join replay interleaves task events with message
+        // history, so the batch needs one of each.
+        a.tx("PRIVMSG #ops :a line about it");
+
+        let mut late = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        late.tx("JOIN #ops");
+        let replayed = late
+            .maybe(|l| l.contains("act-verb=confirm"), 3_000)
+            .expect("the receipt replays like any other stored task event");
+        assert_eq!(
+            receipt_subject(&replayed).as_deref(),
+            Some(claim_id.as_str())
+        );
+        assert!(
+            replayed.contains("+freeq.at/sig="),
+            "with its signature, so a late arrival can check it: {replayed}"
+        );
+
+        let mut plain = C::guest(addr, "carol", BASE_CAPS);
+        plain.tx("JOIN #ops");
+        let ended = plain.rx(
+            |l| l.contains("+freeq.at/act") || l.split_whitespace().nth(1) == Some("366"),
+            "a task event, or the end of the burst",
+        );
+        assert!(
+            !ended.contains("+freeq.at/act"),
+            "no capability, no receipts either: {ended}"
+        );
+    })
+    .await;
+}
+
 // ── task history cannot be rewritten ────────────────────────────────────────
 
 #[tokio::test]

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -37,12 +37,22 @@ fn resolver_with(entries: Vec<(&str, &PrivateKey)>) -> DidResolver {
 }
 
 async fn start(resolver: DidResolver) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
-    start_with_expiry(resolver, 604_800).await
+    start_with_clocks(resolver, 604_800, 1_209_600).await
 }
 
 async fn start_with_expiry(
     resolver: DidResolver,
     act_expiry_secs: u64,
+) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
+    start_with_clocks(resolver, act_expiry_secs, 1_209_600).await
+}
+
+/// The two sweeps' limits: how long unfinished work may sit before it is
+/// expired, and how long submitted work may wait on its poster.
+async fn start_with_clocks(
+    resolver: DidResolver,
+    act_expiry_secs: u64,
+    act_review_secs: u64,
 ) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let db_path = tmp.path().to_str().unwrap().to_string();
@@ -53,6 +63,7 @@ async fn start_with_expiry(
         challenge_timeout_secs: 60,
         db_path: Some(db_path),
         act_expiry_secs,
+        act_review_secs,
         ..Default::default()
     };
     freeq_server::server::Server::with_resolver(config, resolver)
@@ -1137,6 +1148,21 @@ fn bounty_line(
     signed_line(&tags, channel, id, key)
 }
 
+/// Every task event this server serves back for a room, as wire lines.
+///
+/// What a sweep's own event is read back through: the server files those and
+/// does not put them on the wire live, so history is where they surface.
+fn act_events_in_history(c: &mut C, channel: &str) -> Vec<String> {
+    c.tx(&format!("CHATHISTORY LATEST {channel} * 50"));
+    let mut lines = Vec::new();
+    while let Some(line) = c.maybe(|_| true, 900) {
+        if line.contains("+freeq.at/act-verb=") {
+            lines.push(line);
+        }
+    }
+    lines
+}
+
 /// Open a bounty and return its id.
 fn open_bounty(c: &mut C, signing: &SigningKey, channel: &str) -> String {
     let id = fresh_id();
@@ -2096,6 +2122,143 @@ async fn chathistory_carries_a_task_posted_after_the_last_message() {
     .await;
 }
 
+// ── the review window ───────────────────────────────────────────────────────
+
+/// Work handed in and left unanswered is deemed accepted when the window
+/// closes — under the home's own signature, and under a verb of its own so the
+/// log says which of the two clocks fired.
+#[tokio::test]
+async fn work_left_unanswered_past_the_review_window_is_accepted() {
+    let ka = key();
+    let kb = key();
+    // The review window is a second; the abandonment limit is a week away, so
+    // whatever happens here is the review sweep's doing.
+    let (addr, _h) = start_with_clocks(
+        resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]),
+        604_800,
+        1,
+    )
+    .await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        // Alice says nothing at all. The sweep runs on its own clock, and
+        // files rather than announces — like the expiry sweep's own event, it
+        // is read back out of the log.
+        std::thread::sleep(Duration::from_secs(6));
+        let events = act_events_in_history(&mut b, "#ops");
+        let closed = events
+            .iter()
+            .find(|l| l.contains("+freeq.at/act-verb=auto-accept"))
+            .unwrap_or_else(|| panic!("the review window closes on its own: {events:?}"));
+        assert!(
+            closed.contains(&format!("+freeq.at/act-id={bounty}")),
+            "on the bounty that was waiting: {closed}"
+        );
+        assert!(
+            closed.contains("+freeq.at/from=did:web:test-act"),
+            "signed under the home's own identity: {closed}"
+        );
+        assert!(closed.contains("+freeq.at/sig="), "{closed}");
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=expire")),
+            "and not as an expiry, which would read as the worker dropping it"
+        );
+
+        // Terminal: the bounty takes nothing further.
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "TERMINAL_TASK");
+    })
+    .await;
+}
+
+/// The clock is per-submission: asking for changes is the poster meeting the
+/// window, and it moves the task, so the window starts again from there.
+#[tokio::test]
+async fn asking_for_changes_stops_the_review_clock() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start_with_clocks(
+        resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]),
+        604_800,
+        4,
+    )
+    .await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        let sent_back = fresh_id();
+        a.tx(&bounty_line(
+            "revise",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &sent_back,
+            &alice_key,
+        ));
+        b.rx(|l| l.contains(&sent_back), "the work is sent back");
+
+        // The task is assigned again, which is not a state this clock owns —
+        // so nothing closes it, however many passes the sweep makes.
+        std::thread::sleep(Duration::from_secs(12));
+        let events = act_events_in_history(&mut b, "#ops");
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=auto-accept")),
+            "a poster who answered is never auto-accepted: {events:?}"
+        );
+    })
+    .await;
+}
+
 // ── expiry ──────────────────────────────────────────────────────────────────
 
 /// Everything at once: the sweep signs its own event under the server's
@@ -2126,6 +2289,47 @@ async fn an_abandoned_task_expires_and_the_room_is_told() {
         assert!(
             notice.ends_with("Task expired without completion: review-the-deploy"),
             "the approved sentence, with the offer's own title: {notice}"
+        );
+    })
+    .await;
+}
+
+/// The neutral clock still catches work somebody took and walked away from.
+/// The two sweeps own different states, so a bounty that was never handed in
+/// is expired rather than accepted.
+#[tokio::test]
+async fn assigned_work_nobody_touches_still_expires() {
+    let ka = key();
+    let kb = key();
+    // Both clocks short, and the review one shorter — so if the review sweep
+    // reached beyond its own states this would come back as an acceptance.
+    let (addr, _h) =
+        start_with_clocks(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]), 2, 1).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        // Bob never hands anything in.
+        b.maybe(
+            |l| l.contains("NOTICE") && l.contains("Task expired"),
+            90_000,
+        )
+        .expect("the abandonment sweep reaches it");
+        let events = act_events_in_history(&mut b, "#ops");
+        assert!(
+            events.iter().any(|l| l.contains("act-verb=expire")),
+            "expired, because nothing was ever delivered: {events:?}"
+        );
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=auto-accept")),
+            "and the review clock did not reach past the states it owns: {events:?}"
         );
     })
     .await;

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1112,12 +1112,12 @@ async fn replay_carries_the_receipts_to_capability_holders_only() {
 
 // ── bounty: the second kind, and no code of its own ─────────────────────────
 
-/// A bounty step, signed. `to` is the winner an award names.
+/// A bounty step, signed. `accepts` is the bid an award takes.
 fn bounty_line(
     verb: &str,
     from: &str,
     task: Option<&str>,
-    to: Option<&str>,
+    accepts: Option<&str>,
     channel: &str,
     id: &str,
     key: &SigningKey,
@@ -1131,17 +1131,29 @@ fn bounty_line(
         Some(t) => tags.push(("+freeq.at/act-id".into(), t.into())),
         None => tags.push(("+freeq.at/act-title".into(), "index-the-archive".into())),
     }
-    if let Some(to) = to {
-        tags.push(("+freeq.at/act-to".into(), to.into()));
+    if let Some(accepts) = accepts {
+        tags.push(("+freeq.at/act-accepts".into(), accepts.into()));
     }
     signed_line(&tags, channel, id, key)
 }
 
+/// A bounty opener carrying a recipient, which is the one thing it cannot do.
+fn directed_bounty_line(from: &str, channel: &str, id: &str, key: &SigningKey) -> String {
+    let tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "bounty".into()),
+        ("+freeq.at/act-verb".into(), "offer".into()),
+        ("+freeq.at/from".into(), from.into()),
+        ("+freeq.at/act-title".into(), "index-the-archive".into()),
+        ("+freeq.at/act-to".into(), DID_BOB.into()),
+    ];
+    signed_line(&tags, channel, id, key)
+}
+
 /// The test of generality: a second kind that needed a table row and no code.
-/// Bids pile up without moving anything, the poster names a winner, and the
-/// winner — not the poster who named them — is the one who can finish it.
+/// Bids pile up without moving anything, the poster takes one of them, and its
+/// author — not the poster who took it — is the one who can finish the work.
 #[tokio::test]
-async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
+async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
     let ka = key();
     let kb = key();
     let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
@@ -1162,6 +1174,7 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
         a.rx(|l| l.contains(&bounty), "the bounty opens");
 
         // Two bids, from two agents, neither of which moves it.
+        let mut bids = Vec::new();
         for (did, k) in [(DID_ALICE, &alice_key), (DID_BOB, &bob_key)] {
             let bid = fresh_id();
             let line = bounty_line("bid", did, Some(&bounty), None, "#ops", &bid, k);
@@ -1170,16 +1183,17 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
                 false => b.tx(&line),
             }
             b.rx(|l| l.contains(&bid), "the bid is accepted");
+            bids.push(bid);
         }
 
-        // The poster picks. Bob is the winner; alice named him and did not
-        // become him.
+        // The poster takes bob's bid — the second one, so the assignee cannot
+        // have come from the sender or from whichever bid arrived first.
         let award = fresh_id();
         a.tx(&bounty_line(
             "award",
             DID_ALICE,
             Some(&bounty),
-            Some(DID_BOB),
+            Some(&bids[1]),
             "#ops",
             &award,
             &alice_key,
@@ -1214,11 +1228,11 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
     .await;
 }
 
-/// An award naming nobody assigns nobody, so the row's `requires` refuses it —
+/// An award naming no bid takes nothing, so the row's `requires` refuses it —
 /// and the sentence names the field rather than the verb, because which field
 /// a step needs is the rules file's to say.
 #[tokio::test]
-async fn an_award_that_names_no_winner_is_refused() {
+async fn an_award_that_names_no_bid_is_refused() {
     let k = key();
     let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
     run(addr, move |addr| {
@@ -1245,9 +1259,75 @@ async fn an_award_that_names_no_winner_is_refused() {
         let line = a.fail();
         assert!(line.contains(" MISSING_REQUIREMENT "), "{line}");
         assert!(
-            line.ends_with("That step must carry act-to"),
+            line.ends_with("That step must carry act-accepts"),
             "the approved sentence names the missing field: {line}"
         );
+    })
+    .await;
+}
+
+/// An award points at one event, and only a bid on the same action answers.
+/// The bounty's own opener is not one, and neither is an id nobody filed.
+#[tokio::test]
+async fn an_award_naming_a_non_bid_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+
+        let bounty = fresh_id();
+        a.tx(&bounty_line(
+            "offer", DID_ALICE, None, None, "#ops", &bounty, &signing,
+        ));
+        a.rx(|l| l.contains(&bounty), "the bounty opens");
+
+        let bid = fresh_id();
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &bid,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&bid), "the bid is accepted");
+
+        // The opener, and then an id this server never filed at all.
+        for named in [bounty.clone(), fresh_id()] {
+            a.tx(&bounty_line(
+                "award",
+                DID_ALICE,
+                Some(&bounty),
+                Some(&named),
+                "#ops",
+                &fresh_id(),
+                &signing,
+            ));
+            let line = a.fail();
+            assert!(line.contains(" ACCEPTS_NOT_A_BID "), "{named}: {line}");
+            assert!(
+                line.ends_with("The award names an event that is not a bid on this action"),
+                "{line}"
+            );
+        }
+
+        // …and the bid itself still works, so the refusals were about what
+        // was named and not about the award.
+        let done = fresh_id();
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&bounty),
+            Some(&bid),
+            "#ops",
+            &done,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&done), "the award is accepted");
     })
     .await;
 }
@@ -1263,11 +1343,8 @@ async fn a_bounty_opened_to_one_recipient_is_refused() {
         let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
         a.msgsig(&signing);
         a.join("#ops");
-        a.tx(&bounty_line(
-            "offer",
+        a.tx(&directed_bounty_line(
             DID_ALICE,
-            None,
-            Some(DID_BOB),
             "#ops",
             &fresh_id(),
             &signing,

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -367,7 +367,7 @@ async fn a_kind_the_rules_file_does_not_list_is_refused() {
         a.msgsig(&signing);
         a.join("#ops");
         let mut tags = offer_tags();
-        tags[0].1 = "bounty".into(); // a real kind, not one this server has
+        tags[0].1 = "approval".into(); // a real kind, not one this server has
         a.tx(&signed_line(&tags, "#ops", &fresh_id(), &signing));
         assert_eq!(a.fail_code(), "UNKNOWN_KIND");
     })
@@ -1106,6 +1106,173 @@ async fn replay_carries_the_receipts_to_capability_holders_only() {
             !ended.contains("+freeq.at/act"),
             "no capability, no receipts either: {ended}"
         );
+    })
+    .await;
+}
+
+// ── bounty: the second kind, and no code of its own ─────────────────────────
+
+/// A bounty step, signed. `to` is the winner an award names.
+fn bounty_line(
+    verb: &str,
+    from: &str,
+    task: Option<&str>,
+    to: Option<&str>,
+    channel: &str,
+    id: &str,
+    key: &SigningKey,
+) -> String {
+    let mut tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "bounty".into()),
+        ("+freeq.at/act-verb".into(), verb.into()),
+        ("+freeq.at/from".into(), from.into()),
+    ];
+    match task {
+        Some(t) => tags.push(("+freeq.at/act-id".into(), t.into())),
+        None => tags.push(("+freeq.at/act-title".into(), "index-the-archive".into())),
+    }
+    if let Some(to) = to {
+        tags.push(("+freeq.at/act-to".into(), to.into()));
+    }
+    signed_line(&tags, channel, id, key)
+}
+
+/// The test of generality: a second kind that needed a table row and no code.
+/// Bids pile up without moving anything, the poster names a winner, and the
+/// winner — not the poster who named them — is the one who can finish it.
+#[tokio::test]
+async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        let bounty = fresh_id();
+        a.tx(&bounty_line(
+            "offer", DID_ALICE, None, None, "#ops", &bounty, &alice_key,
+        ));
+        a.rx(|l| l.contains(&bounty), "the bounty opens");
+
+        // Two bids, from two agents, neither of which moves it.
+        for (did, k) in [(DID_ALICE, &alice_key), (DID_BOB, &bob_key)] {
+            let bid = fresh_id();
+            let line = bounty_line("bid", did, Some(&bounty), None, "#ops", &bid, k);
+            match did == DID_ALICE {
+                true => a.tx(&line),
+                false => b.tx(&line),
+            }
+            b.rx(|l| l.contains(&bid), "the bid is accepted");
+        }
+
+        // The poster picks. Bob is the winner; alice named him and did not
+        // become him.
+        let award = fresh_id();
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&bounty),
+            Some(DID_BOB),
+            "#ops",
+            &award,
+            &alice_key,
+        ));
+        b.rx(|l| l.contains(&award), "the award is accepted");
+
+        // The loser cannot finish work that is not theirs…
+        a.tx(&bounty_line(
+            "complete",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "WRONG_SENDER");
+
+        // …and the winner can.
+        let done = fresh_id();
+        b.tx(&bounty_line(
+            "complete",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &done,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&done), "the winner finishes it");
+    })
+    .await;
+}
+
+/// An award naming nobody assigns nobody, so the row's `requires` refuses it —
+/// and the sentence names the field rather than the verb, because which field
+/// a step needs is the rules file's to say.
+#[tokio::test]
+async fn an_award_that_names_no_winner_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+
+        let bounty = fresh_id();
+        a.tx(&bounty_line(
+            "offer", DID_ALICE, None, None, "#ops", &bounty, &signing,
+        ));
+        a.rx(|l| l.contains(&bounty), "the bounty opens");
+
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        let line = a.fail();
+        assert!(line.contains(" MISSING_REQUIREMENT "), "{line}");
+        assert!(
+            line.ends_with("That step must carry act-to"),
+            "the approved sentence names the missing field: {line}"
+        );
+    })
+    .await;
+}
+
+/// A bounty is open by construction — a directed one is just a handoff — so
+/// an opener carrying a recipient is a step the kind cannot take.
+#[tokio::test]
+async fn a_bounty_opened_to_one_recipient_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        a.tx(&bounty_line(
+            "offer",
+            DID_ALICE,
+            None,
+            Some(DID_BOB),
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        assert_eq!(a.fail_code(), "ILLEGAL_STEP");
     })
     .await;
 }

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -2244,10 +2244,18 @@ async fn work_left_unanswered_past_the_review_window_is_accepted() {
         ));
         b.rx(|l| l.contains(&handed_in), "the work is handed in");
 
-        // Alice says nothing at all. The sweep runs on its own clock, and
-        // files rather than announces — like the expiry sweep's own event, it
-        // is read back out of the log.
-        std::thread::sleep(Duration::from_secs(6));
+        // Alice says nothing at all. The sweep runs on its own clock, and the
+        // room hears the window close the way it hears an expiry.
+        let notice = b
+            .maybe(
+                |l| l.contains("NOTICE") && l.contains("Task accepted"),
+                8_000,
+            )
+            .expect("the room hears the review window close");
+        assert!(
+            notice.ends_with("Task accepted without review: index-the-archive"),
+            "the approved sentence, with the bounty's own title: {notice}"
+        );
         let events = act_events_in_history(&mut b, "#ops");
         let closed = events
             .iter()

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1137,6 +1137,51 @@ fn bounty_line(
     signed_line(&tags, channel, id, key)
 }
 
+/// Open a bounty and return its id.
+fn open_bounty(c: &mut C, signing: &SigningKey, channel: &str) -> String {
+    let id = fresh_id();
+    c.tx(&bounty_line(
+        "offer", DID_ALICE, None, None, channel, &id, signing,
+    ));
+    c.rx(|l| l.contains(&id), "the bounty opens");
+    id
+}
+
+/// Open a bounty, take bob's bid on it, and return its id — the setup every
+/// test of the review half starts from.
+fn award_to_bob(
+    a: &mut C,
+    b: &mut C,
+    alice_key: &SigningKey,
+    bob_key: &SigningKey,
+    channel: &str,
+) -> String {
+    let bounty = open_bounty(a, alice_key, channel);
+    let bid = fresh_id();
+    b.tx(&bounty_line(
+        "bid",
+        DID_BOB,
+        Some(&bounty),
+        None,
+        channel,
+        &bid,
+        bob_key,
+    ));
+    b.rx(|l| l.contains(&bid), "the bid is accepted");
+    let award = fresh_id();
+    a.tx(&bounty_line(
+        "award",
+        DID_ALICE,
+        Some(&bounty),
+        Some(&bid),
+        channel,
+        &award,
+        alice_key,
+    ));
+    b.rx(|l| l.contains(&award), "the award is accepted");
+    bounty
+}
+
 /// A bounty opener carrying a recipient, which is the one thing it cannot do.
 fn directed_bounty_line(from: &str, channel: &str, id: &str, key: &SigningKey) -> String {
     let tags: Vec<(String, String)> = vec![
@@ -1200,9 +1245,9 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
         ));
         b.rx(|l| l.contains(&award), "the award is accepted");
 
-        // The loser cannot finish work that is not theirs…
+        // The loser cannot hand in work that is not theirs…
         a.tx(&bounty_line(
-            "complete",
+            "submit",
             DID_ALICE,
             Some(&bounty),
             None,
@@ -1215,7 +1260,7 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
         // …and the winner can.
         let done = fresh_id();
         b.tx(&bounty_line(
-            "complete",
+            "submit",
             DID_BOB,
             Some(&bounty),
             None,
@@ -1223,7 +1268,207 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
             &done,
             &bob_key,
         ));
-        b.rx(|l| l.contains(&done), "the winner finishes it");
+        b.rx(|l| l.contains(&done), "the winner hands it in");
+    })
+    .await;
+}
+
+/// The bounty's own half of the lifecycle, on the wire: the worker hands the
+/// work in, the poster sends it back once, the worker hands it in again, and
+/// the poster takes it. The poster's word ends it, not the worker's — which is
+/// the whole difference from a handoff.
+#[tokio::test]
+async fn submitted_work_is_sent_back_once_and_then_accepted_by_the_poster() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        for verb in ["revise", "accept-work"] {
+            let handed_in = fresh_id();
+            b.tx(&bounty_line(
+                "submit",
+                DID_BOB,
+                Some(&bounty),
+                None,
+                "#ops",
+                &handed_in,
+                &bob_key,
+            ));
+            b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+            let answer = fresh_id();
+            a.tx(&bounty_line(
+                verb,
+                DID_ALICE,
+                Some(&bounty),
+                None,
+                "#ops",
+                &answer,
+                &alice_key,
+            ));
+            b.rx(|l| l.contains(&answer), verb);
+        }
+
+        // Accepted is terminal: there is nothing further to hand in.
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "TERMINAL_TASK");
+    })
+    .await;
+}
+
+/// Once the work is in, the poster's only moves are taking it and sending it
+/// back — and signing off on the work is not the worker's to do.
+#[tokio::test]
+async fn delivered_work_is_neither_withdrawn_nor_self_accepted() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        a.tx(&bounty_line(
+            "cancel",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "ILLEGAL_STEP");
+
+        b.tx(&bounty_line(
+            "accept-work",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "WRONG_SENDER");
+    })
+    .await;
+}
+
+/// A bounty is not a handoff, and its worker has no verb that ends it. The
+/// two that would are ones the kind's table simply does not list.
+#[tokio::test]
+async fn a_bounty_has_no_complete_and_no_fail() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        let bounty = open_bounty(&mut a, &signing, "#ops");
+        for verb in ["complete", "fail"] {
+            a.tx(&bounty_line(
+                verb,
+                DID_ALICE,
+                Some(&bounty),
+                None,
+                "#ops",
+                &fresh_id(),
+                &signing,
+            ));
+            assert_eq!(a.fail_code(), "UNKNOWN_VERB", "{verb}");
+        }
+    })
+    .await;
+}
+
+/// The worker's exit, from either state they may hold the work in.
+#[tokio::test]
+async fn the_worker_forfeits_the_work_and_the_bounty_is_finished() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        // Not the poster's to give up on the worker's behalf.
+        a.tx(&bounty_line(
+            "forfeit",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "WRONG_SENDER");
+
+        let gone = fresh_id();
+        b.tx(&bounty_line(
+            "forfeit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &gone,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&gone), "the worker walks away");
+
+        a.tx(&bounty_line(
+            "revise",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "TERMINAL_TASK");
     })
     .await;
 }

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1625,6 +1625,88 @@ async fn a_bounty_opened_to_one_recipient_is_refused() {
     .await;
 }
 
+/// A bounty takes bids until the cutoff its offer named, which the server
+/// reads back out of the opener rather than out of a column. The offer's own
+/// deadline is a different time and bounds a different move.
+#[tokio::test]
+async fn a_bounty_stops_taking_bids_at_the_cutoff_its_offer_named() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        // Relative to now, because the ids these bids are minted with have to
+        // be near this server's clock to be adopted at all.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+
+        // A bounty whose bidding closed an hour ago…
+        let closed = open_priced_bounty(&mut a, &signing, "#ops", now - 3_600);
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&closed),
+            None,
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        assert_eq!(a.fail_code(), "DEADLINE_PASSED");
+
+        // …and one that is still taking them. Sent after a pause, because the
+        // act flood counter is per connection and this is the sixth event.
+        std::thread::sleep(Duration::from_millis(2_500));
+        let open = open_priced_bounty(&mut a, &signing, "#ops", now + 3_600);
+        let bid = fresh_id();
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&open),
+            None,
+            "#ops",
+            &bid,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&bid), "a bid inside the cutoff");
+
+        // The award is bound by act-deadline, which neither offer named, so
+        // bidding closing does not stop the poster picking.
+        let award = fresh_id();
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&open),
+            Some(&bid),
+            "#ops",
+            &award,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&award), "the award is accepted");
+    })
+    .await;
+}
+
+/// A bounty naming what it pays and how long it takes bids. The price is
+/// carried and never read; the cutoff is a time the referee compares.
+fn open_priced_bounty(c: &mut C, signing: &SigningKey, channel: &str, cutoff: i64) -> String {
+    let id = fresh_id();
+    let tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "bounty".into()),
+        ("+freeq.at/act-verb".into(), "offer".into()),
+        ("+freeq.at/from".into(), DID_ALICE.into()),
+        ("+freeq.at/act-title".into(), "index-the-archive".into()),
+        ("+freeq.at/act-bid-deadline".into(), cutoff.to_string()),
+        ("+freeq.at/act-price".into(), "250-USD".into()),
+    ];
+    c.tx(&signed_line(&tags, channel, &id, signing));
+    c.rx(|l| l.contains(&id), "the bounty opens");
+    id
+}
+
 // ── the revival relation ────────────────────────────────────────────────────
 
 /// An opener that names the finished action it revives.

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1110,6 +1110,155 @@ async fn replay_carries_the_receipts_to_capability_holders_only() {
     .await;
 }
 
+// ── the revival relation ────────────────────────────────────────────────────
+
+/// An opener that names the finished action it revives.
+fn re_offer_line(from: &str, replaces: &str, channel: &str, id: &str, key: &SigningKey) -> String {
+    let tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "handoff".into()),
+        ("+freeq.at/act-verb".into(), "offer".into()),
+        ("+freeq.at/from".into(), from.into()),
+        (
+            "+freeq.at/act-title".into(),
+            "review-the-deploy-again".into(),
+        ),
+        ("+freeq.at/act-replaces".into(), replaces.into()),
+    ];
+    signed_line(&tags, channel, id, key)
+}
+
+/// A failed handoff, re-offered: the new action carries the link and the old
+/// one is left exactly as it ended.
+#[tokio::test]
+async fn a_re_offer_carries_the_link_to_the_action_it_revives() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        let dead = open_task(&mut a, &alice_key, "#ops", Some(DID_BOB));
+        for verb in ["accept", "fail"] {
+            b.tx(&follow_up_line(
+                verb,
+                DID_BOB,
+                &dead,
+                "#ops",
+                &fresh_id(),
+                &bob_key,
+            ));
+            b.rx(|l| l.contains(&format!("act-verb={verb}")), verb);
+        }
+
+        let revived = fresh_id();
+        a.tx(&re_offer_line(
+            DID_ALICE, &dead, "#ops", &revived, &alice_key,
+        ));
+        let line = a.rx(|l| l.contains(&revived), "the re-offer is accepted");
+        assert!(
+            line.contains(&format!("+freeq.at/act-replaces={dead}")),
+            "the link rides the wire, inside the signature: {line}"
+        );
+    })
+    .await;
+}
+
+/// Reviving something still running would leave two live actions each
+/// claiming to be the work.
+#[tokio::test]
+async fn a_re_offer_naming_a_live_action_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        let live = open_task(&mut a, &signing, "#ops", None);
+
+        a.tx(&re_offer_line(
+            DID_ALICE,
+            &live,
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        let line = a.fail();
+        assert!(line.contains(" REPLACES_NOT_TERMINAL "), "{line}");
+        assert!(
+            line.ends_with("The action it replaces is not finished"),
+            "the approved sentence: {line}"
+        );
+    })
+    .await;
+}
+
+/// The relation belongs to an opener. A step on an action that already exists
+/// names no other.
+#[tokio::test]
+async fn a_step_that_carries_the_revival_relation_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        let task = open_task(&mut a, &signing, "#ops", None);
+
+        let tags: Vec<(String, String)> = vec![
+            ("+freeq.at/act".into(), "handoff".into()),
+            ("+freeq.at/act-verb".into(), "claim".into()),
+            ("+freeq.at/from".into(), DID_ALICE.into()),
+            ("+freeq.at/act-id".into(), task.clone()),
+            ("+freeq.at/act-replaces".into(), task.clone()),
+        ];
+        a.tx(&signed_line(&tags, "#ops", &fresh_id(), &signing));
+        let line = a.fail();
+        assert!(line.contains(" REPLACES_NOT_OPENER "), "{line}");
+        assert!(
+            line.ends_with("Only a new action replaces an earlier one"),
+            "the approved sentence: {line}"
+        );
+    })
+    .await;
+}
+
+/// A value that could not be an action id is answered as itself, rather than
+/// as a link to an action nobody filed.
+#[tokio::test]
+async fn a_revival_naming_something_that_is_not_an_action_id_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        a.tx(&re_offer_line(
+            DID_ALICE,
+            "the-last-one",
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        let line = a.fail();
+        assert!(line.contains(" REPLACES_MALFORMED "), "{line}");
+        assert!(
+            line.ends_with("That is not the id of an action"),
+            "the approved sentence: {line}"
+        );
+    })
+    .await;
+}
+
 // ── task history cannot be rewritten ────────────────────────────────────────
 
 #[tokio::test]

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1581,7 +1581,7 @@ async fn an_award_naming_a_non_bid_is_refused() {
             let line = a.fail();
             assert!(line.contains(" ACCEPTS_NOT_A_BID "), "{named}: {line}");
             assert!(
-                line.ends_with("The award names an event that is not a bid on this action"),
+                line.ends_with("That award names no bid on this task"),
                 "{line}"
             );
         }

--- a/server.toml.example
+++ b/server.toml.example
@@ -30,6 +30,10 @@
 # message_retention_days = 0
 ## How long a task may sit unfinished before the sweep expires it (seconds; 0 = never):
 # act_expiry_secs = 604800
+## How long submitted work waits on the poster before it is deemed accepted
+## (seconds; 0 = never). Every bidder sees this window, so changing it changes
+## the terms they bid under:
+# act_review_secs = 1209600
 
 ## ── Federation (iroh + S2S) ────────────────────────────────────────
 # iroh = true

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -117,6 +117,23 @@
       "target": "dm:did:plc:factory,did:plc:opslead"
     },
     {
+      "canonical": "{\"act\":\"handoff\",\"act-replaces\":\"01JABCDEF000000000000000EF\",\"act-title\":\"Cite 3 sources on X\",\"act-verb\":\"offer\",\"from\":\"did:plc:eliza\",\"id\":\"01JREOFFEREVENTID000000000\",\"target\":\"#ops\"}",
+      "id": "01JREOFFEREVENTID000000000",
+      "kid": "ckVnIEEgN6azOfiEzm2Ruw",
+      "name": "re-offer-replacing-a-failed-handoff",
+      "publicKey": "iodf_x6zhFFXes1a_uQFRWVo3XyJ4JCGOgVXvHr0nxc",
+      "seed": "0606060606060606060606060606060606060606060606060606060606060606",
+      "sigTag": "ed25519:ckVnIEEgN6azOfiEzm2Ruw:EdjZIKc0BF54ho69jWZJJcqs071xtL8sgih_a43iVj2RVnBn-H7BnHA7nh2x1PpIIn1hGS4_Uv0OWLKkv3uRDw",
+      "tags": {
+        "+freeq.at/act": "handoff",
+        "+freeq.at/act-replaces": "01JABCDEF000000000000000EF",
+        "+freeq.at/act-title": "Cite 3 sources on X",
+        "+freeq.at/act-verb": "offer",
+        "+freeq.at/from": "did:plc:eliza"
+      },
+      "target": "#ops"
+    },
+    {
       "canonical": "{\"act\":\"handoff\",\"act-id\":\"01JABCDEF000000000000000EF\",\"act-subject\":\"01JACCEPTEVENTID0000000000\",\"act-verb\":\"confirm\",\"from\":\"did:web:irc.example\",\"id\":\"01JCONFIRMEVENTID000000000\",\"target\":\"#ops\"}",
       "id": "01JCONFIRMEVENTID000000000",
       "kid": "dZl3bDCF4_naDRMHHrC0qw",

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -36,6 +36,15 @@
       "vector": "receipt-confirming-an-accept"
     },
     {
+      "expected": "invalid",
+      "id": "01JAWARDEVENTID000000000A",
+      "name": "award-with-its-winner-stripped",
+      "strippedTag": "+freeq.at/act-to",
+      "tamperedCanonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
+      "target": "#swarm",
+      "vector": "bounty-award"
+    },
+    {
       "expected": "unverifiable",
       "id": "01JABCDEF000000000000000EF",
       "name": "missing-from",
@@ -115,6 +124,40 @@
         "+freeq.at/from": "did:plc:factory"
       },
       "target": "dm:did:plc:factory,did:plc:opslead"
+    },
+    {
+      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-note\":\"two days, sources included\",\"act-verb\":\"bid\",\"from\":\"did:plc:scholar\",\"id\":\"01JBIDEVENTID00000000000B\",\"target\":\"#swarm\"}",
+      "id": "01JBIDEVENTID00000000000B",
+      "kid": "_oEsEvOrTOasXbaaw1L5Bg",
+      "name": "bounty-bid",
+      "publicKey": "6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw",
+      "seed": "0707070707070707070707070707070707070707070707070707070707070707",
+      "sigTag": "ed25519:_oEsEvOrTOasXbaaw1L5Bg:qmW9LGYR9JC6x10bmWFGcgbZuwvE20lEvnaraOlJ_m1sHKDLOChk8K2pUgjmKx2mkAhJlGbIR8REvqNT8Nj4Dg",
+      "tags": {
+        "+freeq.at/act": "bounty",
+        "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
+        "+freeq.at/act-note": "two days, sources included",
+        "+freeq.at/act-verb": "bid",
+        "+freeq.at/from": "did:plc:scholar"
+      },
+      "target": "#swarm"
+    },
+    {
+      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-to\":\"did:plc:scholar\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
+      "id": "01JAWARDEVENTID000000000A",
+      "kid": "XCm3jxCjWkmmIx0I7oQKBA",
+      "name": "bounty-award",
+      "publicKey": "E5j2LG0aRXxRumpLXz29L2n8qTIWIY3ImX5Ba9F9k8o",
+      "seed": "0808080808080808080808080808080808080808080808080808080808080808",
+      "sigTag": "ed25519:XCm3jxCjWkmmIx0I7oQKBA:812WbPDfzcqaVteOZykVBA6VfGzmUrr1JFJMMdTEdmeRQrd5BI45326wKNoBkAKRaRagqGFsN7Q02RO5VhkuCg",
+      "tags": {
+        "+freeq.at/act": "bounty",
+        "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
+        "+freeq.at/act-to": "did:plc:scholar",
+        "+freeq.at/act-verb": "award",
+        "+freeq.at/from": "did:plc:eliza"
+      },
+      "target": "#swarm"
     },
     {
       "canonical": "{\"act\":\"handoff\",\"act-replaces\":\"01JABCDEF000000000000000EF\",\"act-title\":\"Cite 3 sources on X\",\"act-verb\":\"offer\",\"from\":\"did:plc:eliza\",\"id\":\"01JREOFFEREVENTID000000000\",\"target\":\"#ops\"}",

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -126,17 +126,19 @@
       "target": "dm:did:plc:factory,did:plc:opslead"
     },
     {
-      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-note\":\"two days, sources included\",\"act-verb\":\"bid\",\"from\":\"did:plc:scholar\",\"id\":\"01JBIDEVENTID00000000000B\",\"target\":\"#swarm\"}",
+      "canonical": "{\"act\":\"bounty\",\"act-bid\":\"250 USD\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-note\":\"two days, sources included\",\"act-pay-to\":\"did:plc:scholar\",\"act-verb\":\"bid\",\"from\":\"did:plc:scholar\",\"id\":\"01JBIDEVENTID00000000000B\",\"target\":\"#swarm\"}",
       "id": "01JBIDEVENTID00000000000B",
       "kid": "_oEsEvOrTOasXbaaw1L5Bg",
       "name": "bounty-bid",
       "publicKey": "6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw",
       "seed": "0707070707070707070707070707070707070707070707070707070707070707",
-      "sigTag": "ed25519:_oEsEvOrTOasXbaaw1L5Bg:qmW9LGYR9JC6x10bmWFGcgbZuwvE20lEvnaraOlJ_m1sHKDLOChk8K2pUgjmKx2mkAhJlGbIR8REvqNT8Nj4Dg",
+      "sigTag": "ed25519:_oEsEvOrTOasXbaaw1L5Bg:vEPW9qAXNEUR-A_jtlHzP1thuNJ_gy2py2sAWarLLmnZxBVUWZXXUpL1O_5EQnEYlQ2-w27ZmG81r_d3X_TyCg",
       "tags": {
         "+freeq.at/act": "bounty",
+        "+freeq.at/act-bid": "250 USD",
         "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
         "+freeq.at/act-note": "two days, sources included",
+        "+freeq.at/act-pay-to": "did:plc:scholar",
         "+freeq.at/act-verb": "bid",
         "+freeq.at/from": "did:plc:scholar"
       },

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -38,8 +38,8 @@
     {
       "expected": "invalid",
       "id": "01JAWARDEVENTID000000000A",
-      "name": "award-with-its-winner-stripped",
-      "strippedTag": "+freeq.at/act-to",
+      "name": "award-with-its-bid-stripped",
+      "strippedTag": "+freeq.at/act-accepts",
       "tamperedCanonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
       "target": "#swarm",
       "vector": "bounty-award"
@@ -143,17 +143,17 @@
       "target": "#swarm"
     },
     {
-      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-to\":\"did:plc:scholar\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
+      "canonical": "{\"act\":\"bounty\",\"act-accepts\":\"01JBIDEVENTID00000000000B\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
       "id": "01JAWARDEVENTID000000000A",
       "kid": "XCm3jxCjWkmmIx0I7oQKBA",
       "name": "bounty-award",
       "publicKey": "E5j2LG0aRXxRumpLXz29L2n8qTIWIY3ImX5Ba9F9k8o",
       "seed": "0808080808080808080808080808080808080808080808080808080808080808",
-      "sigTag": "ed25519:XCm3jxCjWkmmIx0I7oQKBA:812WbPDfzcqaVteOZykVBA6VfGzmUrr1JFJMMdTEdmeRQrd5BI45326wKNoBkAKRaRagqGFsN7Q02RO5VhkuCg",
+      "sigTag": "ed25519:XCm3jxCjWkmmIx0I7oQKBA:wrN_n38AQwose1bwTeLVs9cH5BvIilDESRG-dCkPfIjHIBnnS04FJmFMGxdFpSgezg3sJC0trQJ2xbb_1CtUAg",
       "tags": {
         "+freeq.at/act": "bounty",
+        "+freeq.at/act-accepts": "01JBIDEVENTID00000000000B",
         "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
-        "+freeq.at/act-to": "did:plc:scholar",
         "+freeq.at/act-verb": "award",
         "+freeq.at/from": "did:plc:eliza"
       },

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -5,6 +5,7 @@
   "eventIdRule": "An offer carries no act-id: its own event id is the task's id. Every later event in a task's life names that id in act-id, and mints its own id for itself.",
   "kidRule": "base64url-nopad(sha256(raw 32-byte ed25519 public key)[0..16])",
   "mandatoryFieldRule": "`from`, `id` and `target` are mandatory. A document missing one reads unverifiable, never invalid: none is act-prefixed, so tag coverage cannot strip-detect it, and an absence is not evidence about the sender.",
+  "negativeRule": "A negative names a vector and the conditions to check it under. `strippedTag` removes a wire tag and `swappedTag` rewrites one before verifying; `sigAlgorithm` relabels the signature's algorithm; `target` and `id` are the delivery context to rebuild from. Every `invalid` negative also carries the canonical those conditions rebuild to, so a byte-level suite with no verifier can still check it; an `unverifiable` one carries none, because having no canonical to rebuild is what unverifiable means.",
   "negatives": [
     {
       "expected": "invalid",
@@ -21,6 +22,18 @@
       "tamperedCanonical": "{\"act\":\"handoff\",\"act-caps\":\"freeq.at/web-search\",\"act-ctx-h\":\"sha256:9f00\",\"act-deadline\":\"1788000000\",\"act-title\":\"Cite 3 sources on X\",\"act-to\":\"did:plc:scholar\",\"act-verb\":\"offer\",\"from\":\"did:plc:eliza\",\"id\":\"01JOTHEREVENTID00000000000\",\"target\":\"#ops\"}",
       "target": "#ops",
       "vector": "directed-offer"
+    },
+    {
+      "expected": "invalid",
+      "id": "01JCONFIRMEVENTID000000000",
+      "name": "receipt-with-a-swapped-subject",
+      "swappedTag": {
+        "name": "+freeq.at/act-subject",
+        "value": "01JOTHEREVENTID00000000000"
+      },
+      "tamperedCanonical": "{\"act\":\"handoff\",\"act-id\":\"01JABCDEF000000000000000EF\",\"act-subject\":\"01JOTHEREVENTID00000000000\",\"act-verb\":\"confirm\",\"from\":\"did:web:irc.example\",\"id\":\"01JCONFIRMEVENTID000000000\",\"target\":\"#ops\"}",
+      "target": "#ops",
+      "vector": "receipt-confirming-an-accept"
     },
     {
       "expected": "unverifiable",
@@ -102,6 +115,23 @@
         "+freeq.at/from": "did:plc:factory"
       },
       "target": "dm:did:plc:factory,did:plc:opslead"
+    },
+    {
+      "canonical": "{\"act\":\"handoff\",\"act-id\":\"01JABCDEF000000000000000EF\",\"act-subject\":\"01JACCEPTEVENTID0000000000\",\"act-verb\":\"confirm\",\"from\":\"did:web:irc.example\",\"id\":\"01JCONFIRMEVENTID000000000\",\"target\":\"#ops\"}",
+      "id": "01JCONFIRMEVENTID000000000",
+      "kid": "dZl3bDCF4_naDRMHHrC0qw",
+      "name": "receipt-confirming-an-accept",
+      "publicKey": "bnoc3Smwt4_ROvTFWY_v9O8qlxZuPKby5Pv8zYBQW_E",
+      "seed": "0505050505050505050505050505050505050505050505050505050505050505",
+      "sigTag": "ed25519:dZl3bDCF4_naDRMHHrC0qw:lIseSzDKJIuQWdYOncVtJUd5mr6YwcQSfXwAI7DqPQceRs7YN6QPkIsrSg26KNH0y9dUYNO9vP4pSHMd_VejAQ",
+      "tags": {
+        "+freeq.at/act": "handoff",
+        "+freeq.at/act-id": "01JABCDEF000000000000000EF",
+        "+freeq.at/act-subject": "01JACCEPTEVENTID0000000000",
+        "+freeq.at/act-verb": "confirm",
+        "+freeq.at/from": "did:web:irc.example"
+      },
+      "target": "#ops"
     },
     {
       "canonical": "{\"act\":\"handoff\",\"act-id\":\"01JABCDEF000000000000000EF\",\"act-note\":\"ok — \\\"on it\\\" ✓\\n(eta 5m)\",\"act-verb\":\"accept\",\"from\":\"did:plc:scholar\",\"id\":\"01JACCEPTEVENTID0000000000\",\"target\":\"#ops\"}",

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -19,7 +19,9 @@
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
     "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
     "never checked here. `from` is one state, a list of states, or",
-    "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code."
+    "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
+    "a receipt is the home server's word about an event it filed, not a step anybody takes."
   ],
   "version": 1,
   "kinds": {
@@ -38,13 +40,27 @@
       ]
     }
   },
+  "confirmation": {
+    "_note": [
+      "The receipt an action's home writes for a participant-authored step it has filed: same document as",
+      "any other event, signed under the server's own DID, naming the confirmed event in act-subject.",
+      "The verb is generic on purpose. No kind lists it and no kind may add its own row for it — a receipt",
+      "is a statement about an event, not a move on a task — so the checker recognizes it before it looks",
+      "the verb up in any kind's table, and answers `client-confirm` rather than `unknown-verb`. The second",
+      "answer would say a kind could define confirm for itself, which it cannot.",
+      "A receipt carries no state: whatever moved was moved by the event it names."
+    ],
+    "verb": "confirm",
+    "subject": "act-subject"
+  },
   "refusals": {
     "unknown-kind": "The kind is not in this file. Adding a kind means updating this file first.",
     "unknown-verb": "The kind lists no transition with this verb.",
     "terminal-task": "The task is finished. A later event never un-applies an earlier one.",
     "illegal-step": "The verb is not legal from the task's current state.",
     "wrong-sender": "The sender does not hold the role this transition requires.",
-    "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance."
+    "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance.",
+    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step."
   },
   "deadline_rule": {
     "_note": [
@@ -90,6 +106,13 @@
       "verb": "accept",
       "directed": true,
       "expect_refused": "illegal-step"
+    },
+    {
+      "name": "a confirmation opens nothing, whatever kind it names",
+      "kind": "handoff",
+      "verb": "confirm",
+      "directed": false,
+      "expect_refused": "client-confirm"
     },
     {
       "name": "an opener for a kind this file does not list is refused",
@@ -504,6 +527,27 @@
       "steps": [
         { "verb": "award", "sender": "did:plc:eliza", "expect_refused": "unknown-verb" },
         { "verb": "bid", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "nobody but the home confirms, and no kind can claim the verb for itself",
+      "task": {
+        "kind": "handoff",
+        "offer": "directed",
+        "offerer": "did:plc:eliza",
+        "offeree": "did:plc:scholar",
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "confirm", "sender": "did:plc:scholar", "expect_refused": "client-confirm" },
+        { "verb": "confirm", "sender": "did:plc:eliza", "expect_refused": "client-confirm" },
+        {
+          "verb": "confirm",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect_refused": "client-confirm"
+        },
+        { "verb": "accept", "sender": "did:plc:scholar", "expect": "assigned" }
       ]
     },
     {

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -21,7 +21,17 @@
     "never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
-    "a receipt is the home server's word about an event it filed, not a step anybody takes."
+    "a receipt is the home server's word about an event it filed, not a step anybody takes.",
+    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
+    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
+    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
+    "insists on a field, needs a row here and no code anywhere.",
+    "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
+    "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
+    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
+    "record. A checker that second-guessed it would be picking."
   ],
   "version": 1,
   "kinds": {
@@ -36,6 +46,27 @@
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
         { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
         { "verb": "cancel", "from": ["offered", "assigned", "open"], "to": "cancelled", "who": "offerer" },
+        { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
+      ]
+    },
+    "bounty": {
+      "opens": { "verb": "offer", "open": "open" },
+      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "transitions": [
+        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "award",
+          "from": "open",
+          "to": "assigned",
+          "who": "offerer",
+          "before_deadline": true,
+          "assignee_from": "act-to",
+          "requires": ["act-to"]
+        },
+        { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
+        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
+        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
     }
@@ -78,7 +109,8 @@
     "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step.",
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
-    "replaces-not-terminal": "The action it replaces is not finished."
+    "replaces-not-terminal": "The action it replaces is not finished.",
+    "missing-requirement": "The transition requires a field the event does not carry."
   },
   "deadline_rule": {
     "_note": [
@@ -134,10 +166,24 @@
     },
     {
       "name": "an opener for a kind this file does not list is refused",
-      "kind": "bounty",
+      "kind": "approval",
       "verb": "offer",
       "directed": false,
       "expect_refused": "unknown-kind"
+    },
+    {
+      "name": "a bounty opens to the room, and naming a recipient is not something it can do",
+      "kind": "bounty",
+      "verb": "offer",
+      "directed": false,
+      "expect": "open"
+    },
+    {
+      "name": "a directed bounty is just a handoff, so the opener is refused",
+      "kind": "bounty",
+      "verb": "offer",
+      "directed": true,
+      "expect_refused": "illegal-step"
     }
   ],
   "revival_sequences": [
@@ -608,7 +654,7 @@
     {
       "name": "a kind this file does not list is refused",
       "task": {
-        "kind": "bounty",
+        "kind": "approval",
         "offer": "open",
         "state": "open",
         "offerer": "did:plc:eliza",
@@ -616,8 +662,160 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect_refused": "unknown-kind" },
+        { "verb": "request", "sender": "did:plc:scholar", "expect_refused": "unknown-kind" },
         { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "unknown-kind" }
+      ]
+    },
+    {
+      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+      ]
+    },
+    {
+      "name": "the poster awards the work, and the loser is not the one who finishes it",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
+      ]
+    },
+    {
+      "name": "an award names its winner, or it assigns nobody",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "expect_refused": "missing-requirement"
+        },
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "the poster is the only one who awards the work",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:scholar",
+          "tags": ["act-to"],
+          "expect_refused": "wrong-sender"
+        },
+        {
+          "verb": "award",
+          "sender": "did:plc:mallory",
+          "tags": ["act-to"],
+          "expect_refused": "wrong-sender"
+        }
+      ]
+    },
+    {
+      "name": "a bid after the deadline is refused, exactly as an award is",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "expect_refused": "deadline-passed"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "an awarded bounty takes no further bids",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-to"],
+          "assigns": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
+      ]
+    },
+    {
+      "name": "a bounty has no offeree, so it is never accepted or declined",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "accept", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "claim", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
       ]
     }
   ]

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -53,6 +53,21 @@
     "verb": "confirm",
     "subject": "act-subject"
   },
+  "revival": {
+    "_note": [
+      "The typed relation a new action uses to name a finished one it revives: a failed handoff re-offered,",
+      "a forfeited bounty re-listed. Named for its relation rather than carried on a generic pointer, so the",
+      "checker knows what the link claims and can hold it to it — which is the whole argument for one tag",
+      "per relation in the _readme above.",
+      "Only an opener revives anything: a step on an action that already exists names no other. The value",
+      "names an action, so it is shaped like one. And the action it names must be finished — reviving",
+      "something still running would leave two live actions each claiming to be the work.",
+      "An action this server never saw is the case that matters later: receivers must tolerate a link to one",
+      "they never filed, and annotate rather than refuse. On one server that is the link a client mistyped;",
+      "under federation it is the ordinary case, since the predecessor lived on somebody else's machine."
+    ],
+    "tag": "act-replaces"
+  },
   "refusals": {
     "unknown-kind": "The kind is not in this file. Adding a kind means updating this file first.",
     "unknown-verb": "The kind lists no transition with this verb.",
@@ -60,7 +75,10 @@
     "illegal-step": "The verb is not legal from the task's current state.",
     "wrong-sender": "The sender does not hold the role this transition requires.",
     "deadline-passed": "The event was minted after the offer's deadline, beyond the clock tolerance.",
-    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step."
+    "client-confirm": "A confirmation is the home's record of an event it filed, never a sender's step.",
+    "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
+    "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
+    "replaces-not-terminal": "The action it replaces is not finished."
   },
   "deadline_rule": {
     "_note": [
@@ -120,6 +138,43 @@
       "verb": "offer",
       "directed": false,
       "expect_refused": "unknown-kind"
+    }
+  ],
+  "revival_sequences": [
+    {
+      "name": "a re-offer revives the failed action it names",
+      "opens": true,
+      "names": "01M16E7TC0ENDED00000000000",
+      "predecessor": "finished",
+      "expect": "accepted"
+    },
+    {
+      "name": "a re-offer naming an action this server never saw is annotated, not refused",
+      "opens": true,
+      "names": "01M16E7TC0NEVERSEEN0000000",
+      "predecessor": "unknown",
+      "expect": "accepted"
+    },
+    {
+      "name": "an action still running is not something to revive",
+      "opens": true,
+      "names": "01M16E7TC0STANDSYET0000000",
+      "predecessor": "live",
+      "expect_refused": "replaces-not-terminal"
+    },
+    {
+      "name": "a step on an action revives nothing",
+      "opens": false,
+      "names": "01M16E7TC0ENDED00000000000",
+      "predecessor": "finished",
+      "expect_refused": "replaces-not-opener"
+    },
+    {
+      "name": "a value that is not an action id names no action",
+      "opens": true,
+      "names": "01M16E7TC0SHRT",
+      "predecessor": "unknown",
+      "expect_refused": "replaces-malformed"
     }
   ],
   "sequences": [

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -20,6 +20,9 @@
     "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
     "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`before_bid_deadline` is the same comparison against a second time on the same opener: act-deadline",
+    "bounds how long the offer stands, act-bid-deadline how long it takes bids, and a kind that collects",
+    "them wants both. A time the offer never named bounds nothing.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
@@ -29,6 +32,11 @@
     "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What a bounty is worth is nobody's business here: act-price on the offer, act-bid and act-pay-to on a",
+    "bid, act-tx on the acceptance. Stored, relayed, replayed, inside the signature because every act tag is,",
+    "and never read. The server records that a payment was claimed; it never confirms one, and settlement",
+    "lives above this entirely. act-bid-deadline is deliberately not in that list: it is a time the referee",
+    "compares, exactly like act-deadline.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
     "The server still never picks: it checks only that the named event is a `bid` on this action.",
     "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
@@ -61,7 +69,13 @@
       "opens": { "verb": "offer", "open": "open" },
       "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
-        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "bid",
+          "from": "open",
+          "to": "open",
+          "who": "anyone",
+          "before_bid_deadline": true
+        },
         {
           "verb": "award",
           "from": "open",
@@ -983,13 +997,14 @@
       ]
     },
     {
-      "name": "a bid after the deadline is refused, exactly as an award is",
+      "name": "a bounty stops taking bids at its own cutoff",
       "task": {
         "kind": "bounty",
         "offer": "open",
         "offerer": "did:plc:eliza",
         "offeree": null,
-        "deadline": 1788000000
+        "deadline": null,
+        "bid_deadline": 1788000000
       },
       "steps": [
         {
@@ -1002,6 +1017,46 @@
           "verb": "bid",
           "sender": "did:plc:scholar",
           "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "bidding closing does not stop the poster picking",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null,
+        "bid_deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "a bounty that named no bid cutoff takes bids as long as it stands",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
           "expect": "open"
         }
       ]

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -35,7 +35,11 @@
     "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
     "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
     "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
-    "clock, not a further verb."
+    "clock, not a further verb: auto-accept is the server's, it fires on work left unanswered past a window",
+    "every bidder knew before bidding, and it is its own verb rather than a reused expire so the log says",
+    "which of the two happened. The window is one number the operator sets. A per-task act-review-deadline",
+    "the offer declares, read like act-deadline and overriding the global for that task, is the additive",
+    "follow-on: the sweep would change only which number it reads, so nothing here is built to be undone."
   ],
   "version": 1,
   "kinds": {

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -26,7 +26,7 @@
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "accept and claim already mean; a bounty's award sets it to { \"author_of\": \"act-accepts\" }, because the poster picks a bid",
     "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
     "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
     "someone else, or insists on a field, needs a row here and no code anywhere.",
@@ -82,7 +82,7 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "bid-author",
+          "assignee_from": { "author_of": "act-accepts" },
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -22,16 +22,15 @@
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
-    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
-    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
-    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
-    "insists on a field, needs a row here and no code anywhere.",
+    "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
+    "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
+    "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
-    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
-    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
-    "record. A checker that second-guessed it would be picking."
+    "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
+    "The server still never picks: it checks only that the named event is a `bid` on this action."
   ],
   "version": 1,
   "kinds": {
@@ -60,8 +59,8 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "act-to",
-          "requires": ["act-to"]
+          "assignee_from": "bid-author",
+          "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
@@ -110,7 +109,8 @@
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
     "replaces-not-terminal": "The action it replaces is not finished.",
-    "missing-requirement": "The transition requires a field the event does not carry."
+    "missing-requirement": "The transition requires a field the event does not carry.",
+    "accepts-not-a-bid": "The award names an event that is not a bid on this action."
   },
   "deadline_rule": {
     "_note": [
@@ -667,7 +667,7 @@
       ]
     },
     {
-      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "name": "a bounty takes bids, the poster awards one of them, and its author does the work",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -676,17 +676,28 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:rival",
           "expect": "assigned"
         },
-        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+        { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
       ]
     },
     {
@@ -699,13 +710,24 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
@@ -713,7 +735,7 @@
       ]
     },
     {
-      "name": "an award names its winner, or it assigns nobody",
+      "name": "an award names the bid it takes, or it takes nothing",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -730,9 +752,48 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "an award naming the bounty's own opener names no bid",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0THEBNTY000000000",
+          "expect_refused": "accepts-not-a-bid"
+        }
+      ]
+    },
+    {
+      "name": "a bid on another bounty is not one this award can take",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDANTHERACTN0000",
+          "expect_refused": "accepts-not-a-bid"
         }
       ]
     },
@@ -749,13 +810,17 @@
         {
           "verb": "award",
           "sender": "did:plc:scholar",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         },
         {
           "verb": "award",
           "sender": "did:plc:mallory",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         }
       ]
@@ -797,8 +862,9 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -17,8 +17,8 @@
     "Adding a tag is free: the signature covers every act-* tag present, so a second relation never needs a",
     "canonical change, and IRC tags are a flat map — the first event carrying two pointers needs two names anyway.",
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
-    "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
-    "never checked here. `from` is one state, a list of states, or",
+    "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
+    "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
@@ -30,7 +30,12 @@
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
-    "The server still never picks: it checks only that the named event is a `bid` on this action."
+    "The server still never picks: it checks only that the named event is a `bid` on this action.",
+    "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
+    "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
+    "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
+    "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
+    "clock, not a further verb."
   ],
   "version": 1,
   "kinds": {
@@ -50,7 +55,7 @@
     },
     "bounty": {
       "opens": { "verb": "offer", "open": "open" },
-      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
         { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
         {
@@ -63,8 +68,16 @@
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
-        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
-        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "submit", "from": "assigned", "to": "under_review", "who": "assignee" },
+        { "verb": "revise", "from": "under_review", "to": "assigned", "who": "offerer" },
+        { "verb": "accept-work", "from": "under_review", "to": "accepted", "who": "offerer" },
+        {
+          "verb": "forfeit",
+          "from": ["assigned", "under_review"],
+          "to": "forfeited",
+          "who": "assignee"
+        },
+        { "verb": "auto-accept", "from": "under_review", "to": "accepted", "who": "system" },
         { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
@@ -697,7 +710,147 @@
           "expect": "assigned"
         },
         { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect": "assigned" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "the work is the worker's to hand in and the poster's to accept",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "revise", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "delivered work is not something the poster can withdraw",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect": "cancelled" }
+      ]
+    },
+    {
+      "name": "once the work is in, the poster takes it or sends it back and nothing else",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "illegal-step" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "a bounty is not finished by the worker saying so",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "complete", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "fail", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "the worker walks away from work they hold, before or after handing it in",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "forfeit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "forfeit", "sender": "did:plc:scholar", "expect": "forfeited" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect_refused": "terminal-task" }
+      ]
+    },
+    {
+      "name": "the review clock is the server's to run out, and nobody else's",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "auto-accept", "sender": "did:web:irc.example", "system": true, "expect_refused": "illegal-step" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "auto-accept", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "auto-accept", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        {
+          "verb": "auto-accept",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect": "accepted"
+        }
       ]
     },
     {
@@ -730,7 +883,7 @@
           "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
-        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
       ]
     },


### PR DESCRIPTION
The three pieces of [RFC v0.5](https://gist.github.com/zapnap/2510b695c9d5e1cf99aac2fba709d307) that were specified or proposed with no code behind them, scoped to one server. The plan the work followed is the first commit (`docs/ACT-TIER1-PLAN.md`); implementation by claude-opus-5 against it, verified independently.

**Receipts.** Every participant-authored state transition the home files earns exactly one home-signed `confirm` naming its subject in `act-subject` — openers, `progress`, and system verbs earn none. The RFC left the trigger condition undefined ("an action other servers are involved in"); this resolves it by always emitting, which is the rule that cannot be implemented wrong. `confirm` is recognized before the per-kind verb lookup, so a client sending it draws `WRONG_SENDER` / "Only the action's home confirms it", never `UNKNOWN_VERB`. Receipts carry no state, ride replay and REST, and are gated on `freeq.at/act` like everything else.

**`act-replaces`.** Opener-only, ULID-shaped, predecessor must be terminal; an unknown predecessor is accepted and annotated rather than refused — the rule federation will lean on. Migration 007 adds the `replaces` column, filled at ingress and by the rebuild; served on both REST endpoints; `offer({ replaces })` in bot-kit.

**`bounty`.** The generality test, passed on its own terms: a transitions-file entry plus two generic schema additions — `requires` (tags a transition must carry) and `assignee_from` (which field names the assignee; `award` reads `act-to`, the default stays `actor`). No validator gained a kind name. Per the RFC, the server neither picks winners nor checks that the awarded DID ever bid: the poster's signed choice is the record.

**A latent bug the second kind exposed, fixed here:** the view materialized using the kind the *event* declared rather than the one the task is filed under — harmless with one kind; with `assignee_from` in play, a step mislabelled `act=handoff` on a bounty would have made the poster the assignee. The task's kind is now the authority for materialization, as it already was for refereeing.

**Verification** (run twice — by the implementing agent and again independently): full workspace suite green, fmt and clippy clean, 48 gate + 10 API tests, vectors extended and reproduced by both SDKs, acceptance run extended to 42 checks including receipts on accept/complete, the bounty flow with a losing bidder refused, and a failed handoff revived under `act-replaces`.

One heads-up for cold checkouts: `freeq-sdk-js/dist` predating the 08-20 canonical realignment signs the retired keys and every task message draws `SIGNATURE_INVALID` — `npm run build` in both JS packages before running the acceptance script.