### PR TITLE
The web client renders task events as cards

### DIFF
--- a/freeq-app/e2e/act-cards.spec.ts
+++ b/freeq-app/e2e/act-cards.spec.ts
@@ -95,4 +95,19 @@ test.describe('task cards', () => {
       await expect(cards.nth(i)).toContainText(word);
     }
   });
+
+  test('next from the offer card lands on the claim card', async ({ page }) => {
+    const channel = uniqueChannel();
+    await connectGuest(page, uniqueNick(), channel);
+    for (const move of LIFECYCLE) await receiveMove(page, channel, move);
+
+    const cards = page.getByTestId('act-card');
+    await expect(cards).toHaveCount(4);
+    await cards.nth(0).getByText('next →').click();
+
+    // The jump highlights the row it lands on, which is the claim's line.
+    const claim = page.locator(`#msg-m-${LIFECYCLE[1].eventId}`);
+    await expect(claim).toHaveClass(/bg-accent/);
+    await expect(claim.getByTestId('act-card')).toContainText('claimed');
+  });
 });

--- a/freeq-app/e2e/act-cards.spec.ts
+++ b/freeq-app/e2e/act-cards.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * E2E: a task's lifecycle, as the room sees it.
+ *
+ * Runs against a local freeq-server (see playwright.config.ts). Each move is
+ * put into the open conversation the way it arrives on the wire — the event,
+ * then the line its sender wrote beside it — and everything downstream of
+ * that stays real: the store pairs them and the row renders through the app.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { uniqueNick, uniqueChannel, connectGuest } from './helpers';
+
+const TASK = '01JPWLIFECYCLE00000000000A';
+
+type Move = { verb: string; eventId: string; text: string; fields?: Record<string, string> };
+
+const LIFECYCLE: Move[] = [
+  { verb: 'offer', eventId: TASK, text: 'offered: ship the release', fields: { 'act-title': 'ship the release' } },
+  { verb: 'claim', eventId: '01JPWLIFECYCLE00000000000B', text: 'claimed the task' },
+  {
+    verb: 'progress',
+    eventId: '01JPWLIFECYCLE00000000000C',
+    text: 'progress: tagged the build',
+    fields: { 'act-note': 'tagged the build', 'act-ctx': 'https://example.com/checks/abc', 'act-ctx-h': 'sha256:9f00' },
+  },
+  { verb: 'complete', eventId: '01JPWLIFECYCLE00000000000D', text: 'completed the task' },
+];
+
+/** Put one move into the conversation: the event, then its companion line. */
+async function receiveMove(page: Page, channel: string, move: Move) {
+  await page.evaluate(
+    async ({ channel, move, task }) => {
+      const { useStore } = await import('/src/store.ts');
+      const s = useStore.getState();
+      s.addActEvent(channel, {
+        from: 'worker',
+        did: 'did:plc:worker',
+        kind: 'handoff',
+        verb: move.verb,
+        eventId: move.eventId,
+        taskId: task,
+        fields: { act: 'handoff', 'act-verb': move.verb, ...(move.fields ?? {}) },
+      });
+      s.addMessage(channel, {
+        id: `m-${move.eventId}`,
+        from: 'worker',
+        text: move.text,
+        timestamp: new Date(),
+        tags: { '+freeq.at/ref': task, msgid: `m-${move.eventId}` },
+      });
+    },
+    { channel, move, task: TASK },
+  );
+}
+
+test.describe('task cards', () => {
+  test('every move of a lifecycle keeps its own card, and its own word', async ({ page }) => {
+    const channel = uniqueChannel();
+    await connectGuest(page, uniqueNick(), channel);
+
+    const cards = page.getByTestId('act-card');
+    const words = ['offered', 'claimed', 'in progress', 'completed'];
+
+    // The first half of the task, live.
+    for (const [i, move] of LIFECYCLE.slice(0, 2).entries()) {
+      await receiveMove(page, channel, move);
+      await expect(cards).toHaveCount(i + 1);
+      await expect(cards.nth(i)).toContainText(words[i]);
+    }
+
+    // A reader who reloads mid-task is handed what already happened as replay
+    // and the rest of it live, and both halves read the same.
+    await page.reload();
+    await connectGuest(page, uniqueNick(), channel);
+    for (const move of LIFECYCLE.slice(0, 2)) await receiveMove(page, channel, move);
+    await expect(cards).toHaveCount(2, { timeout: 10_000 });
+    await expect(cards.nth(0)).toContainText(words[0]);
+    await expect(cards.nth(1)).toContainText(words[1]);
+
+    for (const [i, move] of LIFECYCLE.slice(2).entries()) {
+      await receiveMove(page, channel, move);
+      await expect(cards).toHaveCount(i + 3);
+      await expect(cards.nth(i + 2)).toContainText(words[i + 2]);
+    }
+
+    // The finished lifecycle: four cards, four words, and the sender's prose
+    // nowhere — every event is a card and stays one.
+    await expect(cards.nth(2)).toContainText('tagged the build');
+    await expect(page.getByTestId('message-list')).not.toContainText('offered: ship the release');
+
+    // And the whole thing over again — the JOIN replay, then the CHATHISTORY
+    // the client asks for next — is still those same four cards.
+    for (const move of LIFECYCLE) await receiveMove(page, channel, move);
+    await expect(cards).toHaveCount(4, { timeout: 10_000 });
+    for (const [i, word] of words.entries()) {
+      await expect(cards.nth(i)).toContainText(word);
+    }
+  });
+});

--- a/freeq-app/e2e/act-wire.spec.ts
+++ b/freeq-app/e2e/act-wire.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E: a task's lifecycle over the wire.
+ *
+ * The other act spec puts each move straight into the store. This one puts
+ * them on a real connection: a signed peer runs the task, the server files
+ * every event and replays them to whoever joins next, and the app's own
+ * bridge is what turns them into cards. The peer's nick carries capitals on
+ * purpose — a replayed event names its sender by the nick the server holds
+ * for the DID, and its companion line by the nick as it was sent.
+ */
+import { test, expect, type Page, type Browser } from '@playwright/test';
+import { uniqueNick, uniqueChannel, connectGuest, prepPage } from './helpers';
+
+type Peer = { page: Page; did: string };
+
+/**
+ * A signed peer in the channel, driven from a second browser page: a spec
+ * body is not bundled, so the SDK is reachable only through the dev server
+ * (see `src/e2e-support.ts`).
+ */
+async function startPeer(browser: Browser, nick: string, channel: string): Promise<Peer> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await prepPage(page);
+  await page.goto('/');
+
+  const did = await page.evaluate(async ({ nick, channel }) => {
+    const { FreeqClient, generateDidKey } = await import('/src/e2e-support.ts');
+    const didKey = await generateDidKey();
+    const client = new FreeqClient({
+      url: `ws://${location.hostname}:8080/irc`,
+      nick,
+      channels: [channel],
+      sasl: { did: didKey.did, method: 'crypto', signer: didKey.signer, token: '', pdsUrl: '' },
+    });
+    (window as any).__peer = client;
+    const joined = new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('peer never joined')), 20_000);
+      client.on('channelJoined', (chan: string) => {
+        if (chan.toLowerCase() === channel.toLowerCase()) {
+          clearTimeout(t);
+          resolve();
+        }
+      });
+    });
+    client.connect();
+    await joined;
+    return didKey.did;
+  }, { nick, channel });
+
+  return { page, did };
+}
+
+/** One move by the peer: the signed event, and the line it writes beside it. */
+async function sendMove(
+  peer: Peer,
+  channel: string,
+  verb: string,
+  task: string | undefined,
+  fields: Record<string, string> = {},
+): Promise<string> {
+  return peer.page.evaluate(async ({ channel, verb, task, fields, did }) => {
+    const { actTags } = await import('/src/e2e-support.ts');
+    const client = (window as any).__peer;
+    return client.sendAct(channel, actTags('handoff', verb, task, did, fields), { taskId: task });
+  }, { channel, verb, task, fields, did: peer.did });
+}
+
+test('a task run on the wire reads as cards, live and again after a reload', async ({ page, browser }) => {
+  const channel = uniqueChannel();
+  const peer = await startPeer(browser, uniqueNick('TaskBot'), channel);
+
+  try {
+    await connectGuest(page, uniqueNick(), channel);
+    const cards = page.getByTestId('act-card');
+
+    const task = await sendMove(peer, channel, 'offer', undefined, { title: 'ship the release' });
+    await expect(cards).toHaveCount(1, { timeout: 15_000 });
+    await expect(cards.nth(0)).toContainText('offered');
+
+    await sendMove(peer, channel, 'claim', task);
+    await expect(cards).toHaveCount(2, { timeout: 15_000 });
+    await expect(cards.nth(1)).toContainText('claimed');
+
+    await sendMove(peer, channel, 'progress', task, { note: 'tagged the build' });
+    await expect(cards).toHaveCount(3, { timeout: 15_000 });
+    await expect(cards.nth(2)).toContainText('in progress');
+    await expect(cards.nth(2)).toContainText('tagged the build');
+
+    await sendMove(peer, channel, 'complete', task);
+    await expect(cards).toHaveCount(4, { timeout: 15_000 });
+    await expect(cards.nth(3)).toContainText('completed');
+
+    // What the server replays to a reader who arrives after all of it: the
+    // same four cards, from the events and lines it hands back on the join.
+    await page.reload();
+    await connectGuest(page, uniqueNick(), channel);
+    await expect(cards).toHaveCount(4, { timeout: 15_000 });
+    for (const [i, word] of ['offered', 'claimed', 'in progress', 'completed'].entries()) {
+      await expect(cards.nth(i)).toContainText(word);
+    }
+  } finally {
+    await peer.page.context().close();
+  }
+});

--- a/freeq-app/src/components/ActCards.test.tsx
+++ b/freeq-app/src/components/ActCards.test.tsx
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
-import { ActEventCard } from './ActCards';
+import { ActEventCard, cardNeighbours } from './ActCards';
 import { actHeadline } from '../lib/act-verbs';
 import type { Message, ActTask, ActEvent } from '../store';
 
@@ -101,5 +101,49 @@ describe('what the card carries', () => {
     const ev = event('claim');
     const { container } = render(<ActEventCard msg={msg(ev.msgId!)} task={task([ev])} event={ev} />);
     expect(container.textContent).not.toContain('whatever the sender wrote');
+  });
+});
+
+describe('skipping between a task\'s cards', () => {
+  const lifecycle = [event('offer'), event('claim'), event('progress'), event('complete')];
+
+  it('names the card before and the card after', () => {
+    expect(cardNeighbours(task(lifecycle), lifecycle[1])).toEqual({ prev: 'm-offer', next: 'm-progress' });
+  });
+
+  it('offers nothing before the first card, or after the last', () => {
+    expect(cardNeighbours(task(lifecycle), lifecycle[0])).toEqual({ prev: undefined, next: 'm-claim' });
+    expect(cardNeighbours(task(lifecycle), lifecycle[3])).toEqual({ prev: 'm-progress', next: undefined });
+  });
+
+  it('skips the events the home signs, which are lines and not cards', () => {
+    const confirmed = [
+      lifecycle[0],
+      { eventId: 'e-confirm', verb: 'confirm', from: 'e2e', fields: {} },
+      lifecycle[1],
+    ];
+    expect(cardNeighbours(task(confirmed), lifecycle[0])).toEqual({ prev: undefined, next: 'm-claim' });
+  });
+
+  it('shows a link for each neighbour a card has', () => {
+    const first = render(<ActEventCard msg={msg('m-offer')} task={task(lifecycle)} event={lifecycle[0]} />);
+    expect(first.container.textContent).toContain('next →');
+    expect(first.container.textContent).not.toContain('← prev');
+    cleanup();
+
+    const middle = render(<ActEventCard msg={msg('m-claim')} task={task(lifecycle)} event={lifecycle[1]} />);
+    expect(middle.container.textContent).toContain('← prev');
+    expect(middle.container.textContent).toContain('next →');
+  });
+
+  it('asks the list to jump to the neighbour it names', async () => {
+    const { useStore } = await import('../store');
+    const { getByText } = render(
+      <ActEventCard msg={msg('m-claim')} task={task(lifecycle)} event={lifecycle[1]} />,
+    );
+    getByText('next →').click();
+    expect(useStore.getState().scrollToMsgId).toBe('m-progress');
+    getByText('← prev').click();
+    expect(useStore.getState().scrollToMsgId).toBe('m-offer');
   });
 });

--- a/freeq-app/src/components/ActCards.test.tsx
+++ b/freeq-app/src/components/ActCards.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+/**
+ * The card a task event's companion line becomes: its headline is the word
+ * for the verb that event carried, and every event keeps its own card.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ActEventCard } from './ActCards';
+import { actHeadline } from '../lib/act-verbs';
+import type { Message, ActTask, ActEvent } from '../store';
+
+afterEach(cleanup);
+
+const TASK_ID = '01JOPENER00000000000000000';
+
+function task(events: ActEvent[]): ActTask {
+  return {
+    taskId: TASK_ID,
+    kind: 'handoff',
+    title: 'ship the release',
+    offerer: 'did:plc:poster',
+    verb: events[events.length - 1].verb,
+    ctx: [],
+    events,
+  };
+}
+
+function event(verb: string, fields: Record<string, string> = {}): ActEvent {
+  return { eventId: `e-${verb}`, verb, from: 'worker', did: 'did:plc:worker', fields, msgId: `m-${verb}` };
+}
+
+function msg(id: string): Message {
+  return { id, from: 'worker', text: 'whatever the sender wrote', timestamp: new Date(0), tags: { '+freeq.at/ref': TASK_ID } };
+}
+
+const WORDS: Array<[string, string]> = [
+  ['offer', 'offered'],
+  ['accept', 'accepted'],
+  ['decline', 'declined'],
+  ['claim', 'claimed'],
+  ['progress', 'in progress'],
+  ['complete', 'completed'],
+  ['fail', 'failed'],
+  ['cancel', 'cancelled'],
+  ['bid', 'bid'],
+  ['award', 'awarded'],
+  ['submit', 'submitted'],
+  ['revise', 'revisions requested'],
+  ['accept-work', 'accepted'],
+  ['forfeit', 'forfeited'],
+];
+
+describe('the headline word', () => {
+  it.each(WORDS)('a %s shows "%s"', (verb, word) => {
+    const ev = event(verb);
+    const { container } = render(<ActEventCard msg={msg(ev.msgId!)} task={task([ev])} event={ev} />);
+    expect(container.textContent).toContain(word);
+  });
+
+  it('shows a verb it has not been taught by its own name', () => {
+    expect(actHeadline('withdraw-bid')).toBe('withdraw-bid');
+  });
+
+  // The home's own two verbs write no companion, so they have no card — their
+  // words are read in the timeline, off the same table.
+  it('has a word for each verb the home signs itself', () => {
+    expect(actHeadline('confirm')).toBe('confirmed');
+    expect(actHeadline('expire')).toBe('expired');
+  });
+
+  it('reads a progress off the event, not off where the task got to', () => {
+    const moves = [event('claim'), event('progress', { 'act-note': 'tagged the build' })];
+    const { container } = render(
+      <ActEventCard msg={msg('m-progress')} task={task(moves)} event={moves[1]} />,
+    );
+    expect(container.textContent).toContain('in progress');
+    expect(container.textContent).not.toContain('claimed');
+  });
+});
+
+describe('what the card carries', () => {
+  it('shows the task title and the event\'s own note', () => {
+    const ev = event('progress', { 'act-note': 'tagged the build' });
+    const { container } = render(<ActEventCard msg={msg(ev.msgId!)} task={task([ev])} event={ev} />);
+    expect(container.textContent).toContain('ship the release');
+    expect(container.textContent).toContain('tagged the build');
+  });
+
+  it('links the context the event carried, under the hash its signature covers', () => {
+    const ev = event('progress', {
+      'act-ctx': 'https://example.com/checks/abc',
+      'act-ctx-h': 'sha256:9f00',
+    });
+    const { container } = render(<ActEventCard msg={msg(ev.msgId!)} task={task([ev])} event={ev} />);
+    const link = container.querySelector('a')!;
+    expect(link.getAttribute('href')).toBe('https://example.com/checks/abc');
+    expect(link.getAttribute('title')).toBe('sha256:9f00');
+  });
+
+  it('never shows the sender\'s prose in place of the card', () => {
+    const ev = event('claim');
+    const { container } = render(<ActEventCard msg={msg(ev.msgId!)} task={task([ev])} event={ev} />);
+    expect(container.textContent).not.toContain('whatever the sender wrote');
+  });
+});

--- a/freeq-app/src/components/ActCards.tsx
+++ b/freeq-app/src/components/ActCards.tsx
@@ -1,0 +1,77 @@
+/**
+ * Task event cards.
+ *
+ * A task event rides as a TAGMSG the message list never shows; the line its
+ * sender wrote beside it is what a reader sees, and that line becomes this
+ * card. Every event keeps a card of its own — the headline is the word for
+ * the verb that event carried, never a word read off the task's state, so a
+ * progress report never reads as a claim.
+ */
+import { useState } from 'react';
+import type { Message, ActTask, ActEvent } from '../store';
+import { CardFrame } from './CoordinationCards';
+import { TaskTimeline } from './TaskTimeline';
+import { useStore } from '../store';
+import { actHeadline } from '../lib/act-verbs';
+
+export function ActEventCard({ msg, task, event }: {
+  msg: Message;
+  task: ActTask;
+  event: ActEvent;
+}) {
+  const [open, setOpen] = useState(false);
+  const note = event.fields['act-note'];
+  const ctx = event.fields['act-ctx'];
+
+  return (
+    <>
+      <div data-testid="act-card" onClick={() => setOpen(true)} className="cursor-pointer">
+        <CardFrame icon="📋" label={actHeadline(event.verb)} msg={msg}>
+          {task.title && <div className="text-fg whitespace-pre-wrap">{task.title}</div>}
+          {note && <div className="text-fg-muted whitespace-pre-wrap">{note}</div>}
+          {ctx && (
+            <a
+              href={ctx}
+              target="_blank"
+              rel="noopener noreferrer"
+              // The hash is what the signature covers, so it rides along for
+              // anyone checking the bytes they fetched.
+              title={event.fields['act-ctx-h']}
+              onClick={e => e.stopPropagation()}
+              className="text-accent hover:underline break-all text-xs"
+            >
+              {ctx}
+            </a>
+          )}
+        </CardFrame>
+      </div>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          onClick={() => setOpen(false)}
+        >
+          <div onClick={e => e.stopPropagation()}>
+            <TaskTimeline actId={task.taskId} onClose={() => setOpen(false)} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * The task and event a message is the companion line of, if it is one.
+ *
+ * Reads the channel's task map, so it answers only for a message whose event
+ * the store has already seen — which is every companion, once its event has
+ * arrived, live or in replay.
+ */
+export function useActCompanion(msg: Message, channel?: string): { task: ActTask; event: ActEvent } | null {
+  const actTasks = useStore(s => (channel ? s.channels.get(channel.toLowerCase())?.actTasks : undefined));
+  const ref = msg.tags?.['+freeq.at/ref'];
+  if (!ref) return null;
+  const task = actTasks?.get(ref);
+  if (!task) return null;
+  const event = task.events.find(e => e.msgId === msg.id);
+  return event ? { task, event } : null;
+}

--- a/freeq-app/src/components/ActCards.tsx
+++ b/freeq-app/src/components/ActCards.tsx
@@ -14,14 +14,30 @@ import { TaskTimeline } from './TaskTimeline';
 import { useStore } from '../store';
 import { actHeadline } from '../lib/act-verbs';
 
+/**
+ * The cards either side of this one, by companion msgid.
+ *
+ * A task's cards are its events in the order they were made, minus the two
+ * the home signs for itself: those are system lines, with no card to land on.
+ * Absent at each end, which is what stops the links being offered there.
+ */
+export function cardNeighbours(task: ActTask, event: ActEvent): { prev?: string; next?: string } {
+  const cards = task.events.filter(e => e.msgId);
+  const i = cards.findIndex(e => e.eventId === event.eventId);
+  if (i === -1) return {};
+  return { prev: cards[i - 1]?.msgId, next: cards[i + 1]?.msgId };
+}
+
 export function ActEventCard({ msg, task, event }: {
   msg: Message;
   task: ActTask;
   event: ActEvent;
 }) {
   const [open, setOpen] = useState(false);
+  const setScrollToMsgId = useStore(s => s.setScrollToMsgId);
   const note = event.fields['act-note'];
   const ctx = event.fields['act-ctx'];
+  const { prev, next } = cardNeighbours(task, event);
 
   return (
     <>
@@ -42,6 +58,20 @@ export function ActEventCard({ msg, task, event }: {
             >
               {ctx}
             </a>
+          )}
+          {(prev || next) && (
+            <div className="flex gap-3 mt-1.5 text-[11px]" onClick={e => e.stopPropagation()}>
+              {prev && (
+                <button className="text-fg-dim hover:text-fg-muted" onClick={() => setScrollToMsgId(prev)}>
+                  ← prev
+                </button>
+              )}
+              {next && (
+                <button className="text-fg-dim hover:text-fg-muted" onClick={() => setScrollToMsgId(next)}>
+                  next →
+                </button>
+              )}
+            </div>
           )}
         </CardFrame>
       </div>

--- a/freeq-app/src/components/CoordinationCards.tsx
+++ b/freeq-app/src/components/CoordinationCards.tsx
@@ -42,7 +42,7 @@ function TaskIdBadge({ taskId }: { taskId?: string }) {
 
 // ─── Card Wrapper ───────────────────────────────────
 
-function CardFrame({ icon, label, children, msg, className }: {
+export function CardFrame({ icon, label, children, msg, className }: {
   icon: string;
   label: string;
   children: React.ReactNode;

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -13,6 +13,7 @@ import { LinkPreview } from './LinkPreview';
 import { MessageContextMenu } from './MessageContextMenu';
 import { MarkdownMessage } from './MarkdownRenderer';
 import { CoordinationEventCard, isCoordinationEvent } from './CoordinationCards';
+import { ActEventCard, useActCompanion } from './ActCards';
 import { jumbomojiSize } from '../lib/jumbomoji';
 import { buildTranscript } from '../lib/transcript';
 import { useCachedVerdict, VERIFY_LABELS } from '../lib/verify-signature';
@@ -421,6 +422,7 @@ function MessageContentImpl({ msg, channel, onNickClick }: {
   onNickClick?: (nick: string, did: string | undefined, origin: string | undefined, e: React.MouseEvent, evidence?: RowEvidence) => void;
 }) {
   const setLightbox = useStore((s) => s.setLightboxUrl);
+  const actCompanion = useActCompanion(msg, channel);
   const linkCtx: RenderCtx = { channel, onNickClick };
 
   if (msg.isAction) {
@@ -430,6 +432,11 @@ function MessageContentImpl({ msg, channel, onNickClick }: {
         <span style={{ color }} className="font-semibold not-italic">{'* '}{displayNameForKey(msg.from)}</span>{' '}{msg.text}
       </div>
     );
+  }
+
+  // A task event's companion line is that event's card, and stays one.
+  if (actCompanion) {
+    return <ActEventCard msg={msg} task={actCompanion.task} event={actCompanion.event} />;
   }
 
   // Coordination event cards (Phase 3)

--- a/freeq-app/src/components/TaskTimeline.act.test.tsx
+++ b/freeq-app/src/components/TaskTimeline.act.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+/**
+ * The action timeline's headline: the title the opener signed, and nothing at
+ * all where no opener the reader holds signed one — an id is not a name.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { TaskTimeline } from './TaskTimeline';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const ACT_ID = '01KZACTION0000000000000ACT';
+
+/** One event as `/api/v1/actions/{id}` serves it: the bytes it signed, and
+ *  the row the view lists it under. */
+function event(eventId: string, doc: Record<string, string>) {
+  return {
+    event_id: eventId,
+    canonical: JSON.stringify(doc),
+    signature: 'ed25519:kid:sigsigsig',
+    actor_did: 'did:plc:worker',
+    timestamp: 0,
+  };
+}
+
+function serve(events: ReturnType<typeof event>[]) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ task: null, events }),
+  }));
+}
+
+describe('the action timeline headline', () => {
+  it('shows the title the opener signed', async () => {
+    serve([
+      event(ACT_ID, { 'act-verb': 'offer', 'act-title': 'ship the release' }),
+      event('01KZCLAIM00000000000000CLM', { 'act-verb': 'claim' }),
+    ]);
+
+    const { container } = render(<TaskTimeline actId={ACT_ID} onClose={() => {}} />);
+    await waitFor(() => expect(container.textContent).toContain('ship the release'));
+    expect(container.textContent).toContain('claimed');
+  });
+
+  it("reads the home's own moves under their own words", async () => {
+    serve([
+      event(ACT_ID, { 'act-verb': 'offer', 'act-title': 'ship the release' }),
+      event('01KZCONFIRM000000000000CNF', { 'act-verb': 'confirm', 'act-subject': ACT_ID }),
+      event('01KZEXPIRE0000000000000EXP', { 'act-verb': 'expire' }),
+    ]);
+
+    const { container } = render(<TaskTimeline actId={ACT_ID} onClose={() => {}} />);
+    await waitFor(() => expect(container.textContent).toContain('confirmed'));
+    expect(container.textContent).toContain('expired');
+  });
+
+  it('shows no id in place of a title the reader never got', async () => {
+    serve([event('01KZCLAIM00000000000000CLM', { 'act-verb': 'claim' })]);
+
+    const { container } = render(<TaskTimeline actId={ACT_ID} onClose={() => {}} />);
+    await waitFor(() => expect(container.textContent).toContain('claimed'));
+    expect(container.textContent).not.toContain(ACT_ID);
+    // The id fragment beside the headline is the badge every card carries.
+    expect(container.textContent).toContain(ACT_ID.slice(0, 12));
+  });
+});

--- a/freeq-app/src/components/TaskTimeline.tsx
+++ b/freeq-app/src/components/TaskTimeline.tsx
@@ -1,9 +1,15 @@
 /**
- * TaskTimeline — focused view for a single task.
- * Fetches from GET /api/v1/tasks/{taskId}
+ * TaskTimeline — focused view for a single task, of either family.
+ *
+ * A coordination task is fetched from `/api/v1/tasks/{id}` and shown as the
+ * phase-and-evidence view it has always had; a task event's action is fetched
+ * from `/api/v1/actions/{id}` and shown as what it is — the moves made on it,
+ * each under the word for the verb it carried.
  */
 import { useEffect, useState } from 'react';
 import { VerifySignaturePanel } from './VerifySignaturePanel';
+import { displayNameForKey } from '../lib/display-name';
+import { actHeadline } from '../lib/act-verbs';
 
 interface TaskEvent {
   event_id: string;
@@ -23,7 +29,94 @@ interface TaskData {
 
 const phaseOrder = ['specifying', 'designing', 'building', 'reviewing', 'testing', 'deploying'];
 
-export function TaskTimeline({ taskId, onClose }: { taskId: string; onClose: () => void }) {
+export function TaskTimeline(props: { taskId?: string; actId?: string; onClose: () => void }) {
+  return props.actId
+    ? <ActionTimeline actId={props.actId} onClose={props.onClose} />
+    : <CoordinationTimeline taskId={props.taskId ?? ''} onClose={props.onClose} />;
+}
+
+/** One event of an action, as `/api/v1/actions/{id}` serves it. */
+interface ActionEvent {
+  event_id: string;
+  canonical: string;
+  signature?: string;
+  actor_did?: string;
+  confirm_state?: string;
+  timestamp: number;
+}
+
+function ActionTimeline({ actId, onClose }: { actId: string; onClose: () => void }) {
+  const [data, setData] = useState<{ task: any; events: ActionEvent[] } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [verify, setVerify] = useState<{ id: string; signed: boolean; pos: { x: number; y: number } } | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/v1/actions/${encodeURIComponent(actId)}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [actId]);
+
+  if (loading) return <div className="p-4 text-fg-dim text-sm">Loading task...</div>;
+  if (!data?.events?.length) return <div className="p-4 text-fg-dim text-sm">Task not found.</div>;
+
+  // The document each event signed is where its verb and title live, so the
+  // view reads the same bytes the signature covers.
+  const docs = data.events.map(e => {
+    let doc: Record<string, string> = {};
+    try { doc = JSON.parse(e.canonical); } catch { /* an unreadable event still lists */ }
+    return { event: e, doc };
+  });
+  // Only the opener signs a title, so a reader holding no opener is shown
+  // none: the id beside it is a handle, not a name for the work.
+  const title = docs.find(d => d.doc['act-title'])?.doc['act-title'];
+
+  return (
+    <div className="rounded-lg border border-border overflow-hidden bg-bg-secondary max-w-md">
+      <div className="flex items-center justify-between px-3 py-2 bg-surface/50 border-b border-border/50">
+        <div className="flex items-center gap-2">
+          <span>📋</span>
+          {title && <span className="font-semibold text-sm text-fg">{title}</span>}
+          <span className="text-[10px] font-mono text-fg-dim/60">{actId.slice(0, 12)}</span>
+        </div>
+        <button onClick={onClose} className="text-fg-dim hover:text-fg text-sm">✕</button>
+      </div>
+
+      <div className="px-3 py-2">
+        {docs.map(({ event, doc }) => (
+          <div key={event.event_id} className="flex items-center gap-2 text-xs py-1">
+            <span className="font-semibold text-fg-muted">{actHeadline(doc['act-verb'] ?? '')}</span>
+            <span className="text-fg-dim truncate">
+              {event.actor_did ? displayNameForKey(event.actor_did) : ''}
+            </span>
+            <span className="ml-auto text-[10px] text-fg-dim/50">
+              {new Date(event.timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </span>
+            <button
+              className="text-[10px] text-fg-dim/60 hover:text-fg-muted underline decoration-dotted"
+              title="Check this event's signature"
+              onClick={ev => setVerify({ id: event.event_id, signed: !!event.signature, pos: { x: ev.clientX, y: ev.clientY } })}
+            >
+              verify
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {verify && (
+        <VerifySignaturePanel
+          msgid={verify.id}
+          signed={verify.signed}
+          position={verify.pos}
+          noun="event"
+          onClose={() => setVerify(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function CoordinationTimeline({ taskId, onClose }: { taskId: string; onClose: () => void }) {
   const [data, setData] = useState<TaskData | null>(null);
   const [loading, setLoading] = useState(true);
   const [verify, setVerify] = useState<{ id: string; signed: boolean; pos: { x: number; y: number } } | null>(null);

--- a/freeq-app/src/e2e-support.ts
+++ b/freeq-app/src/e2e-support.ts
@@ -7,4 +7,4 @@
  * paths the dev server already serves. This module is such a path. Nothing in
  * the app imports it, so it never reaches a production bundle.
  */
-export { FreeqClient, generateDidKey } from '@freeq/sdk';
+export { FreeqClient, generateDidKey, actTags } from '@freeq/sdk';

--- a/freeq-app/src/irc/client-act.test.ts
+++ b/freeq-app/src/irc/client-act.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/**
+ * The bridge's task-event wiring: an `actEvent` off the SDK reaches the
+ * store's task map, and a DM one gets a buffer to land in.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const storage = new Map<string, string>();
+// @ts-expect-error mock
+globalThis.localStorage = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => { storage.delete(k); },
+  clear: () => storage.clear(),
+  get length() { return storage.size; },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+};
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'uuid-' + Math.random().toString(36).slice(2), subtle: {} },
+  writable: true, configurable: true,
+});
+// @ts-expect-error mock
+globalThis.window = { localStorage: globalThis.localStorage, location: { hash: '', origin: 'http://localhost' }, addEventListener: () => {} };
+
+const { useStore } = await import('../store');
+const { __wireEventsForTests } = await import('./client');
+
+/** Stub client that records `.on` registrations and can fire them. */
+function makeEventStub() {
+  const handlers = new Map<string, Array<(...args: any[]) => void>>();
+  return {
+    nick: 'me',
+    on(event: string, fn: (...args: any[]) => void) {
+      const list = handlers.get(event) ?? [];
+      list.push(fn);
+      handlers.set(event, list);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const fn of handlers.get(event) ?? []) fn(...args);
+    },
+    opts: { url: 'ws://test' },
+  };
+}
+
+const OPENER = '01JOPENER00000000000000000';
+
+function actEvent(channel: string) {
+  return {
+    channel,
+    from: 'poster',
+    did: 'did:plc:poster',
+    kind: 'handoff',
+    verb: 'offer',
+    eventId: OPENER,
+    taskId: OPENER,
+    fields: { act: 'handoff', 'act-verb': 'offer', 'act-title': 'ship the release' },
+    tags: {},
+    replayed: false,
+  };
+}
+
+beforeEach(() => {
+  storage.clear();
+  useStore.getState().reset();
+});
+
+describe('actEvent wiring', () => {
+  it('files a channel task event in that channel', () => {
+    const stub = makeEventStub();
+    __wireEventsForTests(stub as any);
+    useStore.getState().addChannel('#work');
+
+    stub.emit('actEvent', actEvent('#work'));
+
+    const task = useStore.getState().channels.get('#work')!.actTasks.get(OPENER)!;
+    expect(task.title).toBe('ship the release');
+    expect(task.verb).toBe('offer');
+  });
+
+  it('opens a DM buffer for a task event sent direct', () => {
+    const stub = makeEventStub();
+    __wireEventsForTests(stub as any);
+
+    stub.emit('actEvent', actEvent('poster'));
+
+    const ch = useStore.getState().channels.get('poster');
+    expect(ch?.actTasks.get(OPENER)?.title).toBe('ship the release');
+  });
+});

--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -850,6 +850,16 @@ function wireEvents(c: FreeqClient) {
     }
   });
 
+  c.on('actEvent', (ev) => {
+    // The TAGMSG is the event; its companion prose line arrives separately as
+    // a `message`. The store joins the two and keeps the task they describe.
+    const isChannel = ev.channel.startsWith('#') || ev.channel.startsWith('&');
+    if (!isChannel && !useStore.getState().channels.has(ev.channel.toLowerCase())) {
+      s().addChannel(ev.channel);
+    }
+    s().addActEvent(ev.channel, ev);
+  });
+
   c.on('messageEdited', (channel, originalMsgId, newText, newMsgId, isStreaming, editorNick, editorAccount) => {
     // Ensure DM buffer exists
     const isChannel = channel.startsWith('#') || channel.startsWith('&');

--- a/freeq-app/src/lib/act-verbs.ts
+++ b/freeq-app/src/lib/act-verbs.ts
@@ -1,0 +1,32 @@
+/**
+ * The word each task verb shows a reader.
+ *
+ * The headline of a card is the word for the verb its event carried — the
+ * verb is on the wire and the client computes nothing from it, so a progress
+ * report never reads as a claim. A verb with no row here shows itself, which
+ * is how a kind may add one without this having to be taught it.
+ */
+const HEADLINE: Record<string, string> = {
+  offer: 'offered',
+  accept: 'accepted',
+  decline: 'declined',
+  claim: 'claimed',
+  progress: 'in progress',
+  complete: 'completed',
+  fail: 'failed',
+  cancel: 'cancelled',
+  bid: 'bid',
+  award: 'awarded',
+  submit: 'submitted',
+  revise: 'revisions requested',
+  'accept-work': 'accepted',
+  forfeit: 'forfeited',
+  // The two the home signs for itself. They write no companion line, so these
+  // words are read in the timeline rather than on a card.
+  confirm: 'confirmed',
+  expire: 'expired',
+};
+
+export function actHeadline(verb: string): string {
+  return HEADLINE[verb] ?? verb;
+}

--- a/freeq-app/src/store.act.test.ts
+++ b/freeq-app/src/store.act.test.ts
@@ -268,3 +268,83 @@ describe('companion lines', () => {
     expect(events[1].msgId).toBeUndefined();
   });
 });
+
+describe('the events that write no line of their own', () => {
+  it('tells the room what the home confirmed', () => {
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('claim', 'e2'));
+    st.addActEvent(CH, move('confirm', 'e3', { 'act-subject': 'e2' }, 'acceptance'));
+
+    const lines = useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem);
+    expect(lines.map((m) => m.text)).toEqual([
+      "confirmed: worker's claim on ship the release",
+    ]);
+  });
+
+  it('says nothing about a move it does not hold', () => {
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('confirm', 'e3', { 'act-subject': 'e2' }, 'acceptance'));
+
+    expect(useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem)).toHaveLength(0);
+  });
+
+  it('says nothing about a task whose opener it never held', () => {
+    // The events replay in a window of their own, so a task's later moves
+    // arrive without the opener that carries its title.
+    const st = useStore.getState();
+    st.addActEvent(CH, move('expire', 'e2', {}, 'acceptance'));
+
+    expect(useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem)).toHaveLength(0);
+  });
+
+  it('tells the room when a task expired', () => {
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('expire', 'e2', {}, 'acceptance'));
+
+    const lines = useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem);
+    expect(lines.map((m) => m.text)).toEqual(['ship the release expired']);
+  });
+
+  it('says when the home moved, not when the line reached us', () => {
+    // A receipt handed back on join is old news: it carries its own time in
+    // the id it was minted under.
+    const at = Date.UTC(2026, 7, 22, 9, 15, 0);
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('expire', idAt(at), {}, 'acceptance'));
+
+    const line = useStore.getState().channels.get(CH)!.messages.find((m) => m.isSystem)!;
+    expect(line.timestamp.getTime()).toBe(at);
+  });
+
+  it('puts a replayed move among the lines it belongs between', () => {
+    const at = Date.UTC(2026, 7, 22, 9, 15, 0);
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addMessage(CH, { ...msg('m-later', 'poster', 'said later', OPENER), timestamp: new Date(at + 60_000) } as any);
+    st.addActEvent(CH, move('expire', idAt(at), {}, 'acceptance'));
+
+    const rows = useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem || m.id === 'm-later');
+    expect(rows.map((m) => m.id)).toEqual([idAt(at), 'm-later']);
+  });
+
+  it('says it once when the event is replayed', () => {
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('expire', 'e2', {}, 'acceptance'));
+    st.addActEvent(CH, move('expire', 'e2', {}, 'acceptance'));
+
+    expect(useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem)).toHaveLength(1);
+  });
+
+  it('leaves every other verb to its card', () => {
+    const st = useStore.getState();
+    st.addActEvent(CH, ev());
+    st.addActEvent(CH, move('progress', 'e2', { 'act-note': 'tagged the build' }));
+
+    expect(useStore.getState().channels.get(CH)!.messages.filter((m) => m.isSystem)).toHaveLength(0);
+  });
+});

--- a/freeq-app/src/store.act.test.ts
+++ b/freeq-app/src/store.act.test.ts
@@ -1,0 +1,270 @@
+/**
+ * The store's task map: what a channel remembers about the work done in it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const storage = new Map<string, string>();
+// @ts-expect-error mock
+globalThis.localStorage = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => { storage.delete(k); },
+  clear: () => storage.clear(),
+  get length() { return storage.size; },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+};
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'uuid-' + Math.random().toString(36).slice(2), subtle: {} },
+  writable: true, configurable: true,
+});
+// @ts-expect-error mock
+globalThis.window = { localStorage: globalThis.localStorage, location: { hash: '' }, addEventListener: () => {} };
+
+const { useStore } = await import('./store');
+
+const CH = '#work';
+const OPENER = '01JOPENER00000000000000000';
+const POSTER = 'did:plc:poster';
+const WORKER = 'did:plc:worker';
+
+beforeEach(() => {
+  storage.clear();
+  useStore.getState().reset();
+  useStore.getState().addChannel(CH);
+});
+
+/** One task event as the bridge hands it over. */
+function ev(overrides: Record<string, any> = {}) {
+  return {
+    from: 'poster',
+    did: POSTER,
+    kind: 'handoff',
+    verb: 'offer',
+    eventId: OPENER,
+    taskId: OPENER,
+    fields: { act: 'handoff', 'act-verb': 'offer', 'act-title': 'ship the release' },
+    ...overrides,
+  };
+}
+
+function move(verb: string, eventId: string, extra: Record<string, string> = {}, who = 'worker', did = WORKER) {
+  return ev({
+    from: who,
+    did,
+    verb,
+    eventId,
+    taskId: OPENER,
+    fields: { act: 'handoff', 'act-verb': verb, 'act-id': OPENER, ...extra },
+  });
+}
+
+function tasks() {
+  return useStore.getState().channels.get(CH)!.actTasks;
+}
+
+function msg(id: string, from: string, text: string, ref: string) {
+  return { id, from, text, timestamp: new Date(), tags: { '+freeq.at/ref': ref } };
+}
+
+/** The id an event minted at that moment carries: a ULID, time first. */
+function idAt(ms: number): string {
+  const crockford = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+  let time = '';
+  for (let i = 0; i < 10; i++) {
+    time = crockford[ms % 32] + time;
+    ms = Math.floor(ms / 32);
+  }
+  return time + 'ZZZZZZZZZZZZZZZZ';
+}
+
+/** A companion line as replay hands it back: the nick as it was sent, and
+ *  the sender's DID under the server's `account` tag. */
+function line(id: string, from: string, text: string, ref: string, did?: string, at?: number) {
+  return {
+    id,
+    from,
+    text,
+    timestamp: new Date(at ?? Date.now()),
+    tags: { '+freeq.at/ref': ref, ...(did ? { account: did } : {}) },
+  };
+}
+
+describe('task map', () => {
+  it('opens a task from an offer, keyed by the opener\'s own id', () => {
+    useStore.getState().addActEvent(CH, ev());
+    const task = tasks().get(OPENER)!;
+    expect(task.taskId).toBe(OPENER);
+    expect(task.events[0].eventId).toBe(OPENER);
+    expect(task.kind).toBe('handoff');
+    expect(task.title).toBe('ship the release');
+    expect(task.offerer).toBe(POSTER);
+    expect(task.verb).toBe('offer');
+  });
+
+  it('takes the assignee from a directed offer', () => {
+    useStore.getState().addActEvent(CH, ev({
+      fields: { act: 'handoff', 'act-verb': 'offer', 'act-title': 't', 'act-to': WORKER },
+    }));
+    expect(tasks().get(OPENER)!.assignee).toBe(WORKER);
+  });
+
+  it('carries the latest verb and appends every move to the event list', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addActEvent(CH, move('claim', 'e2'));
+    s.addActEvent(CH, move('progress', 'e3', { 'act-note': 'tagged the build' }));
+    s.addActEvent(CH, move('complete', 'e4'));
+
+    const task = tasks().get(OPENER)!;
+    expect(task.verb).toBe('complete');
+    expect(task.assignee).toBe(WORKER);
+    expect(task.note).toBe('tagged the build');
+    expect(task.events.map((e) => e.verb)).toEqual(['offer', 'claim', 'progress', 'complete']);
+  });
+
+  it('collects each context link with the hash its signature covers', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addActEvent(CH, move('progress', 'e2', {
+      'act-ctx': 'https://example.com/checks/abc',
+      'act-ctx-h': 'sha256:9f00',
+    }));
+    s.addActEvent(CH, move('complete', 'e3', { 'act-ctx': 'https://example.com/article' }));
+
+    expect(tasks().get(OPENER)!.ctx).toEqual([
+      { url: 'https://example.com/checks/abc', hash: 'sha256:9f00' },
+      { url: 'https://example.com/article', hash: undefined },
+    ]);
+  });
+
+  it('resolves an award to the bidder whose bid it names', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev({ kind: 'bounty' }));
+    s.addActEvent(CH, move('bid', 'bid-worker', {}, 'worker', WORKER));
+    s.addActEvent(CH, move('bid', 'bid-rival', {}, 'rival', 'did:plc:rival'));
+    s.addActEvent(CH, move('award', 'e4', { 'act-accepts': 'bid-rival' }, 'poster', POSTER));
+
+    expect(tasks().get(OPENER)!.assignee).toBe('did:plc:rival');
+  });
+
+  it('changes nothing when an event is replayed', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addActEvent(CH, move('claim', 'e2'));
+    const before = tasks().get(OPENER)!;
+
+    s.addActEvent(CH, ev());
+    s.addActEvent(CH, move('claim', 'e2'));
+
+    expect(tasks().get(OPENER)).toBe(before);
+    expect(before.events).toHaveLength(2);
+  });
+});
+
+describe('companion lines', () => {
+  it('joins each event to the line its sender wrote beside it', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addMessage(CH, msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+    s.addActEvent(CH, move('claim', 'e2'));
+    s.addMessage(CH, msg('m2', 'worker', 'claimed the task', OPENER) as any);
+
+    expect(tasks().get(OPENER)!.events.map((e) => e.msgId)).toEqual(['m1', 'm2']);
+  });
+
+  it('joins them when the line arrives before the event', () => {
+    const s = useStore.getState();
+    s.addMessage(CH, msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+    s.addActEvent(CH, ev());
+
+    expect(tasks().get(OPENER)!.events[0].msgId).toBe('m1');
+  });
+
+  it('joins a line that comes back through history to an event already filed', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.mergeHistory(CH, [msg('m1', 'poster', 'offered: ship the release', OPENER) as any]);
+
+    expect(tasks().get(OPENER)!.events[0].msgId).toBe('m1');
+  });
+
+  it('joins a line that lands with a batch', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.startBatch('b1', 'chathistory', CH);
+    s.addBatchMessage('b1', msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+    s.endBatch('b1');
+
+    expect(tasks().get(OPENER)!.events[0].msgId).toBe('m1');
+  });
+
+  it('joins them by DID when the two sides spell the nick differently', () => {
+    // Replay hands the event back under the lowercased nick the server holds
+    // and the line under the nick as it was sent.
+    const s = useStore.getState();
+    s.addActEvent(CH, ev({ from: 'taskbot', did: POSTER }));
+    s.mergeHistory(CH, [line('m1', 'TaskBot', 'offered: ship the release', OPENER, POSTER) as any]);
+
+    expect(tasks().get(OPENER)!.events[0].msgId).toBe('m1');
+  });
+
+  it('joins them by nick, case aside, when neither side carries a DID', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev({ from: 'taskbot', did: undefined }));
+    s.mergeHistory(CH, [line('m1', 'TaskBot', 'offered: ship the release', OPENER) as any]);
+
+    expect(tasks().get(OPENER)!.events[0].msgId).toBe('m1');
+  });
+
+  it('gives each line the event nearest it in time, not the next one in order', () => {
+    // The lines and the task events replay as two windows that truncate
+    // independently: here the offer's line fell outside its window.
+    const s = useStore.getState();
+    const t0 = Date.UTC(2026, 7, 23, 12, 0, 0);
+    const at = [t0, t0 + 60_000, t0 + 120_000, t0 + 180_000];
+    const ids = at.map(idAt);
+    const st = useStore.getState();
+    st.addActEvent(CH, ev({ from: 'worker', did: WORKER, eventId: ids[0], taskId: ids[0] }));
+    for (const [i, verb] of ['claim', 'progress', 'complete'].entries()) {
+      st.addActEvent(CH, ev({
+        from: 'worker',
+        did: WORKER,
+        verb,
+        eventId: ids[i + 1],
+        taskId: ids[0],
+        fields: { act: 'handoff', 'act-verb': verb, 'act-id': ids[0] },
+      }));
+    }
+    s.mergeHistory(CH, ['claim', 'progress', 'complete'].map((verb, i) =>
+      line(`m-${verb}`, 'worker', `${verb} line`, ids[0], WORKER, at[i + 1]) as any,
+    ));
+
+    expect(tasks().get(ids[0])!.events.map((e) => e.msgId)).toEqual([
+      undefined, 'm-claim', 'm-progress', 'm-complete',
+    ]);
+  });
+
+  it('leaves an event with no companion unpaired', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addMessage(CH, msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+    // The home signs `confirm` itself and writes no line beside it.
+    s.addActEvent(CH, move('confirm', 'e2', {}, 'acceptance', undefined as any));
+
+    const events = tasks().get(OPENER)!.events;
+    expect(events[0].msgId).toBe('m1');
+    expect(events[1].msgId).toBeUndefined();
+  });
+
+  it('keeps a pairing when the same line is replayed', () => {
+    const s = useStore.getState();
+    s.addActEvent(CH, ev());
+    s.addMessage(CH, msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+    s.addActEvent(CH, move('progress', 'e2', {}, 'poster', POSTER));
+    s.addMessage(CH, msg('m1', 'poster', 'offered: ship the release', OPENER) as any);
+
+    const events = tasks().get(OPENER)!.events;
+    expect(events[0].msgId).toBe('m1');
+    expect(events[1].msgId).toBeUndefined();
+  });
+});

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -553,6 +553,35 @@ function pairActCompanions(ch: Channel): void {
   if (changed) ch.actTasks = tasks;
 }
 
+/**
+ * What the room is told about an event that wrote no line of its own.
+ *
+ * The home signs `confirm` and `expire` itself and sends no companion, so
+ * these two are the only events the reader hears about as a system line
+ * rather than a card.
+ */
+function actSystemLine(task: ActTask, ev: ActEventInput): string | undefined {
+  // Both lines name the task by its title, which only the opener carries, and
+  // the opener falls out of the replay window before the events that follow
+  // it do — so with no title held there is nothing to name, and nothing said.
+  const title = task.title;
+  if (!title) return undefined;
+  switch (ev.verb) {
+    case 'confirm': {
+      // The receipt carries only the id of the move it confirms, so the move's
+      // sender and its raw verb are read off that event — and with no such
+      // event held there is nothing to name, and nothing to say.
+      const subject = task.events.find((e) => e.eventId === ev.fields['act-subject']);
+      if (!subject) return undefined;
+      return `confirmed: ${subject.from}'s ${subject.verb} on ${title}`;
+    }
+    case 'expire':
+      return `${title} expired`;
+    default:
+      return undefined;
+  }
+}
+
 /** Who holds the task after this move: named outright on a directed offer,
  *  taken by whoever claims or accepts it, and on an award the bidder whose
  *  bid was chosen — `act-accepts` names the bid, not the bidder. */
@@ -1592,6 +1621,29 @@ export const useStore = create<Store>((set, get) => ({
 
     const ch: Channel = { ...base, actTasks };
     pairActCompanions(ch);
+
+    const line = actSystemLine(actTasks.get(ev.taskId)!, ev);
+    if (line) {
+      // When the home moved, off the id it minted the event under — a receipt
+      // handed back on join is old news, and saying "now" would date it wrong
+      // and file it under the newest thing said.
+      const at = actEventTime(ev.eventId);
+      const said = at === undefined ? new Date() : new Date(at);
+      // Keyed by the event id, so the repeat a joiner is handed lands on the
+      // dedup above rather than printing the line twice.
+      const row: Message = {
+        id: ev.eventId,
+        from: '',
+        text: line,
+        timestamp: said,
+        tags: {},
+        isSystem: true,
+      };
+      let i = ch.messages.length;
+      while (i > 0 && (ch.messages[i - 1].timestamp?.getTime?.() ?? 0) > said.getTime()) i--;
+      ch.messages = [...ch.messages.slice(0, i), row, ...ch.messages.slice(i)].slice(-1000);
+    }
+
     const channels = new Map(s.channels);
     channels.set(key, ch);
     return { channels };

--- a/freeq-app/src/store.ts
+++ b/freeq-app/src/store.ts
@@ -65,6 +65,53 @@ export interface PinnedMessage {
   pinned_at: number;
 }
 
+/** A link an event carried as context, with the hash its signature covers. */
+export interface ActCtxLink {
+  url: string;
+  hash?: string;
+}
+
+/** One move on a task, in the order it arrived. */
+export interface ActEvent {
+  eventId: string;
+  verb: string;
+  from: string;
+  did?: string;
+  /** Every `act-` tag of the event, keyed as the SDK hands them over — so a
+   *  note reads as `act-note` and the kind itself as `act`. */
+  fields: Record<string, string>;
+  /** The companion line's msgid, once it has arrived. The home's own
+   *  `confirm` and `expire` send no companion and keep none. */
+  msgId?: string;
+}
+
+/** A task as this channel has seen it, keyed by its opener's event id. */
+export interface ActTask {
+  taskId: string;
+  kind: string;
+  title: string;
+  /** Who opened it, and who holds it — `act-to` on a directed offer, else
+   *  whoever claimed it or was awarded it. */
+  offerer?: string;
+  assignee?: string;
+  /** The latest move made on it, and the latest note anyone attached. */
+  verb: string;
+  note?: string;
+  ctx: ActCtxLink[];
+  events: ActEvent[];
+}
+
+/** What the bridge hands over from the SDK's `actEvent`. */
+export interface ActEventInput {
+  from: string;
+  did?: string;
+  kind: string;
+  verb: string;
+  eventId: string;
+  taskId: string;
+  fields: Record<string, string>;
+}
+
 export interface Channel {
   name: string;
   topic: string;
@@ -93,6 +140,8 @@ export interface Channel {
    *  held — so it says nothing about whether paging back is getting
    *  anywhere. */
   historyFetchAnchored: boolean;
+  /** The tasks this channel has seen, keyed by the opener's event id. */
+  actTasks: Map<string, ActTask>;
 }
 
 /**
@@ -339,6 +388,7 @@ export interface Store {
   setPins: (channel: string, pins: PinnedMessage[]) => void;
   addPin: (channel: string, msgid: string, pinnedBy: string) => void;
   removePin: (channel: string, msgid: string) => void;
+  addActEvent: (channel: string, ev: ActEventInput) => void;
   setSearchQuery: (query: string) => void;
   setChannelListOpen: (open: boolean) => void;
   setChannelList: (list: ChannelListEntry[]) => void;
@@ -396,10 +446,134 @@ function getOrCreateChannel(channels: Map<string, Channel>, name: string): Chann
       historyFetching: false,
       historyAutoPaused: false,
       historyFetchAnchored: false,
+      actTasks: new Map(),
     };
     channels.set(key, ch);
   }
   return ch;
+}
+
+/** Crockford base32, as ULIDs use it. */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/**
+ * When an event was minted, off the ULID it is named by — the only time an
+ * event carries. Undefined for an id that is not a ULID, so ids the server
+ * never minted (a test's, a peer's own spelling) fall back to arrival order.
+ */
+function actEventTime(eventId: string): number | undefined {
+  if (eventId.length !== 26) return undefined;
+  let ms = 0;
+  for (const c of eventId.slice(0, 10)) {
+    const digit = CROCKFORD.indexOf(c);
+    if (digit < 0) return undefined;
+    ms = ms * 32 + digit;
+  }
+  return ms;
+}
+
+/**
+ * Whether a line was written by the sender an event names: the DID when both
+ * sides carry one, the nick otherwise — case aside, since replay hands back
+ * the event under the lowercased nick the server holds and the line under the
+ * nick as it was sent.
+ */
+function actSameSender(ev: ActEvent, m: Message): boolean {
+  const lineDid = m.tags?.['account'];
+  if (ev.did && lineDid) return ev.did === lineDid;
+  return ev.from.toLowerCase() === m.from.toLowerCase();
+}
+
+/**
+ * Join each task event to the companion line carrying its prose.
+ *
+ * The companion names only the task (`+freeq.at/ref`), never the event, so
+ * the two are matched by their sender and then by how close in time they are:
+ * a joiner is handed the lines and the task events as two windows that
+ * truncate independently, so a line missing from its window must leave its
+ * event unpaired rather than shift every later line onto the wrong event.
+ * Either side can land first, so this runs from both, and never re-pairs what
+ * it has already paired: the message list is capped, and an evicted companion
+ * must not shift its successors.
+ */
+function pairActCompanions(ch: Channel): void {
+  if (ch.actTasks.size === 0) return;
+  const claimed = new Set<string>();
+  for (const task of ch.actTasks.values()) {
+    for (const ev of task.events) if (ev.msgId) claimed.add(ev.msgId);
+  }
+  const free = new Map<string, Message[]>();
+  for (const m of ch.messages) {
+    const ref = m.tags?.['+freeq.at/ref'];
+    if (!ref || claimed.has(m.id) || !ch.actTasks.has(ref)) continue;
+    const list = free.get(ref);
+    if (list) list.push(m);
+    else free.set(ref, [m]);
+  }
+  if (free.size === 0) return;
+  let changed = false;
+  const tasks = new Map(ch.actTasks);
+  for (const [id, task] of tasks) {
+    const lines = free.get(id);
+    if (!lines) continue;
+    // Every line each unpaired event could take, nearest in time first, and
+    // in arrival order where neither side dates itself.
+    const near: { ev: number; line: number; gap: number }[] = [];
+    task.events.forEach((ev, evIdx) => {
+      if (ev.msgId) return;
+      const at = actEventTime(ev.eventId);
+      lines.forEach((m, lineIdx) => {
+        if (!actSameSender(ev, m)) return;
+        const wrote = m.timestamp?.getTime?.();
+        const gap =
+          at !== undefined && wrote !== undefined && !Number.isNaN(wrote)
+            ? Math.abs(wrote - at)
+            : Infinity;
+        near.push({ ev: evIdx, line: lineIdx, gap });
+      });
+    });
+    near.sort((a, b) => (a.gap === b.gap ? a.ev - b.ev || a.line - b.line : a.gap - b.gap));
+    const pairedTo = new Map<number, string>();
+    const used = new Set<number>();
+    for (const { ev, line } of near) {
+      if (pairedTo.has(ev) || used.has(line)) continue;
+      pairedTo.set(ev, lines[line].id);
+      used.add(line);
+    }
+    if (pairedTo.size === 0) continue;
+    tasks.set(id, {
+      ...task,
+      events: task.events.map((ev, evIdx) => {
+        const msgId = pairedTo.get(evIdx);
+        return msgId ? { ...ev, msgId } : ev;
+      }),
+    });
+    changed = true;
+  }
+  if (changed) ch.actTasks = tasks;
+}
+
+/** Who holds the task after this move: named outright on a directed offer,
+ *  taken by whoever claims or accepts it, and on an award the bidder whose
+ *  bid was chosen — `act-accepts` names the bid, not the bidder. */
+function actAssignee(
+  prior: ActTask | undefined,
+  ev: ActEventInput,
+  events: ActEvent[],
+): string | undefined {
+  switch (ev.verb) {
+    case 'offer':
+      return ev.fields['act-to'] ?? prior?.assignee;
+    case 'claim':
+    case 'accept':
+      return ev.did ?? ev.from;
+    case 'award': {
+      const bid = events.find((e) => e.eventId === ev.fields['act-accepts']);
+      return bid ? bid.did ?? bid.from : prior?.assignee;
+    }
+    default:
+      return prior?.assignee;
+  }
 }
 
 export const useStore = create<Store>((set, get) => ({
@@ -827,6 +1001,7 @@ export const useStore = create<Store>((set, get) => ({
       historyFetching: false,
       historyAutoPaused: false,
       historyFetchAnchored: false,
+      actTasks: new Map(),
     };
     // Always produce a fresh Channel object so subscribers comparing
     // channel identity (Sidebar, MessageList children, etc.) see a new
@@ -847,6 +1022,10 @@ export const useStore = create<Store>((set, get) => ({
           ? base.unreadCount + 1
           : base.unreadCount,
     };
+
+    // A companion line is the row that becomes a task's card, so joining it
+    // to its event has to happen wherever it lands — live or in replay.
+    if (msg.tags?.['+freeq.at/ref']) pairActCompanions(ch);
 
     const channels = new Map(s.channels);
     channels.set(key, ch);
@@ -924,6 +1103,9 @@ export const useStore = create<Store>((set, get) => ({
     // MESSAGE_WINDOW would drop the page that was just fetched. The window
     // grows to hold whatever comes back, with no ceiling above it.
     ch.messages = merged;
+    // A joiner's replay caps lines and task events separately, so a line
+    // whose event is already here arrives by history, and pairs here.
+    if (novel.some((m) => m.tags?.['+freeq.at/ref'])) pairActCompanions(ch);
     channels.set(channel.toLowerCase(), ch);
     return { channels };
   }),
@@ -1206,6 +1388,9 @@ export const useStore = create<Store>((set, get) => ({
     // Batch messages go at the beginning (history) — same window rule as
     // mergeHistory: keep the fetched page, with no ceiling above it.
     ch.messages = [...newMsgs, ...ch.messages];
+    // The batch is where a line lands, so it is where a line is joined to
+    // the event it belongs to — the same as live and as a history merge.
+    if (newMsgs.some((m) => m.tags?.['+freeq.at/ref'])) pairActCompanions(ch);
     channels.set(batch.target.toLowerCase(), ch);
     return { channels, batches };
   }),
@@ -1355,6 +1540,60 @@ export const useStore = create<Store>((set, get) => ({
       ch.pins = ch.pins.filter(p => p.msgid !== msgid);
       channels.set(channel.toLowerCase(), { ...ch });
     }
+    return { channels };
+  }),
+  addActEvent: (channel, ev) => set((s) => {
+    const key = channel.toLowerCase();
+    const base: Channel = s.channels.get(key) ?? {
+      name: channel,
+      topic: '',
+      members: new Map(),
+      messages: [],
+      modes: new Set<string>(),
+      isEncrypted: false,
+      unreadCount: 0,
+      mentionCount: 0,
+      isJoined: false,
+      pins: [],
+      typingUsers: new Map(),
+      historyEdge: 'unknown',
+      historyFetching: false,
+      historyAutoPaused: false,
+      historyFetchAnchored: false,
+      actTasks: new Map(),
+    };
+
+    const prior = base.actTasks.get(ev.taskId);
+    // Dedup by event id — a joiner is handed the same events twice, once by
+    // the JOIN replay and once by the CHATHISTORY it asks for next.
+    if (prior?.events.some((e) => e.eventId === ev.eventId)) return {};
+
+    const events: ActEvent[] = [
+      ...(prior?.events ?? []),
+      { eventId: ev.eventId, verb: ev.verb, from: ev.from, did: ev.did, fields: ev.fields },
+    ];
+    const ctx = ev.fields['act-ctx'];
+    const actTasks = new Map(base.actTasks);
+    actTasks.set(ev.taskId, {
+      taskId: ev.taskId,
+      kind: ev.kind || prior?.kind || '',
+      title: ev.fields['act-title'] ?? prior?.title ?? '',
+      // An opener names no other task, so its own id is the task's — which
+      // is what makes it the opener, and its sender the offerer.
+      offerer: ev.eventId === ev.taskId ? ev.did ?? ev.from : prior?.offerer,
+      assignee: actAssignee(prior, ev, events),
+      verb: ev.verb,
+      note: ev.fields['act-note'] ?? prior?.note,
+      ctx: ctx
+        ? [...(prior?.ctx ?? []), { url: ctx, hash: ev.fields['act-ctx-h'] }]
+        : prior?.ctx ?? [],
+      events,
+    });
+
+    const ch: Channel = { ...base, actTasks };
+    pairActCompanions(ch);
+    const channels = new Map(s.channels);
+    channels.set(key, ch);
     return { channels };
   }),
   setSearchQuery: (query) => set({ searchQuery: query }),

--- a/freeq-bot-kit-js/examples/act-acceptance.ts
+++ b/freeq-bot-kit-js/examples/act-acceptance.ts
@@ -260,7 +260,20 @@ async function main() {
     const late = await spawnBot('acceptance-latecomer');
     await sleep(2000);
     const replayed = late.seen.raw.filter((l) => l.includes('+freeq.at/act='));
-    check(replayed.length > 0, `task events replayed on join (${replayed.length} lines)`);
+    // Every stored event reaches a joiner twice: the channel replays history
+    // at JOIN, and sdk-js then asks for CHATHISTORY, which answers with the
+    // same rows. Counted exactly, so either half changing is visible here
+    // rather than passing as "some lines arrived".
+    const stored = (
+      await Promise.all(
+        [declined, task, revived].map(async (id) =>
+          (await api(`/api/v1/actions/${id}`)).events.length),
+      )
+    ).reduce((a, b) => a + b, 0);
+    check(
+      replayed.length === stored * 2,
+      `every stored task event replayed on join, twice over (${replayed.length} lines, ${stored} events)`,
+    );
     check(
       replayed.some((l) => l.includes('+freeq.at/sig=')),
       'with their signatures, so a late arrival can check them',

--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -367,6 +367,23 @@ describe('messaging methods', () => {
     expect(client.getNickForDid('did:plc:bob')).toBe('bob'); // binding learned
   });
 
+  it('a replayed line whose batch was never opened arrives as history', async () => {
+    // The envelope can be missed — a reconnect mid-replay, an open lost to
+    // the login burst — and the line inside it still says it is a replay.
+    // Handing it over as live filed day-old rows under the newest thing said.
+    const { client, ws } = await makeRegistered();
+    const live: string[] = [];
+    const history: Array<[string, number]> = [];
+    client.on('message', (channel) => live.push(channel));
+    client.on('historyBatch', (channel, msgs) => history.push([channel, msgs.length]));
+
+    ws.recv('@batch=gone;time=2026-08-22T10:00:00.000Z;msgid=m1 :bob!b@h PRIVMSG #room :old news');
+    for (let i = 0; i < 4; i++) await flushAsync();
+
+    expect(live).toEqual([]);
+    expect(history).toEqual([['#room', 1]]);
+  });
+
   it('sendMarkdown() resolves the DM target like sendMessage', async () => {
     const { client, ws } = await makeRegistered();
     client.nickToDid = (n) => (n.toLowerCase() === 'bob' ? 'did:plc:bob' : undefined);

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -2251,8 +2251,16 @@ export class FreeqClient extends EventEmitter {
 
         // Check if this message belongs to a batch
         const batchId = msg.tags['batch'];
-        if (batchId && this.batches.has(batchId)) {
-          this.batches.get(batchId)!.messages.push(message);
+        if (batchId) {
+          const batch = this.batches.get(batchId);
+          if (batch) {
+            batch.messages.push(message);
+            break;
+          }
+          // A line naming a batch we never saw opened is still a replay: the
+          // envelope was missed, not the line. It goes over as history, which
+          // the app files by time, rather than as something just said.
+          this.emit('historyBatch', bufName, [message]);
           break;
         }
 


### PR DESCRIPTION

#65 gave both SDKs a generic send and receive for task events (`+freeq.at/act`); no client displays them yet — the TAGMSG never reaches the web store, and the prose line beside it renders as plain chat. This gives them their first face:

- **The bridge subscribes to `actEvent` and the store keeps tasks** — a per-channel map keyed by the opener's event id: kind, title, offerer, assignee, latest verb and note, `act-ctx` links with their hashes, and the full event list. Fed live and by replay, deduped by event id at both layers. Each event is joined to the prose line its sender wrote beside it, matched by identity (DID when both sides carry one, else case-insensitive nick — replay serves the two halves with different nick casing) and by nearest time within a task and sender (the replay windows for lines and events truncate independently, so positional matching mis-pairs).
- **Every event's line becomes a card**, in the `CardFrame` shell the coordination cards use, headlined by the word for the verb it carries — offered, claimed, in progress, completed, and so on; a verb with no word shows itself, so a new kind needs no client change. One card per event, kept, matching how coordination cards behave. The home's own `confirm`/`expire` events carry no line and print as system rows, stamped and placed by the time in the event's ULID. Clicking a card opens the task's history over `GET /api/v1/actions/{id}`, each move under its verb's word with a per-event signature check; the coordination family keeps its own route and view.
- **Cards link "← prev" / "next →"** to walk a task's history through the existing jump-to-message scroll.
- **Two SDK fixes surfaced by replay testing:** an act TAGMSG inside a history batch is delivered with the batch instead of racing it, and a replayed plain line whose batch envelope the client never saw opened is handed over as history instead of filing a day-old row under the newest thing in the room. The second is this branch's one `freeq-sdk-js` change beyond tests.

Tests: 915 web unit tests (store, cards, timeline, headline words), a wire-level Playwright lifecycle driven by a signed did:key peer through a real connection — capitalized nick, mid-lifecycle reload — plus the existing e2e suite unchanged against base. The Phase 4 acceptance script's replay assertion tightened to an exact count. SDK 444, bot-kit 366.
