### PR TITLE
bounty: award names the bid, the poster accepts the work, review window, money tags

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -203,7 +203,7 @@ const bounty = await offer(ctx, {
 });
 
 // a worker, elsewhere in the room
-const myBid = await bid(ctx, bounty, { amount: '250 USD', payTo: ctx.did, note: 'two days' });
+const myBid = await bid(ctx, bounty, { price: '250 USD', payTo: ctx.did, note: 'two days' });
 
 // the poster, having read the bids
 await award(ctx, bounty, myBid);      // the bid's event id, not a DID

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -160,6 +160,63 @@ Two words appear throughout freeq's errors and records, and they are not interch
 
 **A task from another server is display-only, for now.** Task messages relay across servers intact — signature and all — so a task-aware client on either side can render the card. But only the server where a task was created has it on file. Acting on a remote task draws `FAIL TAGMSG UNKNOWN_TASK :That task is not on file`, and will until cross-server participation lands. Read a remote task, follow along with it, and offer your own work on your own server; do not build a flow whose next step is accepting someone else's remote offer.
 
+### Bounties: priced work, bid on and awarded
+
+A handoff moves a unit of work to someone. A **bounty** is the same lifecycle with an auction in front of it and a review gate behind it: the work is posted openly, agents bid, the poster picks one bid, and the poster — not the worker — is who says the job is done.
+
+The run, end to end:
+
+```
+offer      (anyone)    → open           the bounty is posted, with what it pays
+bid        (anyone)    → open           additive: every bid stays on file
+award      (poster)    → assigned       the poster takes one bid
+progress   (worker)    → assigned
+submit     (worker)    → under_review   the work is in, not finished
+revise     (poster)    → assigned       sent back for another pass
+accept-work(poster)    → accepted       terminal
+forfeit    (worker)    → forfeited      terminal, from assigned or under_review
+cancel     (poster)    → cancelled      from open or assigned, never under_review
+```
+
+There is no `complete` on a bounty. The worker hands work in; the offerer signs off. And once work is in, the poster cannot withdraw it — a poster who could cancel after seeing the work would get it for nothing.
+
+**`act-accepts` names a bid, not a bidder.** An award carries the winning bid's own event id and no `act-to` at all. A bounty's terms live in the bid — what the bidder asks, where they want paying, what they propose — and bids are the one place several candidates sit side by side, so taking one means naming the exact event. The assignee is whoever wrote that bid. The server checks only that the named event is a `bid` on this bounty; naming anything else draws `FAIL TAGMSG ACCEPTS_NOT_A_BID`, and naming nothing draws `MISSING_REQUIREMENT`. Which bid is worth taking is not the server's business.
+
+**The review window closes on its own.** Work left in `under_review` past the server's `act_review_secs` — fourteen days by default — is deemed accepted, under an `auto-accept` event the server signs itself. That is the answer to a poster who takes delivery and then goes quiet: without it, the ordinary abandonment sweep would eventually close the task as an expiry, which reads as the *worker* having dropped it. The clock is per-submission, so a poster who asks for changes is never caught by it and a fresh submission starts a fresh window. Ask your server operator what its window is; every bidder is bidding under it.
+
+Endless revision is not closed by any of this, and deliberately so: from the outside a real revision and a stall are identical. So are "accepted but never paid" and any other question about money. Those live above the substrate — in reputation, escrow, and dispute — not in a transition table.
+
+**Money is opaque.** `act-price` on the offer, `act-bid` and `act-pay-to` on a bid, `act-tx` on the acceptance. All four are stored, relayed, replayed, and covered by the signature because they are present — and read by nothing. `act-tx` records that a payment was *claimed*, never that one happened.
+
+Two deadlines, both on the offer and both optional: `act-deadline` bounds how long the offer stands, and `act-bid-deadline` bounds how long it takes bids, which usually closes sooner. A bid past the cutoff draws `DEADLINE_PASSED`; the award is measured against `act-deadline` instead, so bidding closing does not stop the poster picking.
+
+In bot-kit:
+
+```ts
+import { offer, bid, award, submit, revise, acceptWork, forfeit } from '@freeq/bot-kit';
+
+const bounty = await offer(ctx, {
+  title: 'index the archive',
+  kind: 'bounty',
+  price: '250 USD',
+  bidDeadline: Math.floor(Date.now() / 1000) + 86_400,
+});
+
+// a worker, elsewhere in the room
+const myBid = await bid(ctx, bounty, { amount: '250 USD', payTo: ctx.did, note: 'two days' });
+
+// the poster, having read the bids
+await award(ctx, bounty, myBid);      // the bid's event id, not a DID
+
+// the worker
+await submit(ctx, bounty, { note: 'branch pushed' });
+
+// the poster
+await acceptWork(ctx, bounty, { tx: 'eth:0xabc' });
+```
+
+Re-running a bounty that was forfeited or expired is a **new** bounty naming the old one in `replaces` — the machine only runs forward, and a terminal state is final.
+
 ### Messages and notices
 
 Both are signed with the same document, and the difference that matters is durability: **a notice leaves no record.** The server stores and logs messages only, so a notice is verifiable in flight and by nothing afterwards — absent from channel history, from CHATHISTORY replay, and from `/api/v1/verify`.

--- a/docs/tag-registry.md
+++ b/docs/tag-registry.md
@@ -60,6 +60,13 @@ across the Rust and TypeScript SDKs with shared test vectors
 | `+freeq.at/act-title` | Human-readable title. |
 | `+freeq.at/from` | The signer/actor (envelope tag; the document key is `from`). |
 | `+freeq.at/eventid` | The event id the signer minted; the server adopts it (shared with chat). |
+| `+freeq.at/act-accepts` | The bid an award takes — that bid's own event id. The assignee is its author. |
+| `+freeq.at/act-deadline` | How long the offer stands, unix seconds. Compared by the referee. |
+| `+freeq.at/act-bid-deadline` | How long a bounty takes bids, unix seconds. Compared by the referee. |
+| `+freeq.at/act-price` | What a bounty offers to pay. Opaque: stored, relayed, signed, never read. |
+| `+freeq.at/act-bid` | What a bidder asks for. Opaque. |
+| `+freeq.at/act-pay-to` | Where a bidder wants paying. Opaque. |
+| `+freeq.at/act-tx` | A payment reference on the acceptance. Opaque — a claim on the record, never a confirmation. |
 
 ## Governance & budgets
 

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -271,7 +271,7 @@ async function main() {
       `open (${bounty})`,
     );
 
-    await act.bid(worker.ctx, bounty, { note: 'two days' });
+    const workerBid = await act.bid(worker.ctx, bounty, { note: 'two days' });
     await act.bid(rival.ctx, bounty, { note: 'one day, no sources' });
     await sleep(900);
     check(
@@ -284,14 +284,14 @@ async function main() {
       'both bids are on file, neither superseding the other',
     );
 
-    step('award', 'the poster picks the winner');
-    const awardId = await act.award(poster.ctx, bounty, worker.ctx.did);
+    step('award', 'the poster takes one of the bids');
+    const awardId = await act.award(poster.ctx, bounty, workerBid);
     await sleep(700);
     const awarded = (await openWork()).find((t) => t.act_id === bounty);
     check(awarded?.state === 'assigned', 'assigned');
     check(
       awarded?.assignee === worker.ctx.did,
-      'and the assignee is the winner the poster named, not the poster',
+      'and the assignee is the author of the bid it took, not the poster',
     );
     check(
       receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(awardId),

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -298,22 +298,45 @@ async function main() {
       'the award is confirmed by the home',
     );
 
-    step('the loser', 'the bot that did not win tries to finish the work');
+    step('the loser', 'the bot whose bid was not taken tries to hand work in');
     rival.seen.fails.length = 0;
-    await act.complete(rival.ctx, bounty, { kind: 'bounty' }).catch(() => {});
+    await act.submit(rival.ctx, bounty).catch(() => {});
     await sleep(700);
     check(
       rival.seen.fails.some((l) => l.includes('WRONG_SENDER')),
       'refused: WRONG_SENDER',
     );
 
-    step('the winner', 'the winner finishes it');
-    const bountyDone = await act.complete(worker.ctx, bounty, { kind: 'bounty' });
+    step('review', 'the winner hands the work in, and the poster sends it back');
+    await act.submit(worker.ctx, bounty);
     await sleep(700);
-    check(!(await openWork()).some((t) => t.act_id === bounty), 'completed — gone from open work');
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'under_review',
+      'under review — handed in, not finished',
+    );
+    poster.seen.fails.length = 0;
+    await act.cancel(poster.ctx, bounty, { kind: 'bounty' }).catch(() => {});
+    await sleep(700);
+    check(
+      poster.seen.fails.some((l) => l.includes('ILLEGAL_STEP')),
+      'and delivered work is not the poster\'s to withdraw: ILLEGAL_STEP',
+    );
+    await act.revise(poster.ctx, bounty);
+    await sleep(700);
+    check(
+      (await openWork()).find((t) => t.act_id === bounty)?.state === 'assigned',
+      'sent back — assigned again, and the worker still holds it',
+    );
+
+    step('the poster accepts', 'the offerer\'s word is what ends a bounty');
+    await act.submit(worker.ctx, bounty);
+    await sleep(700);
+    const bountyDone = await act.acceptWork(poster.ctx, bounty);
+    await sleep(700);
+    check(!(await openWork()).some((t) => t.act_id === bounty), 'accepted — gone from open work');
     check(
       receiptsBySubject((await api(`/api/v1/actions/${bounty}`)).events).has(bountyDone),
-      'and the completion is confirmed too',
+      'and the acceptance is confirmed too',
     );
 
     // ── expiry ──

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -20,6 +20,9 @@
     "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
     "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`before_bid_deadline` is the same comparison against a second time on the same opener: act-deadline",
+    "bounds how long the offer stands, act-bid-deadline how long it takes bids, and a kind that collects",
+    "them wants both. A time the offer never named bounds nothing.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
@@ -29,6 +32,11 @@
     "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What a bounty is worth is nobody's business here: act-price on the offer, act-bid and act-pay-to on a",
+    "bid, act-tx on the acceptance. Stored, relayed, replayed, inside the signature because every act tag is,",
+    "and never read. The server records that a payment was claimed; it never confirms one, and settlement",
+    "lives above this entirely. act-bid-deadline is deliberately not in that list: it is a time the referee",
+    "compares, exactly like act-deadline.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
     "The server still never picks: it checks only that the named event is a `bid` on this action.",
     "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
@@ -61,7 +69,13 @@
       "opens": { "verb": "offer", "open": "open" },
       "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
-        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "bid",
+          "from": "open",
+          "to": "open",
+          "who": "anyone",
+          "before_bid_deadline": true
+        },
         {
           "verb": "award",
           "from": "open",
@@ -983,13 +997,14 @@
       ]
     },
     {
-      "name": "a bid after the deadline is refused, exactly as an award is",
+      "name": "a bounty stops taking bids at its own cutoff",
       "task": {
         "kind": "bounty",
         "offer": "open",
         "offerer": "did:plc:eliza",
         "offeree": null,
-        "deadline": 1788000000
+        "deadline": null,
+        "bid_deadline": 1788000000
       },
       "steps": [
         {
@@ -1002,6 +1017,46 @@
           "verb": "bid",
           "sender": "did:plc:scholar",
           "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "bidding closing does not stop the poster picking",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null,
+        "bid_deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "a bounty that named no bid cutoff takes bids as long as it stands",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
           "expect": "open"
         }
       ]

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -35,7 +35,11 @@
     "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
     "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
     "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
-    "clock, not a further verb."
+    "clock, not a further verb: auto-accept is the server's, it fires on work left unanswered past a window",
+    "every bidder knew before bidding, and it is its own verb rather than a reused expire so the log says",
+    "which of the two happened. The window is one number the operator sets. A per-task act-review-deadline",
+    "the offer declares, read like act-deadline and overriding the global for that task, is the additive",
+    "follow-on: the sweep would change only which number it reads, so nothing here is built to be undone."
   ],
   "version": 1,
   "kinds": {

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -26,7 +26,7 @@
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "accept and claim already mean; a bounty's award sets it to { \"author_of\": \"act-accepts\" }, because the poster picks a bid",
     "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
     "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
     "someone else, or insists on a field, needs a row here and no code anywhere.",
@@ -82,7 +82,7 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "bid-author",
+          "assignee_from": { "author_of": "act-accepts" },
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -22,16 +22,15 @@
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
-    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
-    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
-    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
-    "insists on a field, needs a row here and no code anywhere.",
+    "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
+    "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
+    "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
-    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
-    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
-    "record. A checker that second-guessed it would be picking."
+    "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
+    "The server still never picks: it checks only that the named event is a `bid` on this action."
   ],
   "version": 1,
   "kinds": {
@@ -60,8 +59,8 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "act-to",
-          "requires": ["act-to"]
+          "assignee_from": "bid-author",
+          "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
@@ -110,7 +109,8 @@
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
     "replaces-not-terminal": "The action it replaces is not finished.",
-    "missing-requirement": "The transition requires a field the event does not carry."
+    "missing-requirement": "The transition requires a field the event does not carry.",
+    "accepts-not-a-bid": "The award names an event that is not a bid on this action."
   },
   "deadline_rule": {
     "_note": [
@@ -667,7 +667,7 @@
       ]
     },
     {
-      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "name": "a bounty takes bids, the poster awards one of them, and its author does the work",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -676,17 +676,28 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:rival",
           "expect": "assigned"
         },
-        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+        { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
       ]
     },
     {
@@ -699,13 +710,24 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
@@ -713,7 +735,7 @@
       ]
     },
     {
-      "name": "an award names its winner, or it assigns nobody",
+      "name": "an award names the bid it takes, or it takes nothing",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -730,9 +752,48 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "an award naming the bounty's own opener names no bid",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0THEBNTY000000000",
+          "expect_refused": "accepts-not-a-bid"
+        }
+      ]
+    },
+    {
+      "name": "a bid on another bounty is not one this award can take",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDANTHERACTN0000",
+          "expect_refused": "accepts-not-a-bid"
         }
       ]
     },
@@ -749,13 +810,17 @@
         {
           "verb": "award",
           "sender": "did:plc:scholar",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         },
         {
           "verb": "award",
           "sender": "did:plc:mallory",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         }
       ]
@@ -797,8 +862,9 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }

--- a/freeq-bot-kit-js/src/act-transitions.json
+++ b/freeq-bot-kit-js/src/act-transitions.json
@@ -17,8 +17,8 @@
     "Adding a tag is free: the signature covers every act-* tag present, so a second relation never needs a",
     "canonical change, and IRC tags are a flat map — the first event carrying two pointers needs two names anyway.",
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
-    "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
-    "never checked here. `from` is one state, a list of states, or",
+    "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
+    "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
@@ -30,7 +30,12 @@
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
-    "The server still never picks: it checks only that the named event is a `bid` on this action."
+    "The server still never picks: it checks only that the named event is a `bid` on this action.",
+    "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
+    "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
+    "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
+    "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
+    "clock, not a further verb."
   ],
   "version": 1,
   "kinds": {
@@ -50,7 +55,7 @@
     },
     "bounty": {
       "opens": { "verb": "offer", "open": "open" },
-      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
         { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
         {
@@ -63,8 +68,16 @@
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
-        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
-        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "submit", "from": "assigned", "to": "under_review", "who": "assignee" },
+        { "verb": "revise", "from": "under_review", "to": "assigned", "who": "offerer" },
+        { "verb": "accept-work", "from": "under_review", "to": "accepted", "who": "offerer" },
+        {
+          "verb": "forfeit",
+          "from": ["assigned", "under_review"],
+          "to": "forfeited",
+          "who": "assignee"
+        },
+        { "verb": "auto-accept", "from": "under_review", "to": "accepted", "who": "system" },
         { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
@@ -697,7 +710,147 @@
           "expect": "assigned"
         },
         { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect": "assigned" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "the work is the worker's to hand in and the poster's to accept",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "revise", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "delivered work is not something the poster can withdraw",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect": "cancelled" }
+      ]
+    },
+    {
+      "name": "once the work is in, the poster takes it or sends it back and nothing else",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "illegal-step" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "a bounty is not finished by the worker saying so",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "complete", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "fail", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "the worker walks away from work they hold, before or after handing it in",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "forfeit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "forfeit", "sender": "did:plc:scholar", "expect": "forfeited" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect_refused": "terminal-task" }
+      ]
+    },
+    {
+      "name": "the review clock is the server's to run out, and nobody else's",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "auto-accept", "sender": "did:web:irc.example", "system": true, "expect_refused": "illegal-step" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "auto-accept", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "auto-accept", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        {
+          "verb": "auto-accept",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect": "accepted"
+        }
       ]
     },
     {
@@ -730,7 +883,7 @@
           "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
-        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
       ]
     },

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -557,7 +557,10 @@ describe("the two schema additions bounty needed", () => {
   });
 
   it("says where each transition's assignee comes from", () => {
-    expect(assigneeSource("bounty", "award", "open")).toEqual({ from: "bid-author" });
+    expect(assigneeSource("bounty", "award", "open")).toEqual({
+      from: "author_of",
+      field: "act-accepts",
+    });
     for (const [kind, verb, from] of [
       ["handoff", "accept", "offered"],
       ["handoff", "claim", "open"],
@@ -660,7 +663,7 @@ describe("the shared sequences", () => {
             const source = assigneeSource(seq.task.kind, step.verb, state);
             if (source.from === "actor") {
               assignee = step.sender;
-            } else if (source.from === "bid-author") {
+            } else if (source.from === "author_of") {
               if (!step.accepted_bid) {
                 throw new Error(
                   `${where}: this transition assigns the author of the bid it names, and none was resolved`,

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -70,6 +70,7 @@ interface Sequence {
     offerer: string;
     offeree: string | null;
     deadline: number | null;
+    bid_deadline?: number | null;
   };
   steps: Step[];
 }
@@ -567,6 +568,35 @@ describe("the two schema additions bounty needed", () => {
     expect(assigneeSource("approval", "request", "open")).toEqual({ from: "actor" });
   });
 
+  // A bounty takes bids until its own cutoff, which is a shorter question
+  // than how long the offer stands.
+  it("binds a bid to the offer's bid deadline, and the award to its own", () => {
+    const DEADLINE = 1_788_000_000;
+    const TOO_LATE = "01M16HSC58ACCEPTTOOLATE000";
+    const AT_EDGE = "01M16HSB60ACCEPTATEDGE0000";
+    const takingBids: Task = { ...bounty("open"), bidDeadline: DEADLINE };
+    expect(
+      checkTransition(takingBids, { verb: "bid", msgid: TOO_LATE }, who(SCHOLAR)),
+    ).toEqual(refused("deadline-passed"));
+    expect(checkTransition(takingBids, { verb: "bid", msgid: AT_EDGE }, who(SCHOLAR))).toEqual({
+      ok: true,
+      to: "open",
+    });
+    // Bidding closing does not stop the poster picking: the award is bound by
+    // the offer's own deadline, which this bounty never named.
+    expect(
+      checkTransition(
+        takingBids,
+        { verb: "award", msgid: TOO_LATE, accepts: BID, fields: ["act-accepts"] },
+        took(ELIZA, SCHOLAR),
+      ),
+    ).toEqual({ ok: true, to: "assigned" });
+    // …and no bid cutoff means no bid cutoff.
+    expect(
+      checkTransition(bounty("open"), { verb: "bid", msgid: TOO_LATE }, who(SCHOLAR)),
+    ).toEqual({ ok: true, to: "open" });
+  });
+
   it("takes bids additively until the work is awarded", () => {
     expect(checkTransition(bounty("open"), ev("bid"), who(SCHOLAR))).toEqual({
       ok: true,
@@ -598,6 +628,7 @@ describe("the shared sequences", () => {
           offeree: seq.task.offeree,
           assignee,
           deadline: seq.task.deadline,
+          bidDeadline: seq.task.bid_deadline,
         };
         const result = checkTransition(
           task,

--- a/freeq-bot-kit-js/src/act-transitions.test.ts
+++ b/freeq-bot-kit-js/src/act-transitions.test.ts
@@ -45,6 +45,11 @@ interface Step {
   tags?: string[];
   /** Who the step assigns, when it names someone other than its sender. */
   assigns?: string;
+  /** `act-accepts`: the event an award takes. */
+  accepts?: string;
+  /** Who wrote the bid that event turned out to be. Absent when the name
+   *  found no bid on this action. */
+  accepted_bid?: string;
   expect?: string;
   expect_refused?: RefusalReason;
 }
@@ -495,22 +500,50 @@ describe("the deadline", () => {
 describe("the two schema additions bounty needed", () => {
   const refused = (reason: RefusalReason) => ({ ok: false, reason });
   const bounty = (state: string): Task => ({ kind: "bounty", state, offerer: ELIZA });
+  /** The bid an award names in these tests. */
+  const BID = "01M16E7TC0BDTAKEN000000000";
+  const award = { verb: "award", msgid: NOW, accepts: BID, fields: ["act-accepts"] };
+  const took = (did: string, author: string): EventSender => ({
+    did,
+    acceptedBid: { author },
+  });
 
-  // Checked before authority: an award naming no winner is malformed for
+  // Checked before authority: an award naming no bid is malformed for
   // everybody, and "not you" would send the sender after the wrong problem.
-  it("an award names its winner, or it is no award", () => {
+  it("an award names the bid it takes, or it is no award", () => {
     const bare = { verb: "award", msgid: NOW, fields: [] };
-    expect(checkTransition(bounty("open"), bare, who(ELIZA))).toEqual(
+    expect(checkTransition(bounty("open"), bare, took(ELIZA, SCHOLAR))).toEqual(
       refused("missing-requirement"),
     );
-    expect(checkTransition(bounty("open"), bare, who(MALLORY))).toEqual(
+    expect(checkTransition(bounty("open"), bare, took(MALLORY, SCHOLAR))).toEqual(
       refused("missing-requirement"),
     );
-    const named = { verb: "award", msgid: NOW, fields: ["act-to"] };
-    expect(checkTransition(bounty("open"), named, who(ELIZA))).toEqual({
+    expect(checkTransition(bounty("open"), award, took(ELIZA, SCHOLAR))).toEqual({
       ok: true,
       to: "assigned",
     });
+  });
+
+  // The award names one event and the caller resolves it. A name that found
+  // no bid on this action takes nothing, and says so.
+  it("an award naming something that is not a bid takes nothing", () => {
+    expect(checkTransition(bounty("open"), award, who(ELIZA))).toEqual(
+      refused("accepts-not-a-bid"),
+    );
+    expect(checkTransition(bounty("open"), award, who(MALLORY))).toEqual(
+      refused("accepts-not-a-bid"),
+    );
+  });
+
+  // The server still never picks: which of the bids on the table is worth
+  // taking is the poster's to decide.
+  it("lets the poster take whichever bid they name", () => {
+    for (const author of [SCHOLAR, MALLORY, "did:plc:nobody"]) {
+      expect(checkTransition(bounty("open"), award, took(ELIZA, author)), author).toEqual({
+        ok: true,
+        to: "assigned",
+      });
+    }
   });
 
   // The guard has to be free for every row that names nothing, which is
@@ -523,10 +556,7 @@ describe("the two schema additions bounty needed", () => {
   });
 
   it("says where each transition's assignee comes from", () => {
-    expect(assigneeSource("bounty", "award", "open")).toEqual({
-      from: "field",
-      field: "act-to",
-    });
+    expect(assigneeSource("bounty", "award", "open")).toEqual({ from: "bid-author" });
     for (const [kind, verb, from] of [
       ["handoff", "accept", "offered"],
       ["handoff", "claim", "open"],
@@ -571,8 +601,21 @@ describe("the shared sequences", () => {
         };
         const result = checkTransition(
           task,
-          { verb: step.verb, msgid: step.event_id ?? NOW, fields: step.tags ?? [] },
-          { did: step.sender, isSystem: step.system ?? false },
+          {
+            verb: step.verb,
+            msgid: step.event_id ?? NOW,
+            accepts: step.accepts,
+            fields: step.tags ?? [],
+          },
+          {
+            did: step.sender,
+            isSystem: step.system ?? false,
+            // What the caller's log made of the event this one names. A step
+            // that sets nothing named nothing, or named something that is not
+            // a bid — the file does not distinguish, because neither does the
+            // checker.
+            acceptedBid: step.accepted_bid ? { author: step.accepted_bid } : null,
+          },
         );
         const where = `${seq.name} — step ${i + 1} (${step.verb})`;
 
@@ -584,15 +627,22 @@ describe("the shared sequences", () => {
           // its winner rather than becoming one.
           if (assignee === null && step.expect === "assigned") {
             const source = assigneeSource(seq.task.kind, step.verb, state);
-            assignee =
-              source.from === "actor"
-                ? step.sender
-                : (step.assigns ??
-                  (() => {
-                    throw new Error(
-                      `${where}: assigns is not set, but this transition takes its assignee from ${source.field}`,
-                    );
-                  })());
+            if (source.from === "actor") {
+              assignee = step.sender;
+            } else if (source.from === "bid-author") {
+              if (!step.accepted_bid) {
+                throw new Error(
+                  `${where}: this transition assigns the author of the bid it names, and none was resolved`,
+                );
+              }
+              assignee = step.accepted_bid;
+            } else if (!step.assigns) {
+              throw new Error(
+                `${where}: assigns is not set, but this transition takes its assignee from ${source.field}`,
+              );
+            } else {
+              assignee = step.assigns;
+            }
           }
           state = step.expect;
         } else {

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -73,7 +73,7 @@ export interface TaskEvent {
 
 /** The bid an award named, as the caller's log answered for it. */
 export interface AcceptedBid {
-  /** Who wrote the bid. The assignee an award's `bid-author` row lands on. */
+  /** Who wrote the bid. The assignee an award's `author_of` row lands on. */
   author: string;
 }
 
@@ -104,8 +104,9 @@ interface Transition {
   /** Bounded by the offer's `act-bid-deadline` rather than its
    *  `act-deadline`. Data, like its sibling; the comparison is the same code. */
   before_bid_deadline?: boolean;
-  /** The field naming who this transition assigns. Absent = the actor. */
-  assignee_from?: string;
+  /** Who this transition assigns. Absent = the actor; a tag name = the DID in
+   *  that tag; `{ author_of: tag }` = the author of the event that tag names. */
+  assignee_from?: string | { author_of: string };
   /** Fields the transition is illegal without. */
   requires?: string[];
 }
@@ -127,10 +128,6 @@ interface Kind {
 }
 
 const ANY_NONTERMINAL = "*nonterminal";
-
-/** The `assignee_from` value that means "the author of the bid this event
- *  names". */
-const BID_AUTHOR = "bid-author";
 
 /** The verb the event an award names must carry.
  *
@@ -329,7 +326,7 @@ export function checkTransition(
   // reads a log — and a name that found nothing named something that is not a
   // bid on this action. Alongside the requirement above for the same reason:
   // an award that takes no bid is malformed for everybody.
-  if (row.assignee_from === BID_AUTHOR && (!event.accepts || !sender.acceptedBid)) {
+  if (typeof row.assignee_from === "object" && (!event.accepts || !sender.acceptedBid)) {
     return { ok: false, reason: "accepts-not-a-bid" };
   }
 
@@ -385,11 +382,11 @@ export type AssigneeSource =
   | { from: "actor" }
   /** The act field named here, read off the event. */
   | { from: "field"; field: string }
-  /** Whoever wrote the bid the event names in `act-accepts`: a bounty's
-   *  `award` takes one bid, and the terms live in it, so the poster names the
-   *  event rather than a DID. Resolving it is the caller's — this checker
-   *  reads no log — and the answer arrives as `EventSender.acceptedBid`. */
-  | { from: "bid-author" };
+  /** The author of the event named in this act field: a bounty's `award`
+   *  takes one bid, and the terms live in it, so the poster names the event in
+   *  `act-accepts` rather than a DID. Resolving it is the caller's — this
+   *  checker reads no log — and the answer arrives as `EventSender.acceptedBid`. */
+  | { from: "author_of"; field: string };
 
 /**
  * Where the assignee comes from when `verb` moves a `kind` task out of
@@ -408,6 +405,8 @@ export function assigneeSource(
   if (!k) return { from: "actor" };
   const row = k.transitions.find((t) => t.verb === verb && fromMatches(t.from, fromState, k));
   if (!row?.assignee_from) return { from: "actor" };
-  if (row.assignee_from === BID_AUTHOR) return { from: "bid-author" };
+  if (typeof row.assignee_from === "object") {
+    return { from: "author_of", field: row.assignee_from.author_of };
+  }
   return { from: "field", field: row.assignee_from };
 }

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -31,7 +31,8 @@ export type RefusalReason =
   | "replaces-not-opener"
   | "replaces-malformed"
   | "replaces-not-terminal"
-  | "missing-requirement";
+  | "missing-requirement"
+  | "accepts-not-a-bid";
 
 /** Allowed, with the state the task lands in — or refused, with the reason. */
 export type CheckResult = { ok: true; to: string } | { ok: false; reason: RefusalReason };
@@ -55,6 +56,10 @@ export interface TaskEvent {
   /** The id the signer minted; its embedded ULID millisecond is the clock a
    * deadline is measured against. */
   msgid: string;
+  /** `act-accepts`: the event an award takes. Named here rather than read out
+   * of `fields` because it is the one act value a caller must resolve before
+   * asking — see `EventSender.acceptedBid`. */
+  accepts?: string | null;
   /** The act fields the event carries, by their document names (`act-to`,
    * `act-note`, …). Presence only: what a transition's `requires` is checked
    * against. The one place this checker points at a value is
@@ -62,11 +67,28 @@ export interface TaskEvent {
   fields?: string[];
 }
 
-/** Who sent it. */
+/** The bid an award named, as the caller's log answered for it. */
+export interface AcceptedBid {
+  /** Who wrote the bid. The assignee an award's `bid-author` row lands on. */
+  author: string;
+}
+
+/** Who sent it, and what their event resolved to. */
 export interface EventSender {
   did: string;
   /** The server itself — the only actor a `system` transition allows. */
   isSystem?: boolean;
+  /**
+   * The bid this event's `act-accepts` names, when the caller found one on the
+   * action. Absent when it named something that is not a bid here — including
+   * an id belonging to another action, and an id nobody filed.
+   *
+   * This checker reads no log, so the lookup is the caller's: it resolves the
+   * named event among the action's own and hands back the bid's author. A bot
+   * pre-checking its own move has no log — it passes nothing and is told its
+   * award takes nothing, which is the honest answer from where it stands.
+   */
+  acceptedBid?: AcceptedBid | null;
 }
 
 interface Transition {
@@ -98,6 +120,16 @@ interface Kind {
 }
 
 const ANY_NONTERMINAL = "*nonterminal";
+
+/** The `assignee_from` value that means "the author of the bid this event
+ *  names". */
+const BID_AUTHOR = "bid-author";
+
+/** The verb the event an award names must carry.
+ *
+ * Written down once, here, so a caller resolving `act-accepts` asks the rules
+ * rather than spelling a kind's verb into itself. */
+export const BID_VERB = "bid";
 
 const kinds = spec.kinds as unknown as Record<string, Kind>;
 const refusals = spec.refusals as Record<string, string>;
@@ -285,6 +317,15 @@ export function checkTransition(
     return { ok: false, reason: "missing-requirement" };
   }
 
+  // A row that takes its assignee from a named bid needs that bid. Whether the
+  // name found one is the caller's answer, not this checker's — nothing here
+  // reads a log — and a name that found nothing named something that is not a
+  // bid on this action. Alongside the requirement above for the same reason:
+  // an award that takes no bid is malformed for everybody.
+  if (row.assignee_from === BID_AUTHOR && (!event.accepts || !sender.acceptedBid)) {
+    return { ok: false, reason: "accepts-not-a-bid" };
+  }
+
   // Authority second: who the sender is only matters once the move itself
   // makes sense.
   switch (row.who) {
@@ -327,9 +368,13 @@ export function checkTransition(
 export type AssigneeSource =
   /** Whoever took the step — what `accept` and `claim` already mean. */
   | { from: "actor" }
-  /** The act field named here, read off the event: a bounty's `award` names
-   *  its winner in `act-to`, because the poster picks rather than becomes. */
-  | { from: "field"; field: string };
+  /** The act field named here, read off the event. */
+  | { from: "field"; field: string }
+  /** Whoever wrote the bid the event names in `act-accepts`: a bounty's
+   *  `award` takes one bid, and the terms live in it, so the poster names the
+   *  event rather than a DID. Resolving it is the caller's — this checker
+   *  reads no log — and the answer arrives as `EventSender.acceptedBid`. */
+  | { from: "bid-author" };
 
 /**
  * Where the assignee comes from when `verb` moves a `kind` task out of
@@ -347,5 +392,7 @@ export function assigneeSource(
   const k = kinds[kind];
   if (!k) return { from: "actor" };
   const row = k.transitions.find((t) => t.verb === verb && fromMatches(t.from, fromState, k));
-  return row?.assignee_from ? { from: "field", field: row.assignee_from } : { from: "actor" };
+  if (!row?.assignee_from) return { from: "actor" };
+  if (row.assignee_from === BID_AUTHOR) return { from: "bid-author" };
+  return { from: "field", field: row.assignee_from };
 }

--- a/freeq-bot-kit-js/src/act-transitions.ts
+++ b/freeq-bot-kit-js/src/act-transitions.ts
@@ -48,6 +48,10 @@ export interface Task {
   assignee?: string | null;
   /** `act-deadline`, unix seconds. */
   deadline?: number | null;
+  /** `act-bid-deadline`, unix seconds. A second time on the same opener,
+   * compared the same way: it bounds how long a bounty collects bids, which
+   * is a shorter question than how long the offer stands. */
+  bidDeadline?: number | null;
 }
 
 /** The event being checked. */
@@ -97,6 +101,9 @@ interface Transition {
   to: string;
   who: string;
   before_deadline?: boolean;
+  /** Bounded by the offer's `act-bid-deadline` rather than its
+   *  `act-deadline`. Data, like its sibling; the comparison is the same code. */
+  before_bid_deadline?: boolean;
   /** The field naming who this transition assigns. Absent = the actor. */
   assignee_from?: string;
   /** Fields the transition is illegal without. */
@@ -353,8 +360,16 @@ export function checkTransition(
       return { ok: false, reason: "wrong-sender" };
   }
 
-  if (row.before_deadline && task.deadline != null) {
-    const limit = task.deadline * 1000 + DEADLINE_TOLERANCE_MS;
+  // Two deadlines, one comparison. A row declares which of the offer's times
+  // bounds it: how long the offer stands, or — on a kind that collects them —
+  // how long it takes bids. A time the offer never named bounds nothing.
+  const bounds = [
+    row.before_deadline ? task.deadline : null,
+    row.before_bid_deadline ? task.bidDeadline : null,
+  ];
+  for (const deadline of bounds) {
+    if (deadline == null) continue;
+    const limit = deadline * 1000 + DEADLINE_TOLERANCE_MS;
     const minted = eventTimeMs(event.msgid);
     // Fail closed: an id whose clock cannot be read cannot be shown to be
     // inside the deadline.

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -192,6 +192,42 @@ describe("the bounty verbs", () => {
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
   });
 
+  it("carries a bid's terms as tags nothing interprets", async () => {
+    const sent: Sent[] = [];
+    await bid(ctxWith(sent), "01JTASK00000000000000000AA", {
+      amount: "250 USD",
+      payTo: "did:plc:worker",
+    });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act-bid"]).toBe("250 USD");
+    expect(tags["+freeq.at/act-pay-to"]).toBe("did:plc:worker");
+  });
+
+  it("carries a bounty's price and bid cutoff on the offer", async () => {
+    const sent: Sent[] = [];
+    await offer(ctxWith(sent), {
+      title: "index the archive",
+      kind: "bounty",
+      price: "250 USD",
+      bidDeadline: 1_788_000_000,
+      deadline: 1_788_600_000,
+    });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act-price"]).toBe("250 USD");
+    expect(tags["+freeq.at/act-bid-deadline"]).toBe("1788000000");
+    // Two different times, both on the offer.
+    expect(tags["+freeq.at/act-deadline"]).toBe("1788600000");
+  });
+
+  it("carries a payment reference on the acceptance, and none by default", async () => {
+    const sent: Sent[] = [];
+    await acceptWork(ctxWith(sent), "01JTASK00000000000000000AA", { tx: "eth:0xabc" });
+    expect(sent[0].tags["+freeq.at/act-tx"]).toBe("eth:0xabc");
+    const bare: Sent[] = [];
+    await acceptWork(ctxWith(bare), "01JTASK00000000000000000AA");
+    expect(bare[0].tags["+freeq.at/act-tx"]).toBeUndefined();
+  });
+
   it("hands the work in without saying it is done", async () => {
     const sent: Sent[] = [];
     await submit(ctxWith(sent), "01JTASK00000000000000000AA", { note: "branch pushed" });

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -176,14 +176,16 @@ describe("the bounty verbs", () => {
     expect(sent[0].taskId).toBe("01JTASK00000000000000000AA");
   });
 
-  it("awards the work to the winner it names, not to the poster naming them", async () => {
+  it("takes the bid it names, and names no DID at all", async () => {
     const sent: Sent[] = [];
-    await award(ctxWith(sent), "01JTASK00000000000000000AA", "did:plc:worker");
+    await award(ctxWith(sent), "01JTASK00000000000000000AA", "01JBID000000000000000000BB");
     const { tags } = sent[0];
     expect(tags["+freeq.at/act-verb"]).toBe("award");
-    expect(tags["+freeq.at/act-to"]).toBe("did:plc:worker");
+    expect(tags["+freeq.at/act-accepts"]).toBe("01JBID000000000000000000BB");
+    // The winner is the bid's author, so the award names no recipient of its
+    // own — two sources for one fact is what naming a DID here would be.
+    expect(tags["+freeq.at/act-to"]).toBeUndefined();
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
-    expect(sent[0].humanText).toContain("did:plc:worker");
   });
 
   it("carries the kind on a bounty's follow-ups too", async () => {

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -252,9 +252,57 @@ describe("the bounty verbs", () => {
     }
   });
 
-  it("carries the kind on a bounty's follow-ups too", async () => {
+  it("carries the kind on the steps both kinds share", async () => {
     const sent: Sent[] = [];
-    await complete(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
+    await progress(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
     expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
+  });
+
+  it("names the kind it was given on every step about the posting, and the task when given none", async () => {
+    for (const [move, past] of [
+      [accept, "accepted"],
+      [decline, "declined"],
+      [claim, "claimed"],
+      [complete, "completed"],
+      [fail, "failed"],
+    ] as const) {
+      const plain: Sent[] = [];
+      await move(ctxWith(plain), "01JTASK00000000000000000AA");
+      expect(plain[0].humanText, past).toBe(`${past} the task`);
+      const named: Sent[] = [];
+      await move(ctxWith(named), "01JTASK00000000000000000AA", { kind: "handoff" });
+      expect(named[0].humanText, past).toBe(`${past} the handoff`);
+    }
+  });
+
+  it("names the kind it was given when cancelling, and the task when given none", async () => {
+    const sent: Sent[] = [];
+    await cancel(ctxWith(sent), "01JTASK00000000000000000AA", { kind: "bounty" });
+    expect(sent[0].tags["+freeq.at/act"]).toBe("bounty");
+    expect(sent[0].humanText).toBe("cancelled the bounty");
+    const plain: Sent[] = [];
+    await cancel(ctxWith(plain), "01JTASK00000000000000000AA");
+    expect(plain[0].humanText).toBe("cancelled the task");
+    const named: Sent[] = [];
+    await cancel(ctxWith(named), "01JTASK00000000000000000AA", { kind: "handoff" });
+    expect(named[0].humanText).toBe("cancelled the handoff");
+  });
+
+  it("says each bounty step the way the handoff steps are said", async () => {
+    const lines: [(...a: any[]) => Promise<string>, string][] = [
+      [bid, "bid on the bounty"],
+      [submit, "submitted the work"],
+      [revise, "asked for revisions"],
+      [acceptWork, "accepted the work"],
+      [forfeit, "forfeited the bounty"],
+    ];
+    for (const [move, line] of lines) {
+      const sent: Sent[] = [];
+      await move(ctxWith(sent), "01JTASK00000000000000000AA");
+      expect(sent[0].humanText, line).toBe(line);
+    }
+    const sent: Sent[] = [];
+    await award(ctxWith(sent), "01JTASK00000000000000000AA", "01JBID000000000000000000BB");
+    expect(sent[0].humanText).toBe("awarded the bounty");
   });
 });

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -195,7 +195,7 @@ describe("the bounty verbs", () => {
   it("carries a bid's terms as tags nothing interprets", async () => {
     const sent: Sent[] = [];
     await bid(ctxWith(sent), "01JTASK00000000000000000AA", {
-      amount: "250 USD",
+      price: "250 USD",
       payTo: "did:plc:worker",
     });
     const { tags } = sent[0];

--- a/freeq-bot-kit-js/src/act-verbs.test.ts
+++ b/freeq-bot-kit-js/src/act-verbs.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, it } from "vitest";
 import {
   accept,
   award,
+  submit,
+  revise,
+  acceptWork,
+  forfeit,
   bid,
   cancel,
   claim,
@@ -186,6 +190,30 @@ describe("the bounty verbs", () => {
     // own — two sources for one fact is what naming a DID here would be.
     expect(tags["+freeq.at/act-to"]).toBeUndefined();
     expect(tags["+freeq.at/from"]).toBe("did:plc:bot");
+  });
+
+  it("hands the work in without saying it is done", async () => {
+    const sent: Sent[] = [];
+    await submit(ctxWith(sent), "01JTASK00000000000000000AA", { note: "branch pushed" });
+    const { tags } = sent[0];
+    expect(tags["+freeq.at/act"]).toBe("bounty");
+    expect(tags["+freeq.at/act-verb"]).toBe("submit");
+    expect(tags["+freeq.at/act-id"]).toBe("01JTASK00000000000000000AA");
+    expect(tags["+freeq.at/act-note"]).toBe("branch pushed");
+  });
+
+  it("sends the work back, accepts it, or walks away from it", async () => {
+    for (const [move, verb] of [
+      [revise, "revise"],
+      [acceptWork, "accept-work"],
+      [forfeit, "forfeit"],
+    ] as const) {
+      const sent: Sent[] = [];
+      await move(ctxWith(sent), "01JTASK00000000000000000AA");
+      expect(sent[0].tags["+freeq.at/act-verb"], verb).toBe(verb);
+      expect(sent[0].tags["+freeq.at/act"], verb).toBe("bounty");
+      expect(sent[0].taskId, verb).toBe("01JTASK00000000000000000AA");
+    }
   });
 
   it("carries the kind on a bounty's follow-ups too", async () => {

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -201,7 +201,7 @@ export interface BidOptions extends StepOptions {
   /** What you are asking for. Opaque to every server that handles it: stored,
    *  relayed, replayed, and covered by the signature because it is present,
    *  never because anything knows what it means. */
-  amount?: string;
+  price?: string;
   /** Where you want paying. Opaque in the same way. */
   payTo?: string;
 }
@@ -220,7 +220,7 @@ export async function bid(
   opts: BidOptions = {},
 ): Promise<string> {
   const tags = stepTags("bid", ctx.did, taskId, opts.note, BOUNTY);
-  if (opts.amount) tags["+freeq.at/act-bid"] = opts.amount;
+  if (opts.price) tags["+freeq.at/act-bid"] = opts.price;
   if (opts.payTo) tags["+freeq.at/act-pay-to"] = opts.payTo;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? (opts.note ? `bid: ${opts.note}` : "bid on the bounty"),

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -83,6 +83,11 @@ function stepTags(verb: string, did: string, taskId: string, note?: string, kind
   return tags;
 }
 
+/** What a step's default line calls the thing it acts on: the kind, or "task". */
+function named(kind?: string): string {
+  return kind ?? "task";
+}
+
 /**
  * Open a task. Returns its id — the offer's own event id *is* the task's id,
  * which is why an offer carries no `act-id` of its own.
@@ -120,7 +125,7 @@ export async function accept(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("accept", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "accepted the task",
+    humanText: opts.humanText ?? `accepted the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -132,7 +137,7 @@ export async function decline(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("decline", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "declined the task",
+    humanText: opts.humanText ?? `declined the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -144,7 +149,7 @@ export async function claim(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("claim", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "claimed the task",
+    humanText: opts.humanText ?? `claimed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -168,7 +173,7 @@ export async function complete(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("complete", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "completed the task",
+    humanText: opts.humanText ?? `completed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -183,7 +188,7 @@ export async function fail(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("fail", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "failed the task",
+    humanText: opts.humanText ?? `failed the ${named(opts.kind)}`,
     taskId,
   });
 }
@@ -242,7 +247,7 @@ export async function award(
   const tags = stepTags("award", ctx.did, taskId, opts.note, BOUNTY);
   tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
-    humanText: opts.humanText ?? 'awarded the bounty',
+    humanText: opts.humanText ?? "awarded the bounty",
     taskId,
   });
 }
@@ -302,14 +307,10 @@ export async function acceptWork(
 ): Promise<string> {
   const tags = stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY);
   if (opts.tx) tags["+freeq.at/act-tx"] = opts.tx;
-  return ctx.client.sendAct(
-    ctx.target,
-    tags,
-    {
-      humanText: opts.humanText ?? "accepted the work",
-      taskId,
-    },
-  );
+  return ctx.client.sendAct(ctx.target, tags, {
+    humanText: opts.humanText ?? "accepted the work",
+    taskId,
+  });
 }
 
 /**
@@ -329,8 +330,10 @@ export async function forfeit(
 }
 
 /**
- * Withdraw a task you posted. The poster's unilateral act, legal from every
- * live state including mid-work — the worker gets the event, not a say.
+ * Withdraw a task you posted. The poster's unilateral act: on a handoff, legal
+ * from every live state including mid-work; on a bounty, only until the work
+ * is handed in — from there the poster's moves are to accept it or ask for
+ * revisions. Either way the worker gets the event, not a say.
  */
 export async function cancel(
   ctx: ActContext,
@@ -338,7 +341,7 @@ export async function cancel(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("cancel", ctx.did, taskId, opts.note, opts.kind), {
-    humanText: opts.humanText ?? "cancelled the task",
+    humanText: opts.humanText ?? `cancelled the ${named(opts.kind)}`,
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -1,9 +1,9 @@
 // The moves a bot can make on a task.
 //
-// One function per verb the RFC gives a sender. `expire` is not here: only
-// the server may make that move, and it makes it from the sweep, and neither
-// is `confirm`: a receipt is the action's home writing about an event it
-// filed.
+// One function per verb the RFC gives a sender. `expire` and `auto-accept` are
+// not here: only the server may make those moves, and it makes them from the
+// sweep. Neither is `confirm`: a receipt is the action's home writing about an
+// event it filed.
 //
 // Every one does the same paired send — the signed task TAGMSG that *is* the
 // event, and the plain-text line that renders it for the people in the room,
@@ -219,6 +219,78 @@ export async function award(
   tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? 'awarded the bounty',
+    taskId,
+  });
+}
+
+/**
+ * Hand in the work on a bounty you hold. The bounty waits for the poster from
+ * here: nothing about a submission says the work is done, only that it is in.
+ */
+export async function submit(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("submit", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "submitted the work",
+    taskId,
+  });
+}
+
+/**
+ * Send submitted work back for another pass. The bounty is assigned again and
+ * the worker still holds it — asking for changes is the poster answering, so
+ * it also stops the review clock and starts a fresh one on the next
+ * submission.
+ */
+export async function revise(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("revise", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "asked for changes",
+    taskId,
+  });
+}
+
+/**
+ * Accept submitted work on a bounty you posted. Terminal, and the poster's
+ * word rather than the worker's — which is the whole difference between this
+ * kind and a handoff.
+ *
+ * A payment reference rides along as an ordinary act tag if there is one. The
+ * server stores and relays it and never reads it: what settled, and whether it
+ * settled, live above this.
+ */
+export async function acceptWork(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(
+    ctx.target,
+    stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY),
+    {
+      humanText: opts.humanText ?? "accepted the work",
+      taskId,
+    },
+  );
+}
+
+/**
+ * Give up a bounty you hold, before or after handing the work in. Terminal:
+ * re-listing it is a new bounty naming this one in `replaces`, because the
+ * machine only runs forward.
+ */
+export async function forfeit(
+  ctx: ActContext,
+  taskId: string,
+  opts: StepOptions = {},
+): Promise<string> {
+  return ctx.client.sendAct(ctx.target, stepTags("forfeit", ctx.did, taskId, opts.note, BOUNTY), {
+    humanText: opts.humanText ?? "forfeited the bounty",
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -274,7 +274,7 @@ export async function revise(
   opts: StepOptions = {},
 ): Promise<string> {
   return ctx.client.sendAct(ctx.target, stepTags("revise", ctx.did, taskId, opts.note, BOUNTY), {
-    humanText: opts.humanText ?? "asked for changes",
+    humanText: opts.humanText ?? "asked for revisions",
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -200,23 +200,25 @@ export async function bid(
 }
 
 /**
- * Pick the winner of a bounty you posted, and assign the work to them.
+ * Take one of the bids on a bounty you posted, and assign the work to whoever
+ * wrote it.
  *
- * The poster names a winner rather than becoming one, which is why `act-to`
- * is on the award and why the view reads the assignee from it. Nothing checks
- * that the winner bid: the server never picks, and that cuts both ways — this
- * signed choice is the record.
+ * `bidEventId` is the bid's own event id, not the bidder's DID: a bounty's
+ * terms live in the bid, and bids are the one place several candidates sit
+ * side by side, so taking one means naming the exact event. The server checks
+ * only that the named event is a bid on this action — which of them is worth
+ * taking stays the poster's signed choice.
  */
 export async function award(
   ctx: ActContext,
   taskId: string,
-  winnerDid: string,
+  bidEventId: string,
   opts: StepOptions = {},
 ): Promise<string> {
   const tags = stepTags("award", ctx.did, taskId, opts.note, BOUNTY);
-  tags["+freeq.at/act-to"] = winnerDid;
+  tags["+freeq.at/act-accepts"] = bidEventId;
   return ctx.client.sendAct(ctx.target, tags, {
-    humanText: opts.humanText ?? `awarded the bounty to ${winnerDid}`,
+    humanText: opts.humanText ?? 'awarded the bounty',
     taskId,
   });
 }

--- a/freeq-bot-kit-js/src/act-verbs.ts
+++ b/freeq-bot-kit-js/src/act-verbs.ts
@@ -41,6 +41,13 @@ export interface OfferOptions {
   /** Unix seconds. Bounds how long the offer stands — not how long the work
    *  may take. */
   deadline?: number;
+  /** Unix seconds. Bounds how long a bounty takes bids, which closes sooner
+   *  than the offer does. A second time on the same offer, compared the same
+   *  way. */
+  bidDeadline?: number;
+  /** What a bounty offers to pay. Opaque: stored, relayed, replayed, covered
+   *  by the signature because it is present, and never read by any server. */
+  price?: string;
   /** A link to the task's materials, and a hash of them. */
   ctx?: string;
   ctxHash?: string;
@@ -92,6 +99,10 @@ export async function offer(ctx: ActContext, opts: OfferOptions): Promise<string
   if (opts.deadline !== undefined) {
     tags["+freeq.at/act-deadline"] = String(opts.deadline);
   }
+  if (opts.bidDeadline !== undefined) {
+    tags["+freeq.at/act-bid-deadline"] = String(opts.bidDeadline);
+  }
+  if (opts.price) tags["+freeq.at/act-price"] = opts.price;
   if (opts.ctx) tags["+freeq.at/act-ctx"] = opts.ctx;
   if (opts.ctxHash) tags["+freeq.at/act-ctx-h"] = opts.ctxHash;
   // Tagged only when there is something to revive: an absent relation and an
@@ -180,19 +191,32 @@ export async function fail(
 /** The only kind that has bids to take and a winner to name. */
 const BOUNTY = "bounty";
 
+/** What a bid may say about terms, on top of what any step carries. */
+export interface BidOptions extends StepOptions {
+  /** What you are asking for. Opaque to every server that handles it: stored,
+   *  relayed, replayed, and covered by the signature because it is present,
+   *  never because anything knows what it means. */
+  amount?: string;
+  /** Where you want paying. Opaque in the same way. */
+  payTo?: string;
+}
+
 /**
  * Put your name in for an open bounty. Additive: a bid leaves the bounty
- * exactly where it found it, and every bid stays on file.
+ * exactly where it found it, and every bid stays on file — which is what lets
+ * an award name one of them.
  *
- * A bid says nothing about price. `note` is freeform and signed like any act
- * tag; pricing is the agents' to agree, not the substrate's to define.
+ * Terms ride as tags nobody interprets. What settled, and whether it settled,
+ * is the agents' to agree and never the substrate's to say.
  */
 export async function bid(
   ctx: ActContext,
   taskId: string,
-  opts: StepOptions = {},
+  opts: BidOptions = {},
 ): Promise<string> {
   const tags = stepTags("bid", ctx.did, taskId, opts.note, BOUNTY);
+  if (opts.amount) tags["+freeq.at/act-bid"] = opts.amount;
+  if (opts.payTo) tags["+freeq.at/act-pay-to"] = opts.payTo;
   return ctx.client.sendAct(ctx.target, tags, {
     humanText: opts.humanText ?? (opts.note ? `bid: ${opts.note}` : "bid on the bounty"),
     taskId,
@@ -255,6 +279,13 @@ export async function revise(
   });
 }
 
+/** What an acceptance may carry, on top of what any step carries. */
+export interface AcceptWorkOptions extends StepOptions {
+  /** A payment reference. Opaque: a claim on the record that something was
+   *  paid, never a confirmation that it was. */
+  tx?: string;
+}
+
 /**
  * Accept submitted work on a bounty you posted. Terminal, and the poster's
  * word rather than the worker's — which is the whole difference between this
@@ -267,11 +298,13 @@ export async function revise(
 export async function acceptWork(
   ctx: ActContext,
   taskId: string,
-  opts: StepOptions = {},
+  opts: AcceptWorkOptions = {},
 ): Promise<string> {
+  const tags = stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY);
+  if (opts.tx) tags["+freeq.at/act-tx"] = opts.tx;
   return ctx.client.sendAct(
     ctx.target,
-    stepTags("accept-work", ctx.did, taskId, opts.note, BOUNTY),
+    tags,
     {
       humanText: opts.humanText ?? "accepted the work",
       taskId,

--- a/freeq-bot-kit-js/src/index.ts
+++ b/freeq-bot-kit-js/src/index.ts
@@ -86,7 +86,13 @@ export {
   acceptWork,
   forfeit,
 } from "./act-verbs.js";
-export type { ActContext, OfferOptions, StepOptions } from "./act-verbs.js";
+export type {
+  ActContext,
+  OfferOptions,
+  StepOptions,
+  BidOptions,
+  AcceptWorkOptions,
+} from "./act-verbs.js";
 
 // The task lifecycle rules — which move is legal, from which state, by whom.
 // The rules are data (spec/act-transitions.json, copied into src/); this is

--- a/freeq-bot-kit-js/src/index.ts
+++ b/freeq-bot-kit-js/src/index.ts
@@ -66,9 +66,10 @@ export {
 } from "./act.js";
 export type { ActVerifyResult } from "./act.js";
 
-// The eight moves a bot can make on a task — one function per verb, each
-// doing the paired send (the signed task event, plus the line people read).
-// `expire` is absent on purpose: only the server makes that move.
+// The moves a bot can make on a task — one function per verb, each doing the
+// paired send (the signed task event, plus the line people read). A handoff's
+// first, then the ones only a bounty has. `expire` and `auto-accept` are
+// absent on purpose: only the server makes those moves.
 export {
   offer,
   accept,
@@ -78,6 +79,12 @@ export {
   complete,
   fail,
   cancel,
+  bid,
+  award,
+  submit,
+  revise,
+  acceptWork,
+  forfeit,
 } from "./act-verbs.js";
 export type { ActContext, OfferOptions, StepOptions } from "./act-verbs.js";
 

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -773,9 +773,11 @@ mod tests {
                 id: "01KDEF0000000000000000000K",
             },
             Case {
-                // A bid on a bounty. Additive and unremarkable to the
-                // canonical, which is the point: a second kind needed a row
-                // in the transitions file and nothing at all here.
+                // A bid on a bounty, with terms. Additive and unremarkable
+                // to the canonical, which is the point: a second kind needed
+                // a row in the transitions file and nothing at all here, and
+                // its money tags are covered because they are present rather
+                // than because anything knows what they mean.
                 name: "bounty-bid",
                 seed: 7,
                 tags: vec![
@@ -783,6 +785,12 @@ mod tests {
                     ("+freeq.at/act-verb", "bid"),
                     ("+freeq.at/from", "did:plc:scholar"),
                     ("+freeq.at/act-id", BOUNTY_ID),
+                    // What the bidder asks and where they want it paid.
+                    // Opaque to every server that handles them — the point of
+                    // the vector is that two signers agree on bytes neither of
+                    // them interprets.
+                    ("+freeq.at/act-bid", "250 USD"),
+                    ("+freeq.at/act-pay-to", "did:plc:scholar"),
                     ("+freeq.at/act-note", "two days, sources included"),
                 ],
                 target: "#swarm",

--- a/freeq-sdk/src/act.rs
+++ b/freeq-sdk/src/act.rs
@@ -287,6 +287,10 @@ mod tests {
     /// event id, exactly as a handoff's is.
     const BOUNTY_ID: &str = "01JBOUNTYEVENTID00000000B";
 
+    /// The bid on it, and so the value the award names in `act-accepts`: an
+    /// award takes an event, not a DID.
+    const BID_ID: &str = "01JBIDEVENTID00000000000B";
+
     /// The RFC's directed-offer example, as a wire tag map (plus tags that
     /// must NOT be covered as tags: sig, eventid, msgid, actor-class).
     fn offer_tags() -> Vec<(&'static str, &'static str)> {
@@ -782,13 +786,13 @@ mod tests {
                     ("+freeq.at/act-note", "two days, sources included"),
                 ],
                 target: "#swarm",
-                id: "01JBIDEVENTID00000000000B",
+                id: BID_ID,
             },
             Case {
-                // The award: the poster names a winner in act-to, and the
-                // view reads the assignee from that field rather than from
-                // the actor. Both are covered by the signature, so neither
-                // can be re-pointed in transit.
+                // The award: the poster takes one bid by naming its event id,
+                // and the view reads the assignee from that bid's author
+                // rather than from the actor. The pointer is covered by the
+                // signature, so it cannot be re-pointed in transit.
                 name: "bounty-award",
                 seed: 8,
                 tags: vec![
@@ -796,7 +800,7 @@ mod tests {
                     ("+freeq.at/act-verb", "award"),
                     ("+freeq.at/from", "did:plc:eliza"),
                     ("+freeq.at/act-id", BOUNTY_ID),
-                    ("+freeq.at/act-to", "did:plc:scholar"),
+                    ("+freeq.at/act-accepts", BID_ID),
                 ],
                 target: "#swarm",
                 id: "01JAWARDEVENTID000000000A",
@@ -926,16 +930,16 @@ mod tests {
                 swap_alg: None,
             },
             Negative {
-                // An award with its winner stripped. Unlike a missing
-                // envelope field this is strip-*detectable*: act-to is an act
-                // tag, so the sweep covered it and the document rebuilds
+                // An award with the bid it takes stripped. Unlike a missing
+                // envelope field this is strip-*detectable*: act-accepts is an
+                // act tag, so the sweep covered it and the document rebuilds
                 // without it into bytes the signature contradicts.
-                name: "award-with-its-winner-stripped",
+                name: "award-with-its-bid-stripped",
                 of: "bounty-award",
                 expected: "invalid",
                 target: "#swarm",
                 id: "01JAWARDEVENTID000000000A",
-                strip_tag: Some("+freeq.at/act-to"),
+                strip_tag: Some("+freeq.at/act-accepts"),
                 swap_tag: None,
                 swap_alg: None,
             },

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -160,7 +160,7 @@ pub struct Event<'a> {
 /// The bid an award named, as the caller's log answered for it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AcceptedBid<'a> {
-    /// Who wrote the bid. The assignee an award's `bid-author` row lands on.
+    /// Who wrote the bid. The assignee an award's `author_of` row lands on.
     pub author: &'a str,
 }
 
@@ -323,16 +323,22 @@ pub enum AssigneeSource {
     Actor,
     /// The act field named here, read off the event.
     Field(&'static str),
-    /// Whoever wrote the bid the event names in `act-accepts`: a bounty's
-    /// `award` takes one bid, and the terms live in it, so the poster names
-    /// the event rather than a DID. Resolving it is the caller's — this
+    /// The author of the event named in this act field: a bounty's `award`
+    /// takes one bid, and the terms live in it, so the poster names the event
+    /// in `act-accepts` rather than a DID. Resolving it is the caller's — this
     /// checker reads no log — and the answer arrives as
     /// [`Sender::accepted_bid`].
-    BidAuthor,
+    AuthorOf(&'static str),
 }
 
-/// The `assignee_from` value that means [`AssigneeSource::BidAuthor`].
-const BID_AUTHOR: &str = "bid-author";
+/// How a row spells `assignee_from`: a tag holding a DID, or the author of
+/// the event a tag names.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(untagged)]
+enum AssigneeFrom {
+    Field(String),
+    AuthorOf { author_of: String },
+}
 
 /// The verb the event an award names must carry.
 ///
@@ -381,10 +387,10 @@ pub fn assignee_source(kind: &str, verb: &str, from_state: &str) -> AssigneeSour
     k.transitions
         .iter()
         .find(|t| t.verb == verb && t.from.matches(from_state, k))
-        .and_then(|t| t.assignee_from.as_deref())
-        .map_or(AssigneeSource::Actor, |name| match name {
-            BID_AUTHOR => AssigneeSource::BidAuthor,
-            field => AssigneeSource::Field(field),
+        .and_then(|t| t.assignee_from.as_ref())
+        .map_or(AssigneeSource::Actor, |from| match from {
+            AssigneeFrom::Field(field) => AssigneeSource::Field(field),
+            AssigneeFrom::AuthorOf { author_of } => AssigneeSource::AuthorOf(author_of),
         })
 }
 
@@ -487,7 +493,7 @@ pub fn check(
     // here reads a log — and a name that found nothing named something that
     // is not a bid on this action. Alongside the requirement above for the
     // same reason: an award that takes no bid is malformed for everybody.
-    if row.assignee_from.as_deref() == Some(BID_AUTHOR)
+    if matches!(row.assignee_from, Some(AssigneeFrom::AuthorOf { .. }))
         && (event.accepts.is_none() || sender.accepted_bid.is_none())
     {
         return Err(Refusal::AcceptsNotABid);
@@ -594,9 +600,11 @@ struct Transition {
     /// code.
     #[serde(default)]
     before_bid_deadline: bool,
-    /// The field naming who this transition assigns. Absent = the actor.
+    /// Who this transition assigns. Absent = the actor; a tag name = the DID
+    /// in that tag; `{ "author_of": tag }` = the author of the event that tag
+    /// names.
     #[serde(default)]
-    assignee_from: Option<String>,
+    assignee_from: Option<AssigneeFrom>,
     /// Fields the transition is illegal without. Empty for almost every row,
     /// which is why an absent one has to change nothing.
     #[serde(default)]
@@ -1070,7 +1078,7 @@ mod tests {
     fn a_transition_says_where_its_assignee_comes_from() {
         assert_eq!(
             assignee_source("bounty", "award", "open"),
-            AssigneeSource::BidAuthor
+            AssigneeSource::AuthorOf("act-accepts")
         );
         for (kind, verb, from) in [
             ("handoff", "accept", "offered"),
@@ -1791,7 +1799,7 @@ mod tests {
                         assignee = Some(
                             match assignee_source(&seq.task.kind, &step.verb, &state) {
                                 AssigneeSource::Actor => step.sender.clone(),
-                                AssigneeSource::BidAuthor => step
+                                AssigneeSource::AuthorOf(_) => step
                                     .accepted_bid
                                     .clone()
                                     .unwrap_or_else(|| panic!("{where_}: this transition assigns the author of the bid it names, and none was resolved")),

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -335,6 +335,33 @@ const BID_AUTHOR: &str = "bid-author";
 /// rules rather than spelling a kind's verb into itself.
 pub const BID_VERB: &str = "bid";
 
+/// The verb a home files when a review window runs out.
+///
+/// Distinct from `expire` on purpose: the log should say what happened, and
+/// "the review window closed and the work is deemed accepted" is not the same
+/// event as "nobody touched this for a month". A sweep that reused `expire`
+/// would tell every reader the worker dropped the job.
+pub const REVIEW_TIMEOUT_VERB: &str = "auto-accept";
+
+/// Every state some kind's review-timeout row moves a task out of.
+///
+/// The sweep asks this rather than knowing which kinds have a review window:
+/// a kind that writes the row is swept, a kind that does not is left to the
+/// neutral idle limit. Sorted and deduplicated, so two kinds naming the same
+/// state name it once.
+pub fn review_timeout_states() -> Vec<&'static str> {
+    let mut states: Vec<&'static str> = spec()
+        .kinds
+        .values()
+        .flat_map(|k| k.transitions.iter())
+        .filter(|t| t.verb == REVIEW_TIMEOUT_VERB)
+        .flat_map(|t| t.from.states())
+        .collect();
+    states.sort_unstable();
+    states.dedup();
+    states
+}
+
 /// Where the assignee comes from when `verb` moves a `kind` task out of
 /// `from_state`.
 ///
@@ -567,6 +594,16 @@ enum FromStates {
 const ANY_NONTERMINAL: &str = "*nonterminal";
 
 impl FromStates {
+    /// The states named outright. Empty for `*nonterminal`, which names none
+    /// of them: it is a rule about the kind's table rather than a list.
+    fn states(&'static self) -> Vec<&'static str> {
+        match self {
+            FromStates::One(s) if s == ANY_NONTERMINAL => Vec::new(),
+            FromStates::One(s) => vec![s.as_str()],
+            FromStates::Many(states) => states.iter().map(String::as_str).collect(),
+        }
+    }
+
     fn matches(&self, state: &str, kind: &Kind) -> bool {
         match self {
             FromStates::One(s) if s == ANY_NONTERMINAL => !kind.terminal.iter().any(|t| t == state),
@@ -1066,6 +1103,48 @@ mod tests {
         assert_eq!(
             check(&bounty("assigned"), &ev("bid"), &who(MALLORY)),
             Err(Refusal::IllegalStep)
+        );
+    }
+
+    /// The sweep reads which states have a review window off the tables, so a
+    /// kind that adds the row is swept and one that does not is left alone.
+    #[test]
+    fn the_review_timeout_states_come_from_the_tables() {
+        assert_eq!(REVIEW_TIMEOUT_VERB, "auto-accept");
+        assert_eq!(review_timeout_states(), vec!["under_review"]);
+        // Handoff has no review window, so none of its states are swept by
+        // this clock — its work ends when the assignee says so.
+        for state in ["offered", "open", "assigned"] {
+            assert!(!review_timeout_states().contains(&state), "{state}");
+        }
+    }
+
+    /// A bounty's review window is the server's to close, and only from the
+    /// state the work is actually sitting in.
+    #[test]
+    fn only_the_server_closes_a_review_window() {
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &who(ELIZA)),
+            Err(Refusal::WrongSender),
+            "not the poster whose silence started the clock"
+        );
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &who(SCHOLAR)),
+            Err(Refusal::WrongSender)
+        );
+        let system = Sender {
+            did: SERVER,
+            is_system: true,
+            accepted_bid: None,
+        };
+        assert_eq!(
+            check(&bounty("under_review"), &ev("auto-accept"), &system),
+            Ok("accepted")
+        );
+        assert_eq!(
+            check(&bounty("assigned"), &ev("auto-accept"), &system),
+            Err(Refusal::IllegalStep),
+            "there is no window until the work is in"
         );
     }
 

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -71,6 +71,9 @@ pub enum Refusal {
     /// outlives every event — so carrying it costs nothing and saves a round
     /// of guessing.
     MissingRequirement(&'static str),
+    /// An award named an event that is not a bid on this action. The caller
+    /// resolved the name against its own log and found nothing to take.
+    AcceptsNotABid,
 }
 
 impl Refusal {
@@ -89,6 +92,7 @@ impl Refusal {
             Refusal::ReplacesMalformed => "replaces-malformed",
             Refusal::ReplacesNotTerminal => "replaces-not-terminal",
             Refusal::MissingRequirement(_) => "missing-requirement",
+            Refusal::AcceptsNotABid => "accepts-not-a-bid",
         }
     }
 
@@ -136,6 +140,10 @@ pub struct Event<'a> {
     /// deadline is measured against — every verifier then compares the same
     /// number instead of its own wall clock.
     pub msgid: &'a str,
+    /// `act-accepts`: the event an award takes. Named here rather than read
+    /// out of `fields` because it is the one act value a caller must resolve
+    /// before asking — see [`Sender::accepted_bid`].
+    pub accepts: Option<&'a str>,
     /// The act fields the event carries, by their document names (`act-to`,
     /// `act-note`, …). Presence only: what a transition's `requires` is
     /// checked against. Values are the caller's business — the one place this
@@ -144,13 +152,30 @@ pub struct Event<'a> {
     pub fields: &'a [&'a str],
 }
 
-/// Who sent it.
+/// The bid an award named, as the caller's log answered for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AcceptedBid<'a> {
+    /// Who wrote the bid. The assignee an award's `bid-author` row lands on.
+    pub author: &'a str,
+}
+
+/// Who sent it, and what their event resolved to.
 #[derive(Debug, Clone, Copy)]
 pub struct Sender<'a> {
     pub did: &'a str,
     /// The server itself, signing under its own identity — the only actor a
     /// `system` transition allows.
     pub is_system: bool,
+    /// The bid this event's `act-accepts` names, when the caller found one on
+    /// the action. `None` when it named something that is not a bid here —
+    /// including an id belonging to another action, and an id nobody filed.
+    ///
+    /// This checker reads no log, so the lookup is the caller's: it resolves
+    /// the named event among the action's own and hands back the bid's
+    /// author. A caller with no log — a bot pre-checking its own move —
+    /// passes `None` and is told its award takes nothing, which is the honest
+    /// answer from where it stands.
+    pub accepted_bid: Option<AcceptedBid<'a>>,
 }
 
 /// The state a new task of `kind` starts in.
@@ -291,10 +316,24 @@ pub fn check_open(
 pub enum AssigneeSource {
     /// Whoever took the step — what `accept` and `claim` already mean.
     Actor,
-    /// The act field named here, read off the event: a bounty's `award` names
-    /// its winner in `act-to`, because the poster picks rather than becomes.
+    /// The act field named here, read off the event.
     Field(&'static str),
+    /// Whoever wrote the bid the event names in `act-accepts`: a bounty's
+    /// `award` takes one bid, and the terms live in it, so the poster names
+    /// the event rather than a DID. Resolving it is the caller's — this
+    /// checker reads no log — and the answer arrives as
+    /// [`Sender::accepted_bid`].
+    BidAuthor,
 }
+
+/// The `assignee_from` value that means [`AssigneeSource::BidAuthor`].
+const BID_AUTHOR: &str = "bid-author";
+
+/// The verb the event an award names must carry.
+///
+/// Written down once, here, so a caller resolving `act-accepts` asks the
+/// rules rather than spelling a kind's verb into itself.
+pub const BID_VERB: &str = "bid";
 
 /// Where the assignee comes from when `verb` moves a `kind` task out of
 /// `from_state`.
@@ -311,7 +350,10 @@ pub fn assignee_source(kind: &str, verb: &str, from_state: &str) -> AssigneeSour
         .iter()
         .find(|t| t.verb == verb && t.from.matches(from_state, k))
         .and_then(|t| t.assignee_from.as_deref())
-        .map_or(AssigneeSource::Actor, AssigneeSource::Field)
+        .map_or(AssigneeSource::Actor, |name| match name {
+            BID_AUTHOR => AssigneeSource::BidAuthor,
+            field => AssigneeSource::Field(field),
+        })
 }
 
 /// Whether the rules file lists this kind at all.
@@ -406,6 +448,17 @@ pub fn check(
         .find(|f| !event.fields.contains(&f.as_str()))
     {
         return Err(Refusal::MissingRequirement(missing.as_str()));
+    }
+
+    // A row that takes its assignee from a named bid needs that bid. Whether
+    // the name found one is the caller's answer, not this checker's — nothing
+    // here reads a log — and a name that found nothing named something that
+    // is not a bid on this action. Alongside the requirement above for the
+    // same reason: an award that takes no bid is malformed for everybody.
+    if row.assignee_from.as_deref() == Some(BID_AUTHOR)
+        && (event.accepts.is_none() || sender.accepted_bid.is_none())
+    {
+        return Err(Refusal::AcceptsNotABid);
     }
 
     // Authority second: who the sender is only matters once the move itself
@@ -566,6 +619,7 @@ mod tests {
         Event {
             verb,
             msgid: NOW,
+            accepts: None,
             fields: &[],
         }
     }
@@ -574,6 +628,28 @@ mod tests {
         Sender {
             did,
             is_system: false,
+            accepted_bid: None,
+        }
+    }
+
+    /// A sender whose award named a bid the caller resolved to `author`.
+    fn who_took(did: &'static str, author: &'static str) -> Sender<'static> {
+        Sender {
+            accepted_bid: Some(AcceptedBid { author }),
+            ..who(did)
+        }
+    }
+
+    /// The bid an award names in these tests.
+    const BID: &str = "01M16E7TC0BDTAKEN000000000";
+
+    /// An award naming `BID`.
+    fn award() -> Event<'static> {
+        Event {
+            verb: "award",
+            msgid: NOW,
+            accepts: Some(BID),
+            fields: &["act-accepts"],
         }
     }
 
@@ -748,6 +824,7 @@ mod tests {
         let system = Sender {
             did: SERVER,
             is_system: true,
+            accepted_bid: None,
         };
         assert_eq!(
             check(&directed("offered"), &ev("confirm"), &system),
@@ -851,29 +928,45 @@ mod tests {
 
     /// A transition is illegal without the fields its row names, and the
     /// refusal says which one is missing. Checked before authority: an award
-    /// naming no winner is malformed for everybody.
+    /// naming no bid is malformed for everybody.
     #[test]
-    fn an_award_names_its_winner_or_it_is_no_award() {
+    fn an_award_names_the_bid_it_takes_or_it_is_no_award() {
         let bare = Event {
             verb: "award",
             msgid: NOW,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
-            check(&bounty("open"), &bare, &who(ELIZA)),
-            Err(Refusal::MissingRequirement("act-to"))
+            check(&bounty("open"), &bare, &who_took(ELIZA, SCHOLAR)),
+            Err(Refusal::MissingRequirement("act-accepts"))
         );
         assert_eq!(
-            check(&bounty("open"), &bare, &who(MALLORY)),
-            Err(Refusal::MissingRequirement("act-to")),
+            check(&bounty("open"), &bare, &who_took(MALLORY, SCHOLAR)),
+            Err(Refusal::MissingRequirement("act-accepts")),
             "malformed for everybody, so it does not read as 'not you'"
         );
-        let named = Event {
-            verb: "award",
-            msgid: NOW,
-            fields: &["act-to"],
-        };
-        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+        assert_eq!(
+            check(&bounty("open"), &award(), &who_took(ELIZA, SCHOLAR)),
+            Ok("assigned")
+        );
+    }
+
+    /// The award names one event and the caller resolves it. A name that
+    /// found no bid on this action — the bounty's own opener, a bid filed
+    /// against something else, an id nobody ever used — takes nothing, and
+    /// says so rather than assigning the poster's own choice of stranger.
+    #[test]
+    fn an_award_naming_something_that_is_not_a_bid_takes_nothing() {
+        assert_eq!(
+            check(&bounty("open"), &award(), &who(ELIZA)),
+            Err(Refusal::AcceptsNotABid)
+        );
+        // Before authority, like the requirement above.
+        assert_eq!(
+            check(&bounty("open"), &award(), &who(MALLORY)),
+            Err(Refusal::AcceptsNotABid)
+        );
     }
 
     /// The guard has to be free for every row that names nothing, which is
@@ -885,6 +978,7 @@ mod tests {
             let e = Event {
                 verb,
                 msgid: NOW,
+                accepts: None,
                 fields: &[],
             };
             assert!(
@@ -902,7 +996,7 @@ mod tests {
     fn a_transition_says_where_its_assignee_comes_from() {
         assert_eq!(
             assignee_source("bounty", "award", "open"),
-            AssigneeSource::Field("act-to")
+            AssigneeSource::BidAuthor
         );
         for (kind, verb, from) in [
             ("handoff", "accept", "offered"),
@@ -928,17 +1022,18 @@ mod tests {
         );
     }
 
-    /// The server never picks — which cuts both ways. Nothing here checks
-    /// that the awarded DID ever bid: the poster's signed choice is the
-    /// record, and a checker that second-guessed it would be picking.
+    /// The server still never picks. It checks only that the named event is a
+    /// bid on this action; which of the bids on the table is worth taking is
+    /// the poster's to decide and nothing here second-guesses it.
     #[test]
-    fn an_award_may_name_anyone_at_all() {
-        let named = Event {
-            verb: "award",
-            msgid: NOW,
-            fields: &["act-to"],
-        };
-        assert_eq!(check(&bounty("open"), &named, &who(ELIZA)), Ok("assigned"));
+    fn the_poster_takes_whichever_bid_they_name() {
+        for author in [SCHOLAR, MALLORY, "did:plc:nobody"] {
+            assert_eq!(
+                check(&bounty("open"), &award(), &who_took(ELIZA, author)),
+                Ok("assigned"),
+                "{author}"
+            );
+        }
     }
 
     /// Bids are additive: the state they leave is the state they found, so a
@@ -972,7 +1067,8 @@ mod tests {
             Refusal::ReplacesNotOpener,
             Refusal::ReplacesMalformed,
             Refusal::ReplacesNotTerminal,
-            Refusal::MissingRequirement("act-to"),
+            Refusal::MissingRequirement("act-accepts"),
+            Refusal::AcceptsNotABid,
         ] {
             assert!(
                 spec().refusals.contains_key(r.code()),
@@ -1097,6 +1193,7 @@ mod tests {
         let system = Sender {
             did: SERVER,
             is_system: true,
+            accepted_bid: None,
         };
         assert_eq!(
             check(&directed("assigned"), &ev("expire"), &system),
@@ -1150,6 +1247,7 @@ mod tests {
             let system = Sender {
                 did: SERVER,
                 is_system: true,
+                accepted_bid: None,
             };
             assert_eq!(
                 check(&done, &ev("expire"), &system),
@@ -1278,6 +1376,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1292,6 +1391,7 @@ mod tests {
             let e = Event {
                 verb: "accept",
                 msgid: id,
+                accepts: None,
                 fields: &[],
             };
             assert_eq!(
@@ -1313,6 +1413,7 @@ mod tests {
         let late = Event {
             verb: "claim",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1323,6 +1424,7 @@ mod tests {
             let e = Event {
                 verb: "claim",
                 msgid: id,
+                accepts: None,
                 fields: &[],
             };
             assert_eq!(
@@ -1340,6 +1442,7 @@ mod tests {
         let late = Event {
             verb: "decline",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1349,6 +1452,7 @@ mod tests {
         let late_cancel = Event {
             verb: "cancel",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1362,6 +1466,7 @@ mod tests {
         let late = Event {
             verb: "accept",
             msgid: TOO_LATE,
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1377,6 +1482,7 @@ mod tests {
         let junk = Event {
             verb: "accept",
             msgid: "not-a-ulid",
+            accepts: None,
             fields: &[],
         };
         assert_eq!(
@@ -1424,6 +1530,11 @@ mod tests {
         /// Who the step assigns, when it names someone other than its sender:
         /// the value the transition's `assignee_from` field would hold.
         assigns: Option<String>,
+        /// `act-accepts`: the event an award takes.
+        accepts: Option<String>,
+        /// Who wrote the bid that event turned out to be. Absent when the
+        /// name found no bid on this action.
+        accepted_bid: Option<String>,
         expect: Option<String>,
         expect_refused: Option<String>,
     }
@@ -1460,11 +1571,20 @@ mod tests {
             let event = Event {
                 verb: &step.verb,
                 msgid: step.event_id.as_deref().unwrap_or(NOW),
+                accepts: step.accepts.as_deref(),
                 fields: &fields,
             };
             let sender = Sender {
                 did: &step.sender,
                 is_system: step.system,
+                // What the caller's log made of the event this one names. A
+                // step that sets nothing named nothing, or named something
+                // that is not a bid — the file does not distinguish, because
+                // neither does the checker.
+                accepted_bid: step
+                    .accepted_bid
+                    .as_deref()
+                    .map(|author| AcceptedBid { author }),
             };
             let where_ = format!("{} — step {} ({})", seq.name, i + 1, step.verb);
 
@@ -1483,6 +1603,10 @@ mod tests {
                         assignee = Some(
                             match assignee_source(&seq.task.kind, &step.verb, &state) {
                                 AssigneeSource::Actor => step.sender.clone(),
+                                AssigneeSource::BidAuthor => step
+                                    .accepted_bid
+                                    .clone()
+                                    .unwrap_or_else(|| panic!("{where_}: this transition assigns the author of the bid it names, and none was resolved")),
                                 AssigneeSource::Field(name) => step
                                     .assigns
                                     .clone()

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -779,7 +779,16 @@ mod tests {
             "bounty's verb, not handoff's"
         );
         for verb in [
-            "bid", "award", "progress", "complete", "fail", "cancel", "expire",
+            "bid",
+            "award",
+            "progress",
+            "submit",
+            "revise",
+            "accept-work",
+            "forfeit",
+            "auto-accept",
+            "cancel",
+            "expire",
         ] {
             assert!(knows_verb("bounty", verb), "{verb}");
         }
@@ -787,6 +796,12 @@ mod tests {
             !knows_verb("bounty", "accept"),
             "handoff's verb, not bounty's — a bounty has no offeree to accept"
         );
+        for verb in ["complete", "fail"] {
+            assert!(
+                !knows_verb("bounty", verb),
+                "{verb}: a bounty ends on the poster's word, not the worker's"
+            );
+        }
         assert!(!knows_verb("approval", "request"), "no table, no verbs");
     }
 

--- a/freeq-sdk/src/act_transitions.rs
+++ b/freeq-sdk/src/act_transitions.rs
@@ -130,6 +130,11 @@ pub struct Task<'a> {
     pub offeree: Option<&'a str>,
     pub assignee: Option<&'a str>,
     pub deadline: Option<i64>,
+    /// The offer's `act-bid-deadline` in unix seconds, empty when it named
+    /// none. A second time on the same opener, compared the same way: it
+    /// bounds how long a bounty collects bids, which is a shorter question
+    /// than how long the offer stands.
+    pub bid_deadline: Option<i64>,
 }
 
 /// The event being checked.
@@ -503,8 +508,18 @@ pub fn check(
         _ => return Err(Refusal::WrongSender),
     }
 
-    if row.before_deadline
-        && let Some(deadline) = task.deadline
+    // Two deadlines, one comparison. A row declares which of the offer's
+    // times bounds it: how long the offer stands, or — on a kind that
+    // collects them — how long it takes bids. A time the offer never named
+    // bounds nothing.
+    for deadline in [
+        row.before_deadline.then_some(task.deadline).flatten(),
+        row.before_bid_deadline
+            .then_some(task.bid_deadline)
+            .flatten(),
+    ]
+    .into_iter()
+    .flatten()
     {
         let limit = deadline
             .saturating_mul(1_000)
@@ -574,6 +589,11 @@ struct Transition {
     who: String,
     #[serde(default)]
     before_deadline: bool,
+    /// Bounded by the offer's `act-bid-deadline` rather than its
+    /// `act-deadline`. Data, like its sibling; the comparison is the same
+    /// code.
+    #[serde(default)]
+    before_bid_deadline: bool,
     /// The field naming who this transition assigns. Absent = the actor.
     #[serde(default)]
     assignee_from: Option<String>,
@@ -649,6 +669,7 @@ mod tests {
             offeree: Some(SCHOLAR),
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -975,6 +996,7 @@ mod tests {
             offeree: None,
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -1386,6 +1408,7 @@ mod tests {
             offeree: None,
             assignee: None,
             deadline: None,
+            bid_deadline: None,
         }
     }
 
@@ -1569,6 +1592,73 @@ mod tests {
         );
     }
 
+    /// A bounty takes bids until its own cutoff, which is a shorter question
+    /// than how long the offer stands. Both times sit on the same opener and
+    /// are compared the same way.
+    #[test]
+    fn a_bid_is_bound_by_the_offers_bid_deadline() {
+        let taking_bids = Task {
+            bid_deadline: Some(DEADLINE),
+            ..bounty("open")
+        };
+        let late = Event {
+            verb: "bid",
+            msgid: TOO_LATE,
+            accepts: None,
+            fields: &[],
+        };
+        assert_eq!(
+            check(&taking_bids, &late, &who(SCHOLAR)),
+            Err(Refusal::DeadlinePassed)
+        );
+        for id in [IN_TIME, AT_EDGE] {
+            let e = Event {
+                verb: "bid",
+                msgid: id,
+                accepts: None,
+                fields: &[],
+            };
+            assert_eq!(check(&taking_bids, &e, &who(SCHOLAR)), Ok("open"), "{id}");
+        }
+    }
+
+    /// The two times are separate: bidding may close long before the offer
+    /// does, and a bounty that named no bid cutoff takes bids for as long as
+    /// it stands.
+    #[test]
+    fn the_two_deadlines_bound_different_moves() {
+        // Bidding closed; the offer has not.
+        let closed = Task {
+            deadline: None,
+            bid_deadline: Some(DEADLINE),
+            ..bounty("open")
+        };
+        let late = Event {
+            verb: "bid",
+            msgid: TOO_LATE,
+            accepts: None,
+            fields: &[],
+        };
+        assert_eq!(
+            check(&closed, &late, &who(SCHOLAR)),
+            Err(Refusal::DeadlinePassed)
+        );
+        // The award is bound by the offer's own deadline, not by the bid one.
+        let award_late = Event {
+            verb: "award",
+            msgid: TOO_LATE,
+            accepts: Some(BID),
+            fields: &["act-accepts"],
+        };
+        assert_eq!(
+            check(&closed, &award_late, &who_took(ELIZA, SCHOLAR)),
+            Ok("assigned"),
+            "bidding closing does not stop the poster picking"
+        );
+        // …and no bid cutoff means no bid cutoff.
+        assert_eq!(check(&bounty("open"), &late, &who(SCHOLAR)), Ok("open"));
+    }
+
     /// Fail closed: an id whose clock cannot be read cannot be shown to be
     /// inside the deadline, so it is treated as outside it.
     #[test]
@@ -1608,6 +1698,9 @@ mod tests {
         offerer: String,
         offeree: Option<String>,
         deadline: Option<i64>,
+        /// `act-bid-deadline`: how long the offer takes bids, when it named a
+        /// second time.
+        bid_deadline: Option<i64>,
     }
 
     #[derive(Deserialize)]
@@ -1660,6 +1753,7 @@ mod tests {
                 offeree: seq.task.offeree.as_deref(),
                 assignee: assignee.as_deref(),
                 deadline: seq.task.deadline,
+                bid_deadline: seq.task.bid_deadline,
             };
             let fields: Vec<&str> = step.tags.iter().map(String::as_str).collect();
             let event = Event {

--- a/freeq-server/src/config.rs
+++ b/freeq-server/src/config.rs
@@ -132,6 +132,17 @@ pub struct ServerConfig {
     #[arg(long, default_value = "604800")]
     pub act_expiry_secs: u64,
 
+    /// How long submitted work may wait on the poster before it is deemed
+    /// accepted, in seconds. Separate from the abandonment limit because it
+    /// does the opposite job: that one is neutral and catches work nobody is
+    /// doing, this one favours the worker and catches a poster who took
+    /// delivery and then went quiet. Measured from the last movement, so
+    /// asking for changes stops the clock and a fresh submission starts a new
+    /// one. Fixed and documented rather than per-task, so every bidder knows
+    /// the window before they bid. 0 = never auto-accept.
+    #[arg(long, default_value = "1209600")]
+    pub act_review_secs: u64,
+
     /// Message of the Day text. If not set, no MOTD is sent.
     #[arg(long)]
     pub motd: Option<String>,
@@ -307,6 +318,7 @@ impl Default for ServerConfig {
             did_resolver_static: vec![],
             max_messages_per_channel: 10000,
             act_expiry_secs: 604_800,
+            act_review_secs: 1_209_600,
             motd: None,
             motd_file: None,
             web_static_dir: None,
@@ -441,6 +453,7 @@ struct FileConfig {
     did_resolver_static: Option<MapOrPairs>,
     max_messages_per_channel: Option<usize>,
     act_expiry_secs: Option<u64>,
+    act_review_secs: Option<u64>,
     motd: Option<String>,
     motd_file: Option<String>,
     web_static_dir: Option<String>,
@@ -558,6 +571,7 @@ fn apply_file(cfg: &mut ServerConfig, matches: &clap::ArgMatches, file: FileConf
         s2s_allowed_peers,
         max_messages_per_channel,
         act_expiry_secs,
+        act_review_secs,
         plugins,
         require_did_for_ops,
         oper_dids,
@@ -613,6 +627,7 @@ mod tests {
                 max_messages_per_channel = 42
                 iroh = true
                 act_expiry_secs = 120
+                act_review_secs = 240
                 s2s_peer_api = ["abcd=https://irc.example.com"]
                 "#,
             ),
@@ -623,6 +638,7 @@ mod tests {
         assert_eq!(c.max_messages_per_channel, 42);
         assert!(c.iroh);
         assert_eq!(c.act_expiry_secs, 120);
+        assert_eq!(c.act_review_secs, 240);
         assert_eq!(c.s2s_peer_api, vec!["abcd=https://irc.example.com"]);
     }
 

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -1012,6 +1012,10 @@ pub(super) fn gate(
                     missing = format!("That step must carry {field}");
                     ("MISSING_REQUIREMENT", missing.as_str())
                 }
+                Refusal::AcceptsNotABid => (
+                    "ACCEPTS_NOT_A_BID",
+                    "The award names an event that is not a bid on this action",
+                ),
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -1063,10 +1063,9 @@ pub(super) fn gate(
                     missing = format!("That step must carry {field}");
                     ("MISSING_REQUIREMENT", missing.as_str())
                 }
-                Refusal::AcceptsNotABid => (
-                    "ACCEPTS_NOT_A_BID",
-                    "The award names an event that is not a bid on this action",
-                ),
+                Refusal::AcceptsNotABid => {
+                    ("ACCEPTS_NOT_A_BID", "That award names no bid on this task")
+                }
             };
             tracing::debug!(
                 session = %conn.id, did = %did, act_id = %act_id, reason = %reason,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -251,6 +251,41 @@ pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -
     true
 }
 
+/// Close the review window on one task: sign the event, run it through the
+/// same check and storage every other event goes through, and let it go out.
+///
+/// The other clock, and the mirror of `expire_task` — the difference is what
+/// the log ends up saying. Work that was handed in and never answered is
+/// deemed accepted, under a verb of its own, because "the window you were
+/// told about closed" and "nobody touched this for a month" are different
+/// things to have on the record.
+///
+/// No notice to the room. The expiry sweep announces because a task ending
+/// unfinished is news nobody asked for; an acceptance is the ordinary end of
+/// the work, and the event itself is what says so.
+///
+/// Returns whether the task was accepted.
+pub(crate) fn auto_accept_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
+    let verb = freeq_sdk::act_transitions::REVIEW_TIMEOUT_VERB;
+    match file_own_event(state, &task.kind, verb, &task.act_id, &[], &task.venue) {
+        Some((_, crate::db::ActWrite::Filed { .. })) => {
+            tracing::info!(
+                act_id = %task.act_id, venue = %task.venue, state = %task.state,
+                "Review window closed; the work is accepted"
+            );
+            true
+        }
+        other => {
+            tracing::warn!(
+                act_id = %task.act_id, venue = %task.venue,
+                outcome = ?other.map(|(_, w)| w),
+                "Review sweep could not file its own event"
+            );
+            false
+        }
+    }
+}
+
 /// A title is text its sender chose, and this notice is built as a wire line
 /// rather than through `Message`, which escapes tag values on the way out. So
 /// the bytes that end a line — and every other control byte — come out here,

--- a/freeq-server/src/connection/act.rs
+++ b/freeq-server/src/connection/act.rs
@@ -260,15 +260,20 @@ pub(crate) fn expire_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -
 /// told about closed" and "nobody touched this for a month" are different
 /// things to have on the record.
 ///
-/// No notice to the room. The expiry sweep announces because a task ending
-/// unfinished is news nobody asked for; an acceptance is the ordinary end of
-/// the work, and the event itself is what says so.
+/// Announced to the room the way an expiry is: the event is the record, and
+/// the notice is how the people in the conversation hear that the window
+/// closed and the work stands accepted.
 ///
 /// Returns whether the task was accepted.
 pub(crate) fn auto_accept_task(state: &Arc<SharedState>, task: &crate::db::ActTask) -> bool {
     let verb = freeq_sdk::act_transitions::REVIEW_TIMEOUT_VERB;
     match file_own_event(state, &task.kind, verb, &task.act_id, &[], &task.venue) {
         Some((_, crate::db::ActWrite::Filed { .. })) => {
+            let title = state
+                .with_db(|db| db.act_task_title(&task.act_id))
+                .flatten()
+                .unwrap_or_else(|| task.act_id.clone());
+            announce_auto_accept(state, task, &title);
             tracing::info!(
                 act_id = %task.act_id, venue = %task.venue, state = %task.state,
                 "Review window closed; the work is accepted"
@@ -329,6 +334,17 @@ fn venue_sessions(state: &Arc<SharedState>, venue: &str) -> Vec<String> {
 /// Tell the room — or the two people in the conversation — that a task ended
 /// without finishing.
 fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
+    announce_ending(state, task, title, "Task expired without completion");
+}
+
+/// Tell the room the review window closed and the work stands accepted —
+/// the same line the expiry sweep speaks, with a different ending.
+fn announce_auto_accept(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str) {
+    announce_ending(state, task, title, "Task accepted without review");
+}
+
+/// One notice, two endings: `what` is the sentence up to the colon.
+fn announce_ending(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &str, what: &str) {
     // A title of nothing but stripped bytes would announce a task by no name at
     // all, so it falls back the same way a missing title does.
     let cleaned = title_for_wire(title);
@@ -336,7 +352,7 @@ fn announce_expiry(state: &Arc<SharedState>, task: &crate::db::ActTask, title: &
         true => task.act_id.as_str(),
         false => cleaned.as_str(),
     };
-    let text = format!("Task expired without completion: {shown}");
+    let text = format!("{what}: {shown}");
     let sessions = venue_sessions(state, &task.venue);
     let target = match task.venue.starts_with("dm:") {
         true => None,

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -6636,21 +6636,77 @@ impl Db {
         rows.collect()
     }
 
-    /// Live tasks whose last movement is older than `cutoff` — the sweep's
-    /// candidates.
+    /// Live tasks whose last movement is older than `cutoff` and whose state
+    /// is one of `states` — the review sweep's candidates.
     ///
     /// `updated` is what is measured, so a task that anyone touched recently
-    /// is not abandoned however old its opener is.
-    pub fn act_tasks_idle_since(&self, cutoff: i64, limit: usize) -> SqlResult<Vec<ActTask>> {
-        let mut stmt = self.conn.prepare(
+    /// is not abandoned however old its opener is. On a review window that is
+    /// exactly the behaviour wanted: asking for changes moves the task, which
+    /// stops the clock, and the next submission starts a fresh one.
+    pub fn act_tasks_idle_in_states(
+        &self,
+        states: &[&str],
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        self.act_tasks_idle(states, true, cutoff, limit)
+    }
+
+    /// Live tasks idle since `cutoff` whose state is **not** one of `states` —
+    /// the expiry sweep's candidates.
+    ///
+    /// The complement of the query above, so the two clocks cannot both claim
+    /// a task. They pull in opposite directions: a review window favours the
+    /// worker and the idle limit is neutral, so a task sitting inside its
+    /// review window must not be expired out from under it by whichever of
+    /// the two numbers an operator happened to set lower.
+    pub fn act_tasks_idle_outside_states(
+        &self,
+        states: &[&str],
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        self.act_tasks_idle(states, false, cutoff, limit)
+    }
+
+    fn act_tasks_idle(
+        &self,
+        states: &[&str],
+        within: bool,
+        cutoff: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<ActTask>> {
+        // A state name is a rules-file constant, never anything a sender
+        // wrote, but the list is built at runtime — so the placeholders are
+        // counted rather than the values interpolated. Numbered rather than
+        // bare: SQLite numbers a bare `?` from the highest index it has seen,
+        // which would collide with the `?2` the LIMIT further down already
+        // holds.
+        let holes = (0..states.len())
+            .map(|i| format!("?{}", i + 3))
+            .collect::<Vec<_>>()
+            .join(",");
+        let test = match (states.is_empty(), within) {
+            // Nothing to be within, and everything is outside nothing.
+            (true, true) => "0".to_string(),
+            (true, false) => "1".to_string(),
+            (false, true) => format!("state IN ({holes})"),
+            (false, false) => format!("state NOT IN ({holes})"),
+        };
+        let mut stmt = self.conn.prepare(&format!(
             "SELECT act_id, kind, venue, origin, state, offerer, offeree, assignee,
                     caps, deadline, replaces, updated
                FROM act_actions
-              WHERE updated < ?1
+              WHERE updated < ?1 AND {test}
               ORDER BY updated
-              LIMIT ?2",
-        )?;
-        let rows = stmt.query_map(params![cutoff, limit as i64], |row| {
+              LIMIT ?2"
+        ))?;
+        let limit = limit as i64;
+        let mut args: Vec<&dyn rusqlite::ToSql> = vec![&cutoff, &limit];
+        for state in states {
+            args.push(state);
+        }
+        let rows = stmt.query_map(rusqlite::params_from_iter(args), |row| {
             Ok(ActTask {
                 act_id: row.get(0)?,
                 kind: row.get(1)?,

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3164,7 +3164,7 @@ mod tests {
         assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
     }
 
-    /// The loser bid and was not taken, so the work is not theirs to finish.
+    /// The loser bid and was not taken, so the work is not theirs to hand in.
     #[test]
     fn the_loser_of_a_bounty_cannot_finish_the_work() {
         let db = Db::open_memory().unwrap();
@@ -3174,7 +3174,7 @@ mod tests {
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 20);
 
         assert_eq!(
-            bounty_step(&db, "complete", MALLORY, "B1", "C1", None, "#ops", 21),
+            bounty_step(&db, "submit", MALLORY, "B1", "C1", None, "#ops", 21),
             ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender)
         );
         assert_eq!(
@@ -3183,10 +3183,165 @@ mod tests {
             "an awarded bounty takes no further bids"
         );
         assert!(matches!(
-            bounty_step(&db, "complete", SCHOLAR, "B1", "C2", None, "#ops", 23),
+            bounty_step(&db, "submit", SCHOLAR, "B1", "C2", None, "#ops", 23),
             ActWrite::Filed { .. }
         ));
-        assert_eq!(db.act_task("B1").unwrap(), None, "completed and gone");
+        assert!(matches!(
+            bounty_step(&db, "accept-work", ELIZA, "B1", "C3", None, "#ops", 24),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(db.act_task("B1").unwrap(), None, "accepted and gone");
+    }
+
+    /// The difference between this kind and a handoff: the worker says the
+    /// work is in, and the poster says whether it is done. A submission
+    /// parks the bounty in review and moves nothing else.
+    #[test]
+    fn a_bounty_ends_on_the_posters_word_and_not_the_workers() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 12);
+
+        assert_eq!(
+            bounty_step(&db, "submit", SCHOLAR, "B1", "S1", None, "#ops", 13),
+            ActWrite::Filed {
+                was: Some("assigned".into()),
+                state: "under_review".into()
+            }
+        );
+        assert_eq!(
+            bounty_step(&db, "accept-work", SCHOLAR, "B1", "A1", None, "#ops", 14),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender),
+            "the worker cannot sign off on their own work"
+        );
+        // Sent back, worked again, handed in again.
+        assert_eq!(
+            bounty_step(&db, "revise", ELIZA, "B1", "R1", None, "#ops", 15),
+            ActWrite::Filed {
+                was: Some("under_review".into()),
+                state: "assigned".into()
+            }
+        );
+        assert!(matches!(
+            bounty_step(&db, "submit", SCHOLAR, "B1", "S2", None, "#ops", 16),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            bounty_step(&db, "accept-work", ELIZA, "B1", "A2", None, "#ops", 17),
+            ActWrite::Filed {
+                was: Some("under_review".into()),
+                state: "accepted".into()
+            }
+        );
+        assert_eq!(
+            db.act_task("B1").unwrap(),
+            None,
+            "accepted is the end of it"
+        );
+    }
+
+    /// Once work is in, the poster's only moves are taking it and sending it
+    /// back. Cancelling delivered work is the cheap unfairness the table
+    /// closes: the row simply does not reach under_review.
+    #[test]
+    fn delivered_work_is_not_something_the_poster_can_cancel() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 12);
+        // Before it lands, cancelling is the poster's to do.
+        assert!(matches!(
+            bounty_step(&db, "cancel", ELIZA, "B1", "X0", None, "#ops", 13),
+            ActWrite::Filed { .. }
+        ));
+
+        bounty_offer(&db, "B2", "#ops", 20);
+        bounty_step(&db, "bid", SCHOLAR, "B2", "BID1", None, "#ops", 21);
+        bounty_step(&db, "award", ELIZA, "B2", "AW2", Some("BID1"), "#ops", 22);
+        bounty_step(&db, "submit", SCHOLAR, "B2", "S1", None, "#ops", 23);
+        assert_eq!(
+            bounty_step(&db, "cancel", ELIZA, "B2", "X1", None, "#ops", 24),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::IllegalStep)
+        );
+        assert_eq!(db.act_task("B2").unwrap().unwrap().state, "under_review");
+    }
+
+    /// The worker's exit, from either state they may hold the work in. It is
+    /// terminal, so re-running the job is a new bounty naming this one.
+    #[test]
+    fn the_worker_forfeits_work_they_hold_before_or_after_handing_it_in() {
+        let db = Db::open_memory().unwrap();
+        for (task, submit_first) in [("B1", false), ("B2", true)] {
+            bounty_offer(&db, task, "#ops", 10);
+            bounty_step(
+                &db,
+                "bid",
+                SCHOLAR,
+                task,
+                &format!("{task}BID"),
+                None,
+                "#ops",
+                11,
+            );
+            bounty_step(
+                &db,
+                "award",
+                ELIZA,
+                task,
+                &format!("{task}AW"),
+                Some(&format!("{task}BID")),
+                "#ops",
+                12,
+            );
+            if submit_first {
+                bounty_step(
+                    &db,
+                    "submit",
+                    SCHOLAR,
+                    task,
+                    &format!("{task}S"),
+                    None,
+                    "#ops",
+                    13,
+                );
+            }
+            assert_eq!(
+                bounty_step(
+                    &db,
+                    "forfeit",
+                    ELIZA,
+                    task,
+                    &format!("{task}FE"),
+                    None,
+                    "#ops",
+                    14
+                ),
+                ActWrite::Refused(freeq_sdk::act_transitions::Refusal::WrongSender),
+                "{task}: the poster does not forfeit the worker's work"
+            );
+            assert_eq!(
+                bounty_step(
+                    &db,
+                    "forfeit",
+                    SCHOLAR,
+                    task,
+                    &format!("{task}F"),
+                    None,
+                    "#ops",
+                    15
+                ),
+                ActWrite::Filed {
+                    was: Some(match submit_first {
+                        true => "under_review".to_string(),
+                        false => "assigned".to_string(),
+                    }),
+                    state: "forfeited".into()
+                },
+                "{task}"
+            );
+            assert_eq!(db.act_task(task).unwrap(), None, "{task}: terminal");
+        }
     }
 
     /// An award points at one event, and only a bid on this action answers.
@@ -3402,6 +3557,11 @@ mod tests {
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
         bounty_step(&db, "progress", MALLORY, "B1", "PR", None, "#ops", 54);
+        // …and into review and back out again, so the rebuild replays the
+        // states only a bounty has.
+        bounty_step(&db, "submit", MALLORY, "B1", "SB", None, "#ops", 55);
+        bounty_step(&db, "revise", ELIZA, "B1", "RV", None, "#ops", 56);
+        bounty_step(&db, "submit", MALLORY, "B1", "SB2", None, "#ops", 57);
 
         let venues = vec!["#ops".to_string(), "#other".to_string()];
         let mut live = db.act_tasks(&venues, None, None, None, 100).unwrap();

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -6635,7 +6635,7 @@ impl Db {
             was.unwrap_or_default(),
         ) {
             freeq_sdk::act_transitions::AssigneeSource::Actor => Some(ev.actor),
-            freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named,
+            freeq_sdk::act_transitions::AssigneeSource::AuthorOf(_) => named,
             freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                 view.fields.get(name).map(String::as_str)
             }
@@ -7168,7 +7168,7 @@ impl Db {
                         freeq_sdk::act_transitions::AssigneeSource::Actor => {
                             Some(row.actor.clone())
                         }
-                        freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named.clone(),
+                        freeq_sdk::act_transitions::AssigneeSource::AuthorOf(_) => named.clone(),
                         freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                             view.fields.get(name).cloned()
                         }

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3066,6 +3066,35 @@ mod tests {
         .unwrap()
     }
 
+    /// A bounty whose offer names how long it takes bids.
+    fn bounty_offer_with_cutoff(db: &Db, id: &str, venue: &str, cutoff: i64, ts: i64) -> ActWrite {
+        let cutoff = cutoff.to_string();
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "bounty"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-title", "index the archive"),
+                ("+freeq.at/act-bid-deadline", &cutoff),
+            ],
+            venue,
+            id,
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: id,
+            act_id: id,
+            opens: true,
+            venue,
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: ts,
+        })
+        .unwrap()
+    }
+
     /// A bounty step. `accepts` is the bid an award takes — the event the
     /// rules file points `assignee_from` at, whose author gets the work.
     fn bounty_step(
@@ -3344,6 +3373,92 @@ mod tests {
         }
     }
 
+    /// A bounty takes bids until its own cutoff, which is read back out of
+    /// the opener's bytes like every other tag the view has no column for.
+    #[test]
+    fn a_bounty_stops_taking_bids_at_the_cutoff_its_offer_named() {
+        let db = Db::open_memory().unwrap();
+        // 1788000000 unix seconds, as the fixtures use it, and the two ids
+        // that sit either side of the tolerance around it.
+        const TOO_LATE: &str = "01M16HSC58ACCEPTTOOLATE000";
+        const AT_EDGE: &str = "01M16HSB60ACCEPTATEDGE0000";
+        let canonical = act_doc(
+            &[
+                ("+freeq.at/act", "bounty"),
+                ("+freeq.at/act-verb", "offer"),
+                ("+freeq.at/from", ELIZA),
+                ("+freeq.at/act-title", "index the archive"),
+                ("+freeq.at/act-bid-deadline", "1788000000"),
+            ],
+            "#ops",
+            "B1",
+        );
+        db.apply_act_event(&ActEvent {
+            canonical: &canonical,
+            signature: Some("ed25519:kid:sig"),
+            event_id: "B1",
+            act_id: "B1",
+            opens: true,
+            venue: "#ops",
+            actor: ELIZA,
+            from_system: false,
+            origin: None,
+            timestamp: 10,
+        })
+        .unwrap();
+        assert_eq!(db.act_task_bid_deadline("B1").unwrap(), Some(1_788_000_000));
+
+        assert_eq!(
+            bounty_step(&db, "bid", SCHOLAR, "B1", TOO_LATE, None, "#ops", 11),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::DeadlinePassed)
+        );
+        assert!(matches!(
+            bounty_step(&db, "bid", SCHOLAR, "B1", AT_EDGE, None, "#ops", 12),
+            ActWrite::Filed { .. }
+        ));
+        // Bidding closing does not stop the poster picking: the award is
+        // bound by act-deadline, which this offer never named.
+        assert!(matches!(
+            bounty_step(
+                &db,
+                "award",
+                ELIZA,
+                "B1",
+                TOO_LATE,
+                Some(AT_EDGE),
+                "#ops",
+                13
+            ),
+            ActWrite::Filed { .. }
+        ));
+        assert_eq!(
+            db.act_task("B1").unwrap().unwrap().assignee.as_deref(),
+            Some(SCHOLAR)
+        );
+    }
+
+    /// A bounty whose offer named no cutoff takes bids for as long as it
+    /// stands.
+    #[test]
+    fn a_bounty_with_no_cutoff_takes_bids_whenever_they_arrive() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        assert_eq!(db.act_task_bid_deadline("B1").unwrap(), None);
+        assert!(matches!(
+            bounty_step(
+                &db,
+                "bid",
+                SCHOLAR,
+                "B1",
+                "01M16HSC58ACCEPTTOOLATE000",
+                None,
+                "#ops",
+                11
+            ),
+            ActWrite::Filed { .. }
+        ));
+    }
+
     /// An award points at one event, and only a bid on this action answers.
     /// The bounty's own opener is not one, whatever else it is.
     #[test]
@@ -3553,6 +3668,19 @@ mod tests {
         // sender, or the first bid, would disagree with the live row on
         // exactly that column — so there are two bids and the second is taken.
         bounty_offer(&db, "B1", "#ops", 50);
+        // …and one whose offer named a bid cutoff, which the rebuild has to
+        // read back out of the opener exactly as ingress did.
+        bounty_offer_with_cutoff(&db, "B3", "#ops", 1_788_000_000, 50);
+        bounty_step(
+            &db,
+            "bid",
+            SCHOLAR,
+            "B3",
+            "01M16HSB60ACCEPTATEDGE0000",
+            None,
+            "#ops",
+            51,
+        );
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 51);
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
         bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
@@ -3571,8 +3699,8 @@ mod tests {
 
         assert_eq!(
             live.len(),
-            5,
-            "the declined one left the view; its revival and the bounty did not"
+            6,
+            "the declined one left the view; its revival and the bounties did not"
         );
         assert_eq!(rebuilt, live);
     }
@@ -6401,6 +6529,11 @@ impl Db {
                 offeree: task.offeree.as_deref(),
                 assignee: task.assignee.as_deref(),
                 deadline: task.deadline,
+                // Read back out of the opener rather than carried in a
+                // column: it is one of the open set of act tags, and the view
+                // holds only what it needs to referee. The bytes are the
+                // record and they still have it.
+                bid_deadline: self.act_task_bid_deadline(ev.act_id)?,
             };
             match rules::check(&checked, &event, &sender) {
                 Ok(state) => {
@@ -6748,6 +6881,32 @@ impl Db {
         }))
     }
 
+    /// The bid cutoff an offer declared, read back out of the opener's bytes.
+    ///
+    /// The same reading `act_task_title` does, for the same reason: a second
+    /// deadline is one of the open set of act tags, and the view carries only
+    /// the columns it referees on. A value nobody can read as a number is a
+    /// cutoff this server cannot enforce, so it answers as absent — the tag
+    /// stays in the canonical either way.
+    pub fn act_task_bid_deadline(&self, act_id: &str) -> SqlResult<Option<i64>> {
+        let canonical: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT canonical FROM events WHERE kind = 'act' AND event_id = ?1",
+                params![act_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(canonical.and_then(|c| {
+            serde_json::from_str::<serde_json::Value>(&c)
+                .ok()?
+                .get("act-bid-deadline")
+                .and_then(|v| v.as_str())?
+                .parse::<i64>()
+                .ok()
+        }))
+    }
+
     /// Every venue that currently holds a live task.
     ///
     /// The listing endpoint runs each of these through the same authorization
@@ -6888,6 +7047,11 @@ impl Db {
         // replayed its bid is here.
         let mut bids: std::collections::BTreeMap<(String, String), String> =
             std::collections::BTreeMap::new();
+        // And each opener's bid cutoff, which ingress reads back out of the
+        // opener's bytes. Kept here rather than looked up, because the bytes
+        // in question are the ones this replay has already passed.
+        let mut bid_deadlines: std::collections::BTreeMap<String, i64> =
+            std::collections::BTreeMap::new();
         for row in rows {
             let Some(view) = crate::events::derive_act_view(&row.canonical) else {
                 continue;
@@ -6935,6 +7099,7 @@ impl Db {
                         offeree: task.offeree.as_deref(),
                         assignee: task.assignee.as_deref(),
                         deadline: task.deadline,
+                        bid_deadline: bid_deadlines.get(&act_id).copied(),
                     },
                     &freeq_sdk::act_transitions::Event {
                         verb: &view.verb,
@@ -6966,6 +7131,13 @@ impl Db {
                 continue;
             }
             if opens {
+                if let Some(cutoff) = view
+                    .fields
+                    .get("act-bid-deadline")
+                    .and_then(|v| v.parse::<i64>().ok())
+                {
+                    bid_deadlines.insert(act_id.clone(), cutoff);
+                }
                 live.insert(
                     act_id.clone(),
                     ActTask {

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -3066,15 +3066,15 @@ mod tests {
         .unwrap()
     }
 
-    /// A bounty step. `to` is the winner an award names — the field the rules
-    /// file points `assignee_from` at.
+    /// A bounty step. `accepts` is the bid an award takes — the event the
+    /// rules file points `assignee_from` at, whose author gets the work.
     fn bounty_step(
         db: &Db,
         verb: &str,
         actor: &str,
         task: &str,
         id: &str,
-        to: Option<&str>,
+        accepts: Option<&str>,
         venue: &str,
         ts: i64,
     ) -> ActWrite {
@@ -3084,8 +3084,8 @@ mod tests {
             ("+freeq.at/from", actor),
             ("+freeq.at/act-id", task),
         ];
-        if let Some(to) = to {
-            tags.push(("+freeq.at/act-to", to));
+        if let Some(accepts) = accepts {
+            tags.push(("+freeq.at/act-accepts", accepts));
         }
         let canonical = act_doc(&tags, venue, id);
         db.apply_act_event(&ActEvent {
@@ -3104,10 +3104,10 @@ mod tests {
     }
 
     /// The whole point of the second kind: bids pile up without moving
-    /// anything, and the award assigns the DID it names rather than the one
-    /// who sent it.
+    /// anything, and the award assigns whoever wrote the bid it names rather
+    /// than the one who sent it.
     #[test]
-    fn a_bounty_takes_bids_and_the_award_assigns_the_did_it_names() {
+    fn a_bounty_award_assigns_the_author_of_the_bid_it_names() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         for (i, bidder) in [SCHOLAR, MALLORY].iter().enumerate() {
@@ -3131,8 +3131,10 @@ mod tests {
         }
         assert_eq!(db.act_task_events("B1").unwrap().len(), 3, "all on file");
 
+        // The second bid, so the answer cannot come from "the first one" or
+        // from the sender.
         assert_eq!(
-            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20),
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 20),
             ActWrite::Filed {
                 was: Some("open".into()),
                 state: "assigned".into()
@@ -3141,35 +3143,35 @@ mod tests {
         let task = db.act_task("B1").unwrap().unwrap();
         assert_eq!(
             task.assignee.as_deref(),
-            Some(SCHOLAR),
-            "the winner the poster named, not the poster who named them"
+            Some(MALLORY),
+            "whoever wrote the bid the poster took, not the poster who took it"
         );
         assert_eq!(task.offerer, ELIZA);
     }
 
-    /// An award naming nobody assigns nobody, so the transition is illegal
+    /// An award naming no bid takes nothing, so the transition is illegal
     /// without the field its row requires.
     #[test]
-    fn an_award_that_names_no_winner_is_refused() {
+    fn an_award_that_names_no_bid_is_refused() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         assert_eq!(
             bounty_step(&db, "award", ELIZA, "B1", "AW", None, "#ops", 20),
             ActWrite::Refused(freeq_sdk::act_transitions::Refusal::MissingRequirement(
-                "act-to"
+                "act-accepts"
             ))
         );
         assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
     }
 
-    /// The loser bid and did not win, so the work is not theirs to finish.
+    /// The loser bid and was not taken, so the work is not theirs to finish.
     #[test]
     fn the_loser_of_a_bounty_cannot_finish_the_work() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
         bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 12);
-        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 20);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID0"), "#ops", 20);
 
         assert_eq!(
             bounty_step(&db, "complete", MALLORY, "B1", "C1", None, "#ops", 21),
@@ -3187,16 +3189,49 @@ mod tests {
         assert_eq!(db.act_task("B1").unwrap(), None, "completed and gone");
     }
 
-    /// The server never picks, and that cuts both ways: nothing here checks
-    /// that the awarded DID ever bid. The poster's signed choice is the
-    /// record.
+    /// An award points at one event, and only a bid on this action answers.
+    /// The bounty's own opener is not one, whatever else it is.
     #[test]
-    fn an_award_may_name_someone_who_never_bid() {
+    fn an_award_naming_the_bounty_itself_is_refused() {
         let db = Db::open_memory().unwrap();
         bounty_offer(&db, "B1", "#ops", 10);
         bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        assert_eq!(
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("B1"), "#ops", 20),
+            ActWrite::Refused(freeq_sdk::act_transitions::Refusal::AcceptsNotABid)
+        );
+        assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
+    }
+
+    /// A bid is a bid on one bounty. Naming another bounty's — or one nobody
+    /// ever filed — takes nothing here.
+    #[test]
+    fn an_award_naming_a_bid_on_another_bounty_is_refused() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_offer(&db, "B2", "#ops", 11);
+        bounty_step(&db, "bid", SCHOLAR, "B2", "ELSEWHERE", None, "#ops", 12);
+        for named in ["ELSEWHERE", "NEVERFILED"] {
+            assert_eq!(
+                bounty_step(&db, "award", ELIZA, "B1", "AW", Some(named), "#ops", 20),
+                ActWrite::Refused(freeq_sdk::act_transitions::Refusal::AcceptsNotABid),
+                "{named}"
+            );
+        }
+        assert_eq!(db.act_task("B1").unwrap().unwrap().state, "open");
+    }
+
+    /// The server still never picks: it checks that the named event is a bid
+    /// on this action and nothing further. A bid nobody would have taken is
+    /// still one the poster may take.
+    #[test]
+    fn the_poster_takes_whichever_bid_they_name() {
+        let db = Db::open_memory().unwrap();
+        bounty_offer(&db, "B1", "#ops", 10);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 11);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 12);
         assert!(matches!(
-            bounty_step(&db, "award", ELIZA, "B1", "AW", Some(MALLORY), "#ops", 20),
+            bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 20),
             ActWrite::Filed { .. }
         ));
         assert_eq!(
@@ -3357,12 +3392,16 @@ mod tests {
 
         offer(&db, "T4", "#ops", None, 40);
 
-        // A bounty too: its award assigns the DID it names rather than the
-        // sender, and a rebuild that read the sender would disagree with the
-        // live row on exactly that column.
+        // A bounty too: its award assigns the author of the bid it names
+        // rather than the sender, and that is a fact the rebuild has to look
+        // up in the log exactly as ingress did. A rebuild that read the
+        // sender, or the first bid, would disagree with the live row on
+        // exactly that column — so there are two bids and the second is taken.
         bounty_offer(&db, "B1", "#ops", 50);
-        bounty_step(&db, "bid", MALLORY, "B1", "BID0", None, "#ops", 51);
-        bounty_step(&db, "award", ELIZA, "B1", "AW", Some(SCHOLAR), "#ops", 52);
+        bounty_step(&db, "bid", SCHOLAR, "B1", "BID0", None, "#ops", 51);
+        bounty_step(&db, "bid", MALLORY, "B1", "BID1", None, "#ops", 52);
+        bounty_step(&db, "award", ELIZA, "B1", "AW", Some("BID1"), "#ops", 53);
+        bounty_step(&db, "progress", MALLORY, "B1", "PR", None, "#ops", 54);
 
         let venues = vec!["#ops".to_string(), "#other".to_string()];
         let mut live = db.act_tasks(&venues, None, None, None, 100).unwrap();
@@ -6144,6 +6183,9 @@ impl Db {
         // materialized by them too, rather than by whatever the sender wrote.
         let mut was: Option<String> = None;
         let mut kind = view.kind.clone();
+        // Who the step assigns, when the row takes its assignee from the bid
+        // the event names rather than from the actor.
+        let mut assignee_named: Option<String> = None;
         let landed = if ev.opens {
             // The opener's own id is the task's id. A second opener under the
             // same id is the log's duplicate case, handled by the write below.
@@ -6169,14 +6211,28 @@ impl Db {
                 return Ok(ActWrite::WrongVenue);
             }
             let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
+            // The bid an award takes, resolved before the checker is asked:
+            // the checker reads no log, so the lookup is ours. Only a bid
+            // filed against this same action answers, which is what makes an
+            // award naming the opener — or a bid on somebody else's bounty —
+            // take nothing.
+            let accepts = view.fields.get("act-accepts").map(String::as_str);
+            let bid_author = match accepts {
+                Some(named) => self.act_bid_author(ev.act_id, named)?,
+                None => None,
+            };
             let event = rules::Event {
                 verb: &view.verb,
                 msgid: ev.event_id,
+                accepts,
                 fields: &present,
             };
             let sender = rules::Sender {
                 did: ev.actor,
                 is_system: ev.from_system,
+                accepted_bid: bid_author
+                    .as_deref()
+                    .map(|author| rules::AcceptedBid { author }),
             };
             let checked = rules::Task {
                 kind: &task.kind,
@@ -6190,6 +6246,7 @@ impl Db {
                 Ok(state) => {
                     was = Some(task.state.clone());
                     kind = task.kind.clone();
+                    assignee_named = bid_author;
                     state.to_string()
                 }
                 Err(refusal) => return Ok(ActWrite::Refused(refusal)),
@@ -6208,7 +6265,14 @@ impl Db {
         if !self.insert_event(&record)? {
             return Ok(ActWrite::Duplicate);
         }
-        self.materialize_act(ev, &view, &kind, was.as_deref(), &landed)?;
+        self.materialize_act(
+            ev,
+            &view,
+            &kind,
+            was.as_deref(),
+            &landed,
+            assignee_named.as_deref(),
+        )?;
         tx.commit()?;
         Ok(ActWrite::Filed { was, state: landed })
     }
@@ -6221,7 +6285,9 @@ impl Db {
     /// the log holds the history.
     ///
     /// `was` is the state the task came from — what the rules file is asked
-    /// about when it says where a transition's assignee comes from.
+    /// about when it says where a transition's assignee comes from, and
+    /// `named` is who the caller resolved the event's `act-accepts` to when
+    /// the row takes its assignee from a bid.
     fn materialize_act(
         &self,
         ev: &ActEvent<'_>,
@@ -6229,6 +6295,7 @@ impl Db {
         kind: &str,
         was: Option<&str>,
         landed: &str,
+        named: Option<&str>,
     ) -> SqlResult<()> {
         if freeq_sdk::act_transitions::is_terminal(kind, landed) {
             self.conn.execute(
@@ -6264,17 +6331,18 @@ impl Db {
         // work it is reporting on.
         //
         // Who it names is data. Accepting and claiming make the actor the
-        // assignee; a bounty's award names a winner in `act-to`, because the
-        // poster picks rather than becomes. A row whose field is absent names
-        // nobody and leaves the work unassigned — fail closed, though a
-        // `requires` on the same row is what actually keeps that from
-        // happening.
+        // assignee; a bounty's award takes the bid it names, and the work goes
+        // to whoever wrote that bid, because the poster picks rather than
+        // becomes. A row whose source resolves to nobody leaves the work
+        // unassigned — fail closed, though the checker refusing the step is
+        // what actually keeps that from happening.
         let assignee: Option<&str> = match freeq_sdk::act_transitions::assignee_source(
             kind,
             &view.verb,
             was.unwrap_or_default(),
         ) {
             freeq_sdk::act_transitions::AssigneeSource::Actor => Some(ev.actor),
+            freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named,
             freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                 view.fields.get(name).map(String::as_str)
             }
@@ -6517,6 +6585,28 @@ impl Db {
         Ok(events)
     }
 
+    /// Who wrote the bid `event_id` names on this action, or `None` when it
+    /// names something else.
+    ///
+    /// What an award's `act-accepts` resolves to, and the reason the checker
+    /// can stay a function of its arguments: the log answers here, once, and
+    /// hands the checker a fact. The search runs over the action's own events,
+    /// so an id filed against another action answers `None` for the same
+    /// reason a non-bid does — this award has nothing to take.
+    fn act_bid_author(&self, act_id: &str, event_id: &str) -> SqlResult<Option<String>> {
+        Ok(self
+            .act_task_events(act_id)?
+            .into_iter()
+            .find(|e| e.event_id == event_id)
+            .and_then(|e| {
+                let view = crate::events::derive_act_view(&e.canonical)?;
+                match view.verb == freeq_sdk::act_transitions::BID_VERB {
+                    true => e.actor_did,
+                    false => None,
+                }
+            }))
+    }
+
     /// Every stored event of one task, oldest first: the opener, then each
     /// follow-up. This is the history a reader gets, and it outlives the view.
     pub fn act_task_events(&self, act_id: &str) -> SqlResult<Vec<ActLoggedEvent>> {
@@ -6575,6 +6665,13 @@ impl Db {
 
         let mut live: std::collections::BTreeMap<String, ActTask> =
             std::collections::BTreeMap::new();
+        // The bids replayed so far, by the action they were filed against and
+        // their own id. This is the rebuild's copy of the lookup ingress does
+        // against the log: events come back in id order and a bid is always
+        // filed before the award that names it, so by the time an award is
+        // replayed its bid is here.
+        let mut bids: std::collections::BTreeMap<(String, String), String> =
+            std::collections::BTreeMap::new();
         for row in rows {
             let Some(view) = crate::events::derive_act_view(&row.canonical) else {
                 continue;
@@ -6590,6 +6687,9 @@ impl Db {
             let opens = row.subject.is_none();
             let mut was: Option<String> = None;
             let mut kind = view.kind.clone();
+            // The same fact ingress resolves before it asks the checker: who
+            // wrote the bid this event names, when it names one.
+            let mut named: Option<String> = None;
             let landed = if opens {
                 match freeq_sdk::act_transitions::check_open(
                     &view.kind,
@@ -6607,6 +6707,10 @@ impl Db {
                 was = Some(task.state.clone());
                 kind = task.kind.clone();
                 let present: Vec<&str> = view.fields.keys().map(String::as_str).collect();
+                let accepts = view.fields.get("act-accepts").map(String::as_str);
+                named = accepts
+                    .and_then(|id| bids.get(&(act_id.clone(), id.to_string())))
+                    .cloned();
                 match freeq_sdk::act_transitions::check(
                     &freeq_sdk::act_transitions::Task {
                         kind: &task.kind,
@@ -6619,6 +6723,7 @@ impl Db {
                     &freeq_sdk::act_transitions::Event {
                         verb: &view.verb,
                         msgid: &row.event_id,
+                        accepts,
                         fields: &present,
                     },
                     &freeq_sdk::act_transitions::Sender {
@@ -6627,12 +6732,19 @@ impl Db {
                         // it accepted this one — including an expiry it signed
                         // itself, whose sender check already passed.
                         is_system: true,
+                        accepted_bid: named
+                            .as_deref()
+                            .map(|author| freeq_sdk::act_transitions::AcceptedBid { author }),
                     },
                 ) {
                     Ok(s) => s.to_string(),
                     Err(_) => continue,
                 }
             };
+            // Filed, so it is one of the action's bids from here on.
+            if view.verb == freeq_sdk::act_transitions::BID_VERB {
+                bids.insert((act_id.clone(), row.event_id.clone()), row.actor.clone());
+            }
             if freeq_sdk::act_transitions::is_terminal(&kind, &landed) {
                 live.remove(&act_id);
                 continue;
@@ -6668,6 +6780,7 @@ impl Db {
                         freeq_sdk::act_transitions::AssigneeSource::Actor => {
                             Some(row.actor.clone())
                         }
+                        freeq_sdk::act_transitions::AssigneeSource::BidAuthor => named.clone(),
                         freeq_sdk::act_transitions::AssigneeSource::Field(name) => {
                             view.fields.get(name).cloned()
                         }

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -2149,6 +2149,7 @@ impl Server {
         }
 
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         // Heartbeat expiry: check agent liveness every 15 seconds.
         // Agents that miss their TTL transition to degraded, then offline, then disconnect.
@@ -2487,6 +2488,7 @@ impl Server {
         // is consistent.
         spawn_phantom_sweeper(Arc::clone(&state));
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         let handle = tokio::spawn(async move {
             loop {
@@ -2534,6 +2536,7 @@ impl Server {
         // Phantom-session sweeper (defense-in-depth).
         spawn_phantom_sweeper(Arc::clone(&state));
         spawn_act_expiry_sweep(Arc::clone(&state), self.config.act_expiry_secs);
+        spawn_act_review_sweep(Arc::clone(&state), self.config.act_review_secs);
 
         let web_state = Arc::clone(&state);
         let router = crate::web::router(web_state);
@@ -2699,10 +2702,47 @@ fn spawn_act_expiry_sweep(state: Arc<SharedState>, limit_secs: u64) {
             // Bounded per pass: a server that was down for a month should not
             // try to expire everything in one breath.
             let stale = state
-                .with_db(|db| db.act_tasks_idle_since(cutoff, 100))
+                .with_db(|db| {
+                    db.act_tasks_idle_outside_states(
+                        &freeq_sdk::act_transitions::review_timeout_states(),
+                        cutoff,
+                        100,
+                    )
+                })
                 .unwrap_or_default();
             for task in &stale {
                 crate::connection::act::expire_task(&state, task);
+            }
+        }
+    });
+}
+
+/// Close review windows: work that was handed in and left unanswered for
+/// longer than the limit is deemed accepted, under the home's own signature.
+///
+/// A second clock rather than a case of the first, because it does the
+/// opposite job. The abandonment sweep is neutral and catches work nobody is
+/// doing; this one favours the worker and catches a poster who took delivery
+/// and then went quiet — and the two would otherwise race, so the states this
+/// one owns are the states the other skips. `0` disables it.
+fn spawn_act_review_sweep(state: Arc<SharedState>, limit_secs: u64) {
+    let states = freeq_sdk::act_transitions::review_timeout_states();
+    if limit_secs == 0 || states.is_empty() {
+        return;
+    }
+    let limit = limit_secs as i64;
+    tokio::spawn(async move {
+        let every = (limit_secs / 2).clamp(1, 60);
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(every));
+        interval.tick().await; // skip first tick
+        loop {
+            interval.tick().await;
+            let cutoff = chrono::Utc::now().timestamp() - limit;
+            let waiting = state
+                .with_db(|db| db.act_tasks_idle_in_states(&states, cutoff, 100))
+                .unwrap_or_default();
+            for task in &waiting {
+                crate::connection::act::auto_accept_task(&state, task);
             }
         }
     });

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -37,12 +37,22 @@ fn resolver_with(entries: Vec<(&str, &PrivateKey)>) -> DidResolver {
 }
 
 async fn start(resolver: DidResolver) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
-    start_with_expiry(resolver, 604_800).await
+    start_with_clocks(resolver, 604_800, 1_209_600).await
 }
 
 async fn start_with_expiry(
     resolver: DidResolver,
     act_expiry_secs: u64,
+) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
+    start_with_clocks(resolver, act_expiry_secs, 1_209_600).await
+}
+
+/// The two sweeps' limits: how long unfinished work may sit before it is
+/// expired, and how long submitted work may wait on its poster.
+async fn start_with_clocks(
+    resolver: DidResolver,
+    act_expiry_secs: u64,
+    act_review_secs: u64,
 ) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let db_path = tmp.path().to_str().unwrap().to_string();
@@ -53,6 +63,7 @@ async fn start_with_expiry(
         challenge_timeout_secs: 60,
         db_path: Some(db_path),
         act_expiry_secs,
+        act_review_secs,
         ..Default::default()
     };
     freeq_server::server::Server::with_resolver(config, resolver)
@@ -1137,6 +1148,21 @@ fn bounty_line(
     signed_line(&tags, channel, id, key)
 }
 
+/// Every task event this server serves back for a room, as wire lines.
+///
+/// What a sweep's own event is read back through: the server files those and
+/// does not put them on the wire live, so history is where they surface.
+fn act_events_in_history(c: &mut C, channel: &str) -> Vec<String> {
+    c.tx(&format!("CHATHISTORY LATEST {channel} * 50"));
+    let mut lines = Vec::new();
+    while let Some(line) = c.maybe(|_| true, 900) {
+        if line.contains("+freeq.at/act-verb=") {
+            lines.push(line);
+        }
+    }
+    lines
+}
+
 /// Open a bounty and return its id.
 fn open_bounty(c: &mut C, signing: &SigningKey, channel: &str) -> String {
     let id = fresh_id();
@@ -2096,6 +2122,143 @@ async fn chathistory_carries_a_task_posted_after_the_last_message() {
     .await;
 }
 
+// ── the review window ───────────────────────────────────────────────────────
+
+/// Work handed in and left unanswered is deemed accepted when the window
+/// closes — under the home's own signature, and under a verb of its own so the
+/// log says which of the two clocks fired.
+#[tokio::test]
+async fn work_left_unanswered_past_the_review_window_is_accepted() {
+    let ka = key();
+    let kb = key();
+    // The review window is a second; the abandonment limit is a week away, so
+    // whatever happens here is the review sweep's doing.
+    let (addr, _h) = start_with_clocks(
+        resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]),
+        604_800,
+        1,
+    )
+    .await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        // Alice says nothing at all. The sweep runs on its own clock, and
+        // files rather than announces — like the expiry sweep's own event, it
+        // is read back out of the log.
+        std::thread::sleep(Duration::from_secs(6));
+        let events = act_events_in_history(&mut b, "#ops");
+        let closed = events
+            .iter()
+            .find(|l| l.contains("+freeq.at/act-verb=auto-accept"))
+            .unwrap_or_else(|| panic!("the review window closes on its own: {events:?}"));
+        assert!(
+            closed.contains(&format!("+freeq.at/act-id={bounty}")),
+            "on the bounty that was waiting: {closed}"
+        );
+        assert!(
+            closed.contains("+freeq.at/from=did:web:test-act"),
+            "signed under the home's own identity: {closed}"
+        );
+        assert!(closed.contains("+freeq.at/sig="), "{closed}");
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=expire")),
+            "and not as an expiry, which would read as the worker dropping it"
+        );
+
+        // Terminal: the bounty takes nothing further.
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "TERMINAL_TASK");
+    })
+    .await;
+}
+
+/// The clock is per-submission: asking for changes is the poster meeting the
+/// window, and it moves the task, so the window starts again from there.
+#[tokio::test]
+async fn asking_for_changes_stops_the_review_clock() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start_with_clocks(
+        resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]),
+        604_800,
+        4,
+    )
+    .await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        let sent_back = fresh_id();
+        a.tx(&bounty_line(
+            "revise",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &sent_back,
+            &alice_key,
+        ));
+        b.rx(|l| l.contains(&sent_back), "the work is sent back");
+
+        // The task is assigned again, which is not a state this clock owns —
+        // so nothing closes it, however many passes the sweep makes.
+        std::thread::sleep(Duration::from_secs(12));
+        let events = act_events_in_history(&mut b, "#ops");
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=auto-accept")),
+            "a poster who answered is never auto-accepted: {events:?}"
+        );
+    })
+    .await;
+}
+
 // ── expiry ──────────────────────────────────────────────────────────────────
 
 /// Everything at once: the sweep signs its own event under the server's
@@ -2126,6 +2289,47 @@ async fn an_abandoned_task_expires_and_the_room_is_told() {
         assert!(
             notice.ends_with("Task expired without completion: review-the-deploy"),
             "the approved sentence, with the offer's own title: {notice}"
+        );
+    })
+    .await;
+}
+
+/// The neutral clock still catches work somebody took and walked away from.
+/// The two sweeps own different states, so a bounty that was never handed in
+/// is expired rather than accepted.
+#[tokio::test]
+async fn assigned_work_nobody_touches_still_expires() {
+    let ka = key();
+    let kb = key();
+    // Both clocks short, and the review one shorter — so if the review sweep
+    // reached beyond its own states this would come back as an acceptance.
+    let (addr, _h) =
+        start_with_clocks(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)]), 2, 1).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        // Bob never hands anything in.
+        b.maybe(
+            |l| l.contains("NOTICE") && l.contains("Task expired"),
+            90_000,
+        )
+        .expect("the abandonment sweep reaches it");
+        let events = act_events_in_history(&mut b, "#ops");
+        assert!(
+            events.iter().any(|l| l.contains("act-verb=expire")),
+            "expired, because nothing was ever delivered: {events:?}"
+        );
+        assert!(
+            !events.iter().any(|l| l.contains("act-verb=auto-accept")),
+            "and the review clock did not reach past the states it owns: {events:?}"
         );
     })
     .await;

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1112,12 +1112,12 @@ async fn replay_carries_the_receipts_to_capability_holders_only() {
 
 // ── bounty: the second kind, and no code of its own ─────────────────────────
 
-/// A bounty step, signed. `to` is the winner an award names.
+/// A bounty step, signed. `accepts` is the bid an award takes.
 fn bounty_line(
     verb: &str,
     from: &str,
     task: Option<&str>,
-    to: Option<&str>,
+    accepts: Option<&str>,
     channel: &str,
     id: &str,
     key: &SigningKey,
@@ -1131,17 +1131,29 @@ fn bounty_line(
         Some(t) => tags.push(("+freeq.at/act-id".into(), t.into())),
         None => tags.push(("+freeq.at/act-title".into(), "index-the-archive".into())),
     }
-    if let Some(to) = to {
-        tags.push(("+freeq.at/act-to".into(), to.into()));
+    if let Some(accepts) = accepts {
+        tags.push(("+freeq.at/act-accepts".into(), accepts.into()));
     }
     signed_line(&tags, channel, id, key)
 }
 
+/// A bounty opener carrying a recipient, which is the one thing it cannot do.
+fn directed_bounty_line(from: &str, channel: &str, id: &str, key: &SigningKey) -> String {
+    let tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "bounty".into()),
+        ("+freeq.at/act-verb".into(), "offer".into()),
+        ("+freeq.at/from".into(), from.into()),
+        ("+freeq.at/act-title".into(), "index-the-archive".into()),
+        ("+freeq.at/act-to".into(), DID_BOB.into()),
+    ];
+    signed_line(&tags, channel, id, key)
+}
+
 /// The test of generality: a second kind that needed a table row and no code.
-/// Bids pile up without moving anything, the poster names a winner, and the
-/// winner — not the poster who named them — is the one who can finish it.
+/// Bids pile up without moving anything, the poster takes one of them, and its
+/// author — not the poster who took it — is the one who can finish the work.
 #[tokio::test]
-async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
+async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
     let ka = key();
     let kb = key();
     let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
@@ -1162,6 +1174,7 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
         a.rx(|l| l.contains(&bounty), "the bounty opens");
 
         // Two bids, from two agents, neither of which moves it.
+        let mut bids = Vec::new();
         for (did, k) in [(DID_ALICE, &alice_key), (DID_BOB, &bob_key)] {
             let bid = fresh_id();
             let line = bounty_line("bid", did, Some(&bounty), None, "#ops", &bid, k);
@@ -1170,16 +1183,17 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
                 false => b.tx(&line),
             }
             b.rx(|l| l.contains(&bid), "the bid is accepted");
+            bids.push(bid);
         }
 
-        // The poster picks. Bob is the winner; alice named him and did not
-        // become him.
+        // The poster takes bob's bid — the second one, so the assignee cannot
+        // have come from the sender or from whichever bid arrived first.
         let award = fresh_id();
         a.tx(&bounty_line(
             "award",
             DID_ALICE,
             Some(&bounty),
-            Some(DID_BOB),
+            Some(&bids[1]),
             "#ops",
             &award,
             &alice_key,
@@ -1214,11 +1228,11 @@ async fn a_bounty_takes_bids_and_the_poster_awards_the_winner() {
     .await;
 }
 
-/// An award naming nobody assigns nobody, so the row's `requires` refuses it —
+/// An award naming no bid takes nothing, so the row's `requires` refuses it —
 /// and the sentence names the field rather than the verb, because which field
 /// a step needs is the rules file's to say.
 #[tokio::test]
-async fn an_award_that_names_no_winner_is_refused() {
+async fn an_award_that_names_no_bid_is_refused() {
     let k = key();
     let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
     run(addr, move |addr| {
@@ -1245,9 +1259,75 @@ async fn an_award_that_names_no_winner_is_refused() {
         let line = a.fail();
         assert!(line.contains(" MISSING_REQUIREMENT "), "{line}");
         assert!(
-            line.ends_with("That step must carry act-to"),
+            line.ends_with("That step must carry act-accepts"),
             "the approved sentence names the missing field: {line}"
         );
+    })
+    .await;
+}
+
+/// An award points at one event, and only a bid on the same action answers.
+/// The bounty's own opener is not one, and neither is an id nobody filed.
+#[tokio::test]
+async fn an_award_naming_a_non_bid_is_refused() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+
+        let bounty = fresh_id();
+        a.tx(&bounty_line(
+            "offer", DID_ALICE, None, None, "#ops", &bounty, &signing,
+        ));
+        a.rx(|l| l.contains(&bounty), "the bounty opens");
+
+        let bid = fresh_id();
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &bid,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&bid), "the bid is accepted");
+
+        // The opener, and then an id this server never filed at all.
+        for named in [bounty.clone(), fresh_id()] {
+            a.tx(&bounty_line(
+                "award",
+                DID_ALICE,
+                Some(&bounty),
+                Some(&named),
+                "#ops",
+                &fresh_id(),
+                &signing,
+            ));
+            let line = a.fail();
+            assert!(line.contains(" ACCEPTS_NOT_A_BID "), "{named}: {line}");
+            assert!(
+                line.ends_with("The award names an event that is not a bid on this action"),
+                "{line}"
+            );
+        }
+
+        // …and the bid itself still works, so the refusals were about what
+        // was named and not about the award.
+        let done = fresh_id();
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&bounty),
+            Some(&bid),
+            "#ops",
+            &done,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&done), "the award is accepted");
     })
     .await;
 }
@@ -1263,11 +1343,8 @@ async fn a_bounty_opened_to_one_recipient_is_refused() {
         let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
         a.msgsig(&signing);
         a.join("#ops");
-        a.tx(&bounty_line(
-            "offer",
+        a.tx(&directed_bounty_line(
             DID_ALICE,
-            None,
-            Some(DID_BOB),
             "#ops",
             &fresh_id(),
             &signing,

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -2244,10 +2244,18 @@ async fn work_left_unanswered_past_the_review_window_is_accepted() {
         ));
         b.rx(|l| l.contains(&handed_in), "the work is handed in");
 
-        // Alice says nothing at all. The sweep runs on its own clock, and
-        // files rather than announces — like the expiry sweep's own event, it
-        // is read back out of the log.
-        std::thread::sleep(Duration::from_secs(6));
+        // Alice says nothing at all. The sweep runs on its own clock, and the
+        // room hears the window close the way it hears an expiry.
+        let notice = b
+            .maybe(
+                |l| l.contains("NOTICE") && l.contains("Task accepted"),
+                8_000,
+            )
+            .expect("the room hears the review window close");
+        assert!(
+            notice.ends_with("Task accepted without review: index-the-archive"),
+            "the approved sentence, with the bounty's own title: {notice}"
+        );
         let events = act_events_in_history(&mut b, "#ops");
         let closed = events
             .iter()

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1137,6 +1137,51 @@ fn bounty_line(
     signed_line(&tags, channel, id, key)
 }
 
+/// Open a bounty and return its id.
+fn open_bounty(c: &mut C, signing: &SigningKey, channel: &str) -> String {
+    let id = fresh_id();
+    c.tx(&bounty_line(
+        "offer", DID_ALICE, None, None, channel, &id, signing,
+    ));
+    c.rx(|l| l.contains(&id), "the bounty opens");
+    id
+}
+
+/// Open a bounty, take bob's bid on it, and return its id — the setup every
+/// test of the review half starts from.
+fn award_to_bob(
+    a: &mut C,
+    b: &mut C,
+    alice_key: &SigningKey,
+    bob_key: &SigningKey,
+    channel: &str,
+) -> String {
+    let bounty = open_bounty(a, alice_key, channel);
+    let bid = fresh_id();
+    b.tx(&bounty_line(
+        "bid",
+        DID_BOB,
+        Some(&bounty),
+        None,
+        channel,
+        &bid,
+        bob_key,
+    ));
+    b.rx(|l| l.contains(&bid), "the bid is accepted");
+    let award = fresh_id();
+    a.tx(&bounty_line(
+        "award",
+        DID_ALICE,
+        Some(&bounty),
+        Some(&bid),
+        channel,
+        &award,
+        alice_key,
+    ));
+    b.rx(|l| l.contains(&award), "the award is accepted");
+    bounty
+}
+
 /// A bounty opener carrying a recipient, which is the one thing it cannot do.
 fn directed_bounty_line(from: &str, channel: &str, id: &str, key: &SigningKey) -> String {
     let tags: Vec<(String, String)> = vec![
@@ -1200,9 +1245,9 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
         ));
         b.rx(|l| l.contains(&award), "the award is accepted");
 
-        // The loser cannot finish work that is not theirs…
+        // The loser cannot hand in work that is not theirs…
         a.tx(&bounty_line(
-            "complete",
+            "submit",
             DID_ALICE,
             Some(&bounty),
             None,
@@ -1215,7 +1260,7 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
         // …and the winner can.
         let done = fresh_id();
         b.tx(&bounty_line(
-            "complete",
+            "submit",
             DID_BOB,
             Some(&bounty),
             None,
@@ -1223,7 +1268,207 @@ async fn a_bounty_awards_the_bid_it_names_and_the_bidder_becomes_assignee() {
             &done,
             &bob_key,
         ));
-        b.rx(|l| l.contains(&done), "the winner finishes it");
+        b.rx(|l| l.contains(&done), "the winner hands it in");
+    })
+    .await;
+}
+
+/// The bounty's own half of the lifecycle, on the wire: the worker hands the
+/// work in, the poster sends it back once, the worker hands it in again, and
+/// the poster takes it. The poster's word ends it, not the worker's — which is
+/// the whole difference from a handoff.
+#[tokio::test]
+async fn submitted_work_is_sent_back_once_and_then_accepted_by_the_poster() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        for verb in ["revise", "accept-work"] {
+            let handed_in = fresh_id();
+            b.tx(&bounty_line(
+                "submit",
+                DID_BOB,
+                Some(&bounty),
+                None,
+                "#ops",
+                &handed_in,
+                &bob_key,
+            ));
+            b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+            let answer = fresh_id();
+            a.tx(&bounty_line(
+                verb,
+                DID_ALICE,
+                Some(&bounty),
+                None,
+                "#ops",
+                &answer,
+                &alice_key,
+            ));
+            b.rx(|l| l.contains(&answer), verb);
+        }
+
+        // Accepted is terminal: there is nothing further to hand in.
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "TERMINAL_TASK");
+    })
+    .await;
+}
+
+/// Once the work is in, the poster's only moves are taking it and sending it
+/// back — and signing off on the work is not the worker's to do.
+#[tokio::test]
+async fn delivered_work_is_neither_withdrawn_nor_self_accepted() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        let handed_in = fresh_id();
+        b.tx(&bounty_line(
+            "submit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &handed_in,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&handed_in), "the work is handed in");
+
+        a.tx(&bounty_line(
+            "cancel",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "ILLEGAL_STEP");
+
+        b.tx(&bounty_line(
+            "accept-work",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &bob_key,
+        ));
+        assert_eq!(b.fail_code(), "WRONG_SENDER");
+    })
+    .await;
+}
+
+/// A bounty is not a handoff, and its worker has no verb that ends it. The
+/// two that would are ones the kind's table simply does not list.
+#[tokio::test]
+async fn a_bounty_has_no_complete_and_no_fail() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+        let bounty = open_bounty(&mut a, &signing, "#ops");
+        for verb in ["complete", "fail"] {
+            a.tx(&bounty_line(
+                verb,
+                DID_ALICE,
+                Some(&bounty),
+                None,
+                "#ops",
+                &fresh_id(),
+                &signing,
+            ));
+            assert_eq!(a.fail_code(), "UNKNOWN_VERB", "{verb}");
+        }
+    })
+    .await;
+}
+
+/// The worker's exit, from either state they may hold the work in.
+#[tokio::test]
+async fn the_worker_forfeits_the_work_and_the_bounty_is_finished() {
+    let ka = key();
+    let kb = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &ka), (DID_BOB, &kb)])).await;
+    run(addr, move |addr| {
+        let alice_key = SigningKey::from_bytes(&[7u8; 32]);
+        let bob_key = SigningKey::from_bytes(&[8u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, ka, ACT_CAPS);
+        a.msgsig(&alice_key);
+        a.join("#ops");
+        let mut b = C::authenticated(addr, "bob", DID_BOB, kb, ACT_CAPS);
+        b.msgsig(&bob_key);
+        b.join("#ops");
+
+        let bounty = award_to_bob(&mut a, &mut b, &alice_key, &bob_key, "#ops");
+
+        // Not the poster's to give up on the worker's behalf.
+        a.tx(&bounty_line(
+            "forfeit",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "WRONG_SENDER");
+
+        let gone = fresh_id();
+        b.tx(&bounty_line(
+            "forfeit",
+            DID_BOB,
+            Some(&bounty),
+            None,
+            "#ops",
+            &gone,
+            &bob_key,
+        ));
+        b.rx(|l| l.contains(&gone), "the worker walks away");
+
+        a.tx(&bounty_line(
+            "revise",
+            DID_ALICE,
+            Some(&bounty),
+            None,
+            "#ops",
+            &fresh_id(),
+            &alice_key,
+        ));
+        assert_eq!(a.fail_code(), "TERMINAL_TASK");
     })
     .await;
 }

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1625,6 +1625,88 @@ async fn a_bounty_opened_to_one_recipient_is_refused() {
     .await;
 }
 
+/// A bounty takes bids until the cutoff its offer named, which the server
+/// reads back out of the opener rather than out of a column. The offer's own
+/// deadline is a different time and bounds a different move.
+#[tokio::test]
+async fn a_bounty_stops_taking_bids_at_the_cutoff_its_offer_named() {
+    let k = key();
+    let (addr, _h) = start(resolver_with(vec![(DID_ALICE, &k)])).await;
+    run(addr, move |addr| {
+        // Relative to now, because the ids these bids are minted with have to
+        // be near this server's clock to be adopted at all.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let mut a = C::authenticated(addr, "alice", DID_ALICE, k, ACT_CAPS);
+        a.msgsig(&signing);
+        a.join("#ops");
+
+        // A bounty whose bidding closed an hour ago…
+        let closed = open_priced_bounty(&mut a, &signing, "#ops", now - 3_600);
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&closed),
+            None,
+            "#ops",
+            &fresh_id(),
+            &signing,
+        ));
+        assert_eq!(a.fail_code(), "DEADLINE_PASSED");
+
+        // …and one that is still taking them. Sent after a pause, because the
+        // act flood counter is per connection and this is the sixth event.
+        std::thread::sleep(Duration::from_millis(2_500));
+        let open = open_priced_bounty(&mut a, &signing, "#ops", now + 3_600);
+        let bid = fresh_id();
+        a.tx(&bounty_line(
+            "bid",
+            DID_ALICE,
+            Some(&open),
+            None,
+            "#ops",
+            &bid,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&bid), "a bid inside the cutoff");
+
+        // The award is bound by act-deadline, which neither offer named, so
+        // bidding closing does not stop the poster picking.
+        let award = fresh_id();
+        a.tx(&bounty_line(
+            "award",
+            DID_ALICE,
+            Some(&open),
+            Some(&bid),
+            "#ops",
+            &award,
+            &signing,
+        ));
+        a.rx(|l| l.contains(&award), "the award is accepted");
+    })
+    .await;
+}
+
+/// A bounty naming what it pays and how long it takes bids. The price is
+/// carried and never read; the cutoff is a time the referee compares.
+fn open_priced_bounty(c: &mut C, signing: &SigningKey, channel: &str, cutoff: i64) -> String {
+    let id = fresh_id();
+    let tags: Vec<(String, String)> = vec![
+        ("+freeq.at/act".into(), "bounty".into()),
+        ("+freeq.at/act-verb".into(), "offer".into()),
+        ("+freeq.at/from".into(), DID_ALICE.into()),
+        ("+freeq.at/act-title".into(), "index-the-archive".into()),
+        ("+freeq.at/act-bid-deadline".into(), cutoff.to_string()),
+        ("+freeq.at/act-price".into(), "250-USD".into()),
+    ];
+    c.tx(&signed_line(&tags, channel, &id, signing));
+    c.rx(|l| l.contains(&id), "the bounty opens");
+    id
+}
+
 // ── the revival relation ────────────────────────────────────────────────────
 
 /// An opener that names the finished action it revives.

--- a/freeq-server/tests/act_gate.rs
+++ b/freeq-server/tests/act_gate.rs
@@ -1581,7 +1581,7 @@ async fn an_award_naming_a_non_bid_is_refused() {
             let line = a.fail();
             assert!(line.contains(" ACCEPTS_NOT_A_BID "), "{named}: {line}");
             assert!(
-                line.ends_with("The award names an event that is not a bid on this action"),
+                line.ends_with("That award names no bid on this task"),
                 "{line}"
             );
         }

--- a/server.toml.example
+++ b/server.toml.example
@@ -30,6 +30,10 @@
 # message_retention_days = 0
 ## How long a task may sit unfinished before the sweep expires it (seconds; 0 = never):
 # act_expiry_secs = 604800
+## How long submitted work waits on the poster before it is deemed accepted
+## (seconds; 0 = never). Every bidder sees this window, so changing it changes
+## the terms they bid under:
+# act_review_secs = 1209600
 
 ## ── Federation (iroh + S2S) ────────────────────────────────────────
 # iroh = true

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -126,17 +126,19 @@
       "target": "dm:did:plc:factory,did:plc:opslead"
     },
     {
-      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-note\":\"two days, sources included\",\"act-verb\":\"bid\",\"from\":\"did:plc:scholar\",\"id\":\"01JBIDEVENTID00000000000B\",\"target\":\"#swarm\"}",
+      "canonical": "{\"act\":\"bounty\",\"act-bid\":\"250 USD\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-note\":\"two days, sources included\",\"act-pay-to\":\"did:plc:scholar\",\"act-verb\":\"bid\",\"from\":\"did:plc:scholar\",\"id\":\"01JBIDEVENTID00000000000B\",\"target\":\"#swarm\"}",
       "id": "01JBIDEVENTID00000000000B",
       "kid": "_oEsEvOrTOasXbaaw1L5Bg",
       "name": "bounty-bid",
       "publicKey": "6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw",
       "seed": "0707070707070707070707070707070707070707070707070707070707070707",
-      "sigTag": "ed25519:_oEsEvOrTOasXbaaw1L5Bg:qmW9LGYR9JC6x10bmWFGcgbZuwvE20lEvnaraOlJ_m1sHKDLOChk8K2pUgjmKx2mkAhJlGbIR8REvqNT8Nj4Dg",
+      "sigTag": "ed25519:_oEsEvOrTOasXbaaw1L5Bg:vEPW9qAXNEUR-A_jtlHzP1thuNJ_gy2py2sAWarLLmnZxBVUWZXXUpL1O_5EQnEYlQ2-w27ZmG81r_d3X_TyCg",
       "tags": {
         "+freeq.at/act": "bounty",
+        "+freeq.at/act-bid": "250 USD",
         "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
         "+freeq.at/act-note": "two days, sources included",
+        "+freeq.at/act-pay-to": "did:plc:scholar",
         "+freeq.at/act-verb": "bid",
         "+freeq.at/from": "did:plc:scholar"
       },

--- a/spec/act-signing-vectors.json
+++ b/spec/act-signing-vectors.json
@@ -38,8 +38,8 @@
     {
       "expected": "invalid",
       "id": "01JAWARDEVENTID000000000A",
-      "name": "award-with-its-winner-stripped",
-      "strippedTag": "+freeq.at/act-to",
+      "name": "award-with-its-bid-stripped",
+      "strippedTag": "+freeq.at/act-accepts",
       "tamperedCanonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
       "target": "#swarm",
       "vector": "bounty-award"
@@ -143,17 +143,17 @@
       "target": "#swarm"
     },
     {
-      "canonical": "{\"act\":\"bounty\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-to\":\"did:plc:scholar\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
+      "canonical": "{\"act\":\"bounty\",\"act-accepts\":\"01JBIDEVENTID00000000000B\",\"act-id\":\"01JBOUNTYEVENTID00000000B\",\"act-verb\":\"award\",\"from\":\"did:plc:eliza\",\"id\":\"01JAWARDEVENTID000000000A\",\"target\":\"#swarm\"}",
       "id": "01JAWARDEVENTID000000000A",
       "kid": "XCm3jxCjWkmmIx0I7oQKBA",
       "name": "bounty-award",
       "publicKey": "E5j2LG0aRXxRumpLXz29L2n8qTIWIY3ImX5Ba9F9k8o",
       "seed": "0808080808080808080808080808080808080808080808080808080808080808",
-      "sigTag": "ed25519:XCm3jxCjWkmmIx0I7oQKBA:812WbPDfzcqaVteOZykVBA6VfGzmUrr1JFJMMdTEdmeRQrd5BI45326wKNoBkAKRaRagqGFsN7Q02RO5VhkuCg",
+      "sigTag": "ed25519:XCm3jxCjWkmmIx0I7oQKBA:wrN_n38AQwose1bwTeLVs9cH5BvIilDESRG-dCkPfIjHIBnnS04FJmFMGxdFpSgezg3sJC0trQJ2xbb_1CtUAg",
       "tags": {
         "+freeq.at/act": "bounty",
+        "+freeq.at/act-accepts": "01JBIDEVENTID00000000000B",
         "+freeq.at/act-id": "01JBOUNTYEVENTID00000000B",
-        "+freeq.at/act-to": "did:plc:scholar",
         "+freeq.at/act-verb": "award",
         "+freeq.at/from": "did:plc:eliza"
       },

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -20,6 +20,9 @@
     "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
     "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
+    "`before_bid_deadline` is the same comparison against a second time on the same opener: act-deadline",
+    "bounds how long the offer stands, act-bid-deadline how long it takes bids, and a kind that collects",
+    "them wants both. A time the offer never named bounds nothing.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
@@ -29,6 +32,11 @@
     "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
+    "What a bounty is worth is nobody's business here: act-price on the offer, act-bid and act-pay-to on a",
+    "bid, act-tx on the acceptance. Stored, relayed, replayed, inside the signature because every act tag is,",
+    "and never read. The server records that a payment was claimed; it never confirms one, and settlement",
+    "lives above this entirely. act-bid-deadline is deliberately not in that list: it is a time the referee",
+    "compares, exactly like act-deadline.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
     "The server still never picks: it checks only that the named event is a `bid` on this action.",
     "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
@@ -61,7 +69,13 @@
       "opens": { "verb": "offer", "open": "open" },
       "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
-        { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
+        {
+          "verb": "bid",
+          "from": "open",
+          "to": "open",
+          "who": "anyone",
+          "before_bid_deadline": true
+        },
         {
           "verb": "award",
           "from": "open",
@@ -983,13 +997,14 @@
       ]
     },
     {
-      "name": "a bid after the deadline is refused, exactly as an award is",
+      "name": "a bounty stops taking bids at its own cutoff",
       "task": {
         "kind": "bounty",
         "offer": "open",
         "offerer": "did:plc:eliza",
         "offeree": null,
-        "deadline": 1788000000
+        "deadline": null,
+        "bid_deadline": 1788000000
       },
       "steps": [
         {
@@ -1002,6 +1017,46 @@
           "verb": "bid",
           "sender": "did:plc:scholar",
           "event_id": "01M16HSB60ACCEPTATEDGE0000",
+          "expect": "open"
+        }
+      ]
+    },
+    {
+      "name": "bidding closing does not stop the poster picking",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null,
+        "bid_deadline": 1788000000
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "a bounty that named no bid cutoff takes bids as long as it stands",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16HSC58ACCEPTTOOLATE000",
           "expect": "open"
         }
       ]

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -35,7 +35,11 @@
     "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
     "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
     "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
-    "clock, not a further verb."
+    "clock, not a further verb: auto-accept is the server's, it fires on work left unanswered past a window",
+    "every bidder knew before bidding, and it is its own verb rather than a reused expire so the log says",
+    "which of the two happened. The window is one number the operator sets. A per-task act-review-deadline",
+    "the offer declares, read like act-deadline and overriding the global for that task, is the additive",
+    "follow-on: the sweep would change only which number it reads, so nothing here is built to be undone."
   ],
   "version": 1,
   "kinds": {

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -26,7 +26,7 @@
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
     "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "accept and claim already mean; a bounty's award sets it to { \"author_of\": \"act-accepts\" }, because the poster picks a bid",
     "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
     "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
     "someone else, or insists on a field, needs a row here and no code anywhere.",
@@ -82,7 +82,7 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "bid-author",
+          "assignee_from": { "author_of": "act-accepts" },
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -22,16 +22,15 @@
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
-    "`assignee_from` names the field that says who a transition assigns. Absent means the actor, which is what",
-    "accept and claim already mean; a bounty's award sets it to act-to, because the poster names a winner",
-    "rather than becoming one. `requires` lists the act-* fields a transition is illegal without — the award's",
-    "act-to, since an award naming nobody assigns nobody. Both are data: a kind that assigns someone else, or",
-    "insists on a field, needs a row here and no code anywhere.",
+    "`assignee_from` names where a transition's assignee comes from. Absent means the actor, which is what",
+    "accept and claim already mean; a bounty's award sets it to bid-author, because the poster picks a bid",
+    "rather than becoming the worker. `requires` lists the act-* fields a transition is illegal without — the",
+    "award's act-accepts, since an award naming no bid takes nothing. Both are data: a kind that assigns",
+    "someone else, or insists on a field, needs a row here and no code anywhere.",
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
-    "What the file deliberately does not say: that an award must name someone who bid. Bids are sovereign and",
-    "so is the award — the server never picks, which cuts both ways, and the poster's signed choice is the",
-    "record. A checker that second-guessed it would be picking."
+    "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
+    "The server still never picks: it checks only that the named event is a `bid` on this action."
   ],
   "version": 1,
   "kinds": {
@@ -60,8 +59,8 @@
           "to": "assigned",
           "who": "offerer",
           "before_deadline": true,
-          "assignee_from": "act-to",
-          "requires": ["act-to"]
+          "assignee_from": "bid-author",
+          "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
         { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
@@ -110,7 +109,8 @@
     "replaces-not-opener": "The revival relation belongs to an opener. A step on an action names no other.",
     "replaces-malformed": "The value does not name an action. An action id is a 26-character ULID.",
     "replaces-not-terminal": "The action it replaces is not finished.",
-    "missing-requirement": "The transition requires a field the event does not carry."
+    "missing-requirement": "The transition requires a field the event does not carry.",
+    "accepts-not-a-bid": "The award names an event that is not a bid on this action."
   },
   "deadline_rule": {
     "_note": [
@@ -667,7 +667,7 @@
       ]
     },
     {
-      "name": "a bounty takes bids, the poster awards it, and the winner finishes the work",
+      "name": "a bounty takes bids, the poster awards one of them, and its author does the work",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -676,17 +676,28 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:rival",
           "expect": "assigned"
         },
-        { "verb": "progress", "sender": "did:plc:scholar", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:scholar", "expect": "completed" }
+        { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
+        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
       ]
     },
     {
@@ -699,13 +710,24 @@
         "deadline": null
       },
       "steps": [
-        { "verb": "bid", "sender": "did:plc:scholar", "expect": "open" },
-        { "verb": "bid", "sender": "did:plc:rival", "expect": "open" },
+        {
+          "verb": "bid",
+          "sender": "did:plc:scholar",
+          "event_id": "01M16E7TC0BDTAKEN000000000",
+          "expect": "open"
+        },
+        {
+          "verb": "bid",
+          "sender": "did:plc:rival",
+          "event_id": "01M16E7TC0BDPASSEDVER00000",
+          "expect": "open"
+        },
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
@@ -713,7 +735,7 @@
       ]
     },
     {
-      "name": "an award names its winner, or it assigns nobody",
+      "name": "an award names the bid it takes, or it takes nothing",
       "task": {
         "kind": "bounty",
         "offer": "open",
@@ -730,9 +752,48 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
+        }
+      ]
+    },
+    {
+      "name": "an award naming the bounty's own opener names no bid",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0THEBNTY000000000",
+          "expect_refused": "accepts-not-a-bid"
+        }
+      ]
+    },
+    {
+      "name": "a bid on another bounty is not one this award can take",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDANTHERACTN0000",
+          "expect_refused": "accepts-not-a-bid"
         }
       ]
     },
@@ -749,13 +810,17 @@
         {
           "verb": "award",
           "sender": "did:plc:scholar",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         },
         {
           "verb": "award",
           "sender": "did:plc:mallory",
-          "tags": ["act-to"],
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect_refused": "wrong-sender"
         }
       ]
@@ -797,8 +862,9 @@
         {
           "verb": "award",
           "sender": "did:plc:eliza",
-          "tags": ["act-to"],
-          "assigns": "did:plc:scholar",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }

--- a/spec/act-transitions.json
+++ b/spec/act-transitions.json
@@ -17,8 +17,8 @@
     "Adding a tag is free: the signature covers every act-* tag present, so a second relation never needs a",
     "canonical change, and IRC tags are a flat map — the first event carrying two pointers needs two names anyway.",
     "`who` names the role a sender must hold: offerer, offeree, assignee, anyone (any logged-in sender), or",
-    "system (the server itself — expiry only). act-caps is a self-declared hint — stored, filterable, signed,",
-    "never checked here. `from` is one state, a list of states, or",
+    "system (the server itself, on the events no participant sends). act-caps is a self-declared hint — stored,",
+    "filterable, signed, never checked here. `from` is one state, a list of states, or",
     "`*nonterminal` for every state that is not terminal. `before_deadline` is data; the comparison is code.",
     "`confirmation` sits outside `kinds` because the receipt verb belongs to no kind and no kind may claim it:",
     "a receipt is the home server's word about an event it filed, not a step anybody takes.",
@@ -30,7 +30,12 @@
     "A kind whose `opens` has no `directed` can only be opened to the room, and an opener carrying act-to is an",
     "illegal step: a bounty is open by construction, and a directed bounty is just a handoff.",
     "`act-accepts` names the bid an award takes — the bid's own event id. The assignee is that bid's author.",
-    "The server still never picks: it checks only that the named event is a `bid` on this action."
+    "The server still never picks: it checks only that the named event is a `bid` on this action.",
+    "A bounty ends on the offerer's word, not the worker's: submitted work waits in under_review, and the",
+    "poster either takes it or sends it back. So there is no complete on a bounty — the worker says the work",
+    "is in, and accept-work says it is done — and cancel does not reach under_review: once work is delivered",
+    "the poster's only moves are accept-work and revise. What a poster who instead goes silent gets is a",
+    "clock, not a further verb."
   ],
   "version": 1,
   "kinds": {
@@ -50,7 +55,7 @@
     },
     "bounty": {
       "opens": { "verb": "offer", "open": "open" },
-      "terminal": ["completed", "failed", "cancelled", "expired"],
+      "terminal": ["accepted", "forfeited", "cancelled", "expired"],
       "transitions": [
         { "verb": "bid", "from": "open", "to": "open", "who": "anyone", "before_deadline": true },
         {
@@ -63,8 +68,16 @@
           "requires": ["act-accepts"]
         },
         { "verb": "progress", "from": "assigned", "to": "assigned", "who": "assignee" },
-        { "verb": "complete", "from": "assigned", "to": "completed", "who": "assignee" },
-        { "verb": "fail", "from": "assigned", "to": "failed", "who": "assignee" },
+        { "verb": "submit", "from": "assigned", "to": "under_review", "who": "assignee" },
+        { "verb": "revise", "from": "under_review", "to": "assigned", "who": "offerer" },
+        { "verb": "accept-work", "from": "under_review", "to": "accepted", "who": "offerer" },
+        {
+          "verb": "forfeit",
+          "from": ["assigned", "under_review"],
+          "to": "forfeited",
+          "who": "assignee"
+        },
+        { "verb": "auto-accept", "from": "under_review", "to": "accepted", "who": "system" },
         { "verb": "cancel", "from": ["open", "assigned"], "to": "cancelled", "who": "offerer" },
         { "verb": "expire", "from": "*nonterminal", "to": "expired", "who": "system" }
       ]
@@ -697,7 +710,147 @@
           "expect": "assigned"
         },
         { "verb": "progress", "sender": "did:plc:rival", "expect": "assigned" },
-        { "verb": "complete", "sender": "did:plc:rival", "expect": "completed" }
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect": "assigned" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "the work is the worker's to hand in and the poster's to accept",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "accept-work", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "revise", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "delivered work is not something the poster can withdraw",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect": "cancelled" }
+      ]
+    },
+    {
+      "name": "once the work is in, the poster takes it or sends it back and nothing else",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "cancel", "sender": "did:plc:eliza", "expect_refused": "illegal-step" },
+        { "verb": "accept-work", "sender": "did:plc:eliza", "expect": "accepted" }
+      ]
+    },
+    {
+      "name": "a bounty is not finished by the worker saying so",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        { "verb": "complete", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" },
+        { "verb": "fail", "sender": "did:plc:scholar", "expect_refused": "unknown-verb" }
+      ]
+    },
+    {
+      "name": "the worker walks away from work they hold, before or after handing it in",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "forfeit", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        { "verb": "forfeit", "sender": "did:plc:scholar", "expect": "forfeited" },
+        { "verb": "revise", "sender": "did:plc:eliza", "expect_refused": "terminal-task" }
+      ]
+    },
+    {
+      "name": "the review clock is the server's to run out, and nobody else's",
+      "task": {
+        "kind": "bounty",
+        "offer": "open",
+        "offerer": "did:plc:eliza",
+        "offeree": null,
+        "deadline": null
+      },
+      "steps": [
+        {
+          "verb": "award",
+          "sender": "did:plc:eliza",
+          "tags": ["act-accepts"],
+          "accepts": "01M16E7TC0BDTAKEN000000000",
+          "accepted_bid": "did:plc:scholar",
+          "expect": "assigned"
+        },
+        { "verb": "auto-accept", "sender": "did:web:irc.example", "system": true, "expect_refused": "illegal-step" },
+        { "verb": "submit", "sender": "did:plc:scholar", "expect": "under_review" },
+        { "verb": "auto-accept", "sender": "did:plc:scholar", "expect_refused": "wrong-sender" },
+        { "verb": "auto-accept", "sender": "did:plc:eliza", "expect_refused": "wrong-sender" },
+        {
+          "verb": "auto-accept",
+          "sender": "did:web:irc.example",
+          "system": true,
+          "expect": "accepted"
+        }
       ]
     },
     {
@@ -730,7 +883,7 @@
           "accepted_bid": "did:plc:scholar",
           "expect": "assigned"
         },
-        { "verb": "complete", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
+        { "verb": "submit", "sender": "did:plc:rival", "expect_refused": "wrong-sender" },
         { "verb": "bid", "sender": "did:plc:rival", "expect_refused": "illegal-step" }
       ]
     },


### PR DESCRIPTION
Stacked on #61 — ten commits on top of `act-tier1`, take or drop. They bring `bounty` to the design I'd sketched before #61 (and never posted — the four points in my review comment there):

1. **`award` names the bid it takes**, not a DID: `act-accepts=<bid event id>`, the assignee is that bid's author, and an award naming anything that isn't a bid on this bounty is refused (`ACCEPTS_NOT_A_BID`, "That award names no bid on this task"). The checker stays pure — the caller resolves the bid from the action's own events and hands the checker the author; the rebuild resolves it the same way from the log it replays.
2. **The poster ends the work.** `submit` → `under_review` → `accept-work` / `revise`; `forfeit` by the assignee; `complete` and `fail` are gone from bounty; `cancel` can't reach delivered work. `accepted`/`forfeited` are terminal.
3. **Review window.** `act_review_secs` (default 14 days): work left in `under_review` past it is auto-accepted by a home-signed `auto-accept`, announced to the room the way an expiry is (`Task accepted without review: <title>`); `revise` resets the clock. The expiry sweep and the review sweep own disjoint states, read from the rules file.
4. **Bid cutoff and money.** `act-bid-deadline` bounds bids (`before_bid_deadline`), separately from `act-deadline` bounding the award. `act-price`, `act-bid`, `act-pay-to`, `act-tx` are documented as opaque — signed, relayed, never read.
5. Docs: a bounty section in `agents.md`, tag registry rows.

Everything stays data where it can: new rows, `assignee_from: "bid-author"`, `before_bid_deadline`; no kind name in any validator. Both checkers move together; the shared sequences gained seventeen bounty cases. Vectors regenerated (`bounty-award` carries `act-accepts`; `bounty-bid` carries terms); both JS suites reproduce them.

Verification at the tip: `cargo test --workspace` (CI's exclusions) 2490 passed / 0 failed / 33 ignored; fmt and clippy clean; bot-kit 349, sdk-js 409. Not run: the live IRC acceptance script (updated to the new wire).
