### PR TITLE
fix(sdk-js): only match the handle on 671 lines that start with 'AT Protocol handle'

### DIFF
--- a/freeq-sdk-js/src/client.test.ts
+++ b/freeq-sdk-js/src/client.test.ts
@@ -626,7 +626,7 @@ describe('requestWhois', () => {
     expect(ws.sent).toContain('WHOIS bob');
     ws.recv(':srv 311 alice bob ~user host.example * :Bob');
     ws.recv(':srv 330 alice bob did:plc:bob123 :is authenticated as');
-    ws.recv(':srv 671 alice bob bob.bsky.social :is using a registered handle');
+    ws.recv(':srv 671 alice bob :AT Protocol handle: bob.bsky.social');
     ws.recv(':srv 318 alice bob :End of WHOIS list');
     await flushAsync();
     const info = await promise;
@@ -636,6 +636,30 @@ describe('requestWhois', () => {
     expect(info.did).toBe('did:plc:bob123');
     expect(info.handle).toBe('bob.bsky.social');
     expect(typeof info.fetchedAt).toBe('number');
+  });
+
+  it('does not treat a "client:" 671 info line as the handle', async () => {
+    const { client, ws } = await makeRegistered();
+    const promise = client.requestWhois('guest1');
+    await flushAsync();
+    ws.recv(':srv 311 alice guest1 ~user host.example * :Guest');
+    ws.recv(':srv 671 alice guest1 :client: Hermes');
+    ws.recv(':srv 318 alice guest1 :End of WHOIS list');
+    await flushAsync();
+    const info = await promise;
+    expect(info.handle).toBeUndefined();
+  });
+
+  it('does not treat a "linked" 671 info line as the handle', async () => {
+    const { client, ws } = await makeRegistered();
+    const promise = client.requestWhois('bob');
+    await flushAsync();
+    ws.recv(':srv 311 alice bob ~user host.example * :Bob');
+    ws.recv(':srv 671 alice bob :linked github: bobdev');
+    ws.recv(':srv 318 alice bob :End of WHOIS list');
+    await flushAsync();
+    const info = await promise;
+    expect(info.handle).toBeUndefined();
   });
 
   it('rejects on timeout', async () => {

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -2722,14 +2722,17 @@ export class FreeqClient extends EventEmitter {
       }
       case '671': {
         const whoisNick = msg.params[1] || '';
-        const handle = msg.params[2]?.trim();
-        this.emit('whois', whoisNick, { handle });
+        const info = msg.params[2]?.trim() ?? '';
         const lc = whoisNick.toLowerCase();
-        const buf = this._whoisBuffer.get(lc) ?? { nick: whoisNick, fetchedAt: 0 };
-        buf.handle = handle;
-        this._whoisBuffer.set(lc, buf);
+        const handle = info.match(/^AT Protocol handle:\s*(\S+)$/)?.[1];
+        if (handle) {
+          this.emit('whois', whoisNick, { handle });
+          const buf = this._whoisBuffer.get(lc) ?? { nick: whoisNick, fetchedAt: 0 };
+          buf.handle = handle;
+          this._whoisBuffer.set(lc, buf);
+        }
         if (!this.backgroundWhois.has(lc)) {
-          this.emit('systemMessage', 'server', `  Handle: ${handle}`);
+          this.emit('systemMessage', 'server', `  ${info}`);
         }
         break;
       }


### PR DESCRIPTION
When logging in as a guest the atproto handle line was using the client string.

The handle in this example links out to: `https://bsky.app/profile/client:%20ExampleClient`

<img width="241" height="383" alt="Screenshot 2026-08-24 at 12 40 50" src="https://github.com/user-attachments/assets/9a7cc1c1-ecf4-4068-b2a5-ec90c1d9e859" />

This PR ensures that the handle string matches `AT Protocol handle` before setting it.

<img width="250" height="311" alt="Screenshot 2026-08-24 at 12 43 18" src="https://github.com/user-attachments/assets/bb33ad52-529f-4461-9555-a0bb050fbae1" />

The handle is now stored stripped (so `AT Protocol handle: myhandle` becomes just `myhandle`).