### PR TITLE
Hide restricted channel rosters from non-members in NAMES and WHO

### DIFF
--- a/freeq-server/src/connection/channel.rs
+++ b/freeq-server/src/connection/channel.rs
@@ -2089,17 +2089,12 @@ pub(super) fn handle_names(
     let nick_list: Vec<String> = {
         let channels = state.channels.lock();
         let (member_sessions, remote_members, ops, voiced) = match channels.get(channel) {
-            Some(ch)
-                if state.channel_is_discoverable(channel, ch)
-                    || ch.members.contains(session_id) =>
-            {
-                (
-                    ch.members.clone(),
-                    ch.remote_members.clone(),
-                    ch.ops.clone(),
-                    ch.voiced.clone(),
-                )
-            }
+            Some(ch) if state.channel_visible_to(channel, ch, session_id) => (
+                ch.members.clone(),
+                ch.remote_members.clone(),
+                ch.ops.clone(),
+                ch.voiced.clone(),
+            ),
             _ => Default::default(),
         };
         // Read from the guard already held; re-locking here deadlocks
@@ -2206,7 +2201,7 @@ pub(super) fn handle_list(
         // Don't advertise restricted (+i/+k/+E/policy-gated) channels to
         // non-members — listing them only leaks a private channel's existence,
         // name, and topic. Members still see their own channels.
-        if !state.channel_is_discoverable(name, ch) && !ch.members.contains(session_id) {
+        if !state.channel_visible_to(name, ch, session_id) {
             continue;
         }
         let count = ch.members.len() + ch.remote_members.len();

--- a/freeq-server/src/connection/channel.rs
+++ b/freeq-server/src/connection/channel.rs
@@ -2089,13 +2089,18 @@ pub(super) fn handle_names(
     let nick_list: Vec<String> = {
         let channels = state.channels.lock();
         let (member_sessions, remote_members, ops, voiced) = match channels.get(channel) {
-            Some(ch) => (
-                ch.members.clone(),
-                ch.remote_members.clone(),
-                ch.ops.clone(),
-                ch.voiced.clone(),
-            ),
-            None => Default::default(),
+            Some(ch)
+                if state.channel_is_discoverable(channel, ch)
+                    || ch.members.contains(session_id) =>
+            {
+                (
+                    ch.members.clone(),
+                    ch.remote_members.clone(),
+                    ch.ops.clone(),
+                    ch.voiced.clone(),
+                )
+            }
+            _ => Default::default(),
         };
         // Read from the guard already held; re-locking here deadlocks
         // (parking_lot mutexes are not reentrant).

--- a/freeq-server/src/connection/queries.rs
+++ b/freeq-server/src/connection/queries.rs
@@ -93,7 +93,10 @@ pub(super) fn handle_whois(
                 let channels = state.channels.lock();
                 channels
                     .iter()
-                    .filter(|(_, ch)| ch.remote_members.contains_key(target_nick))
+                    .filter(|(name, ch)| {
+                        ch.remote_members.contains_key(target_nick)
+                            && state.channel_visible_to(name, ch, session_id)
+                    })
                     .map(|(name, ch)| {
                         let is_op = rm.did.as_ref().is_some_and(|d| {
                             ch.founder_did.as_deref() == Some(d) || ch.did_ops.contains(d)
@@ -336,6 +339,11 @@ pub(super) fn handle_whois(
         let mut listed: Vec<String> = channels
             .iter()
             .filter_map(|(name, ch)| {
+                // Naming a restricted channel here would hand back exactly what
+                // NAMES and WHO refuse to, keyed by nick instead of channel.
+                if !state.channel_visible_to(name, ch, session_id) {
+                    return None;
+                }
                 // Every session belonging to this person, not just the resolved one.
                 let sessions: Vec<String> = ch
                     .members
@@ -416,9 +424,10 @@ pub(super) fn handle_who(
         // note in channel.rs::handle_names.
         let dids_snapshot = state.session_dids.lock().clone();
         let channels = state.channels.lock();
-        if let Some(ch) = channels.get(&channel).filter(|ch| {
-            state.channel_is_discoverable(&channel, ch) || ch.members.contains(session_id)
-        }) {
+        if let Some(ch) = channels
+            .get(&channel)
+            .filter(|ch| state.channel_visible_to(&channel, ch, session_id))
+        {
             let n2s = state.nick_to_session.lock();
             let away = state.session_away.lock();
 

--- a/freeq-server/src/connection/queries.rs
+++ b/freeq-server/src/connection/queries.rs
@@ -416,7 +416,9 @@ pub(super) fn handle_who(
         // note in channel.rs::handle_names.
         let dids_snapshot = state.session_dids.lock().clone();
         let channels = state.channels.lock();
-        if let Some(ch) = channels.get(&channel) {
+        if let Some(ch) = channels.get(&channel).filter(|ch| {
+            state.channel_is_discoverable(&channel, ch) || ch.members.contains(session_id)
+        }) {
             let n2s = state.nick_to_session.lock();
             let away = state.session_away.lock();
 

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -902,7 +902,7 @@ impl SharedState {
     /// keyed (`+k`), not encrypted-only (`+E`), and not gated by a join policy.
     /// Any restriction means it is effectively private, and advertising its
     /// name/topic to strangers or other tenants only leaks it. Members always
-    /// see their own channels regardless (the callers OR-in membership).
+    /// see their own channels regardless (see `channel_visible_to`).
     pub fn channel_is_discoverable(&self, name: &str, ch: &ChannelState) -> bool {
         if ch.is_mode_restricted() {
             return false;
@@ -913,6 +913,23 @@ impl SharedState {
             return false;
         }
         true
+    }
+
+    /// Can this session see the channel? Shared by LIST, NAMES, WHO, and WHOIS.
+    pub fn channel_visible_to(&self, name: &str, ch: &ChannelState, session_id: &str) -> bool {
+        self.channel_is_discoverable(name, ch) || ch.members.contains(session_id)
+    }
+
+    /// Same, for an HTTP caller who may have several sessions open.
+    /// Empty means anonymous.
+    pub fn channel_visible_to_sessions(
+        &self,
+        name: &str,
+        ch: &ChannelState,
+        viewer_sessions: &[String],
+    ) -> bool {
+        self.channel_is_discoverable(name, ch)
+            || viewer_sessions.iter().any(|s| ch.members.contains(s))
     }
 
     /// Connect-time allowlist (Phase 3.2, opt-in). Returns whether a DID may

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -2583,6 +2583,7 @@ async fn api_user(
 async fn api_user_whois(
     Path(nick): Path<String>,
     State(state): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<WhoisResponse>, StatusCode> {
     let session = state
         .nick_to_session
@@ -2604,11 +2605,29 @@ async fn api_user_whois(
         return Err(StatusCode::NOT_FOUND);
     }
 
+    // Every session the caller holds, resolved before taking `channels` (never
+    // hold both locks at once). Anonymous callers get an empty set, so they see
+    // only the channels the unauthenticated channel list would already name.
+    let caller_sessions: Vec<String> = match caller_did_from_bearer(&state, &headers) {
+        Some(did) => {
+            let session_dids = state.session_dids.lock();
+            session_dids
+                .iter()
+                .filter(|(_, d)| *d == &did)
+                .map(|(s, _)| s.clone())
+                .collect()
+        }
+        None => Vec::new(),
+    };
+
     let channels = if let Some(ref session_id) = session {
         let chans = state.channels.lock();
         chans
             .iter()
-            .filter(|(_, ch)| ch.members.contains(session_id))
+            .filter(|(name, ch)| {
+                ch.members.contains(session_id)
+                    && state.channel_visible_to_sessions(name, ch, &caller_sessions)
+            })
             .map(|(name, _)| name.clone())
             .collect()
     } else {

--- a/freeq-server/tests/names_who_restricted.rs
+++ b/freeq-server/tests/names_who_restricted.rs
@@ -1,0 +1,269 @@
+//! Non-members must not be able to enumerate the roster of a restricted
+//! (+i/+k/+E) channel via NAMES or WHO. Both answer exactly as they would
+//! for a channel that does not exist, so the reply also does not reveal
+//! whether the name is in use.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
+
+use freeq_sdk::did::DidResolver;
+
+async fn start_server() -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        server_name: "test-names-who".to_string(),
+        challenge_timeout_secs: 60,
+        ..Default::default()
+    };
+    let resolver = DidResolver::static_map(HashMap::new());
+    let server = freeq_server::server::Server::with_resolver(config, resolver);
+    server.start().await.unwrap()
+}
+
+async fn run(f: impl FnOnce(SocketAddr) + Send + 'static) {
+    let (addr, _server) = start_server().await;
+    tokio::task::spawn_blocking(move || f(addr)).await.unwrap();
+}
+
+struct C {
+    reader: BufReader<TcpStream>,
+    writer: TcpStream,
+}
+
+impl C {
+    fn connect(addr: SocketAddr, nick: &str) -> Self {
+        let stream = TcpStream::connect(addr).expect("connect");
+        stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+        let writer = stream.try_clone().unwrap();
+        let reader = BufReader::new(stream);
+        let mut c = Self { reader, writer };
+        c.send(&format!("NICK {nick}"));
+        c.send(&format!("USER {nick} 0 * :test"));
+        c
+    }
+
+    fn send(&mut self, line: &str) {
+        writeln!(self.writer, "{line}\r").unwrap();
+        self.writer.flush().ok();
+    }
+
+    fn expect(&mut self, pred: impl Fn(&str) -> bool, desc: &str) -> String {
+        let mut buf = String::new();
+        loop {
+            buf.clear();
+            match self.reader.read_line(&mut buf) {
+                Ok(0) => panic!("EOF waiting for: {desc}"),
+                Ok(_) => {
+                    let line = buf.trim_end();
+                    if line.starts_with("PING") {
+                        let tok = line.strip_prefix("PING ").unwrap_or(":x");
+                        let _ = writeln!(self.writer, "PONG {tok}\r");
+                        let _ = self.writer.flush();
+                        continue;
+                    }
+                    if pred(line) {
+                        return line.to_string();
+                    }
+                }
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::TimedOut
+                        || e.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    panic!("Timeout for: {desc}")
+                }
+                Err(e) => panic!("Error for {desc}: {e}"),
+            }
+        }
+    }
+
+    fn num(&mut self, code: &str) -> String {
+        self.expect(|l| l.split_whitespace().nth(1) == Some(code), code)
+    }
+
+    fn reg(&mut self) -> String {
+        self.num("001")
+    }
+
+    /// Read until the given end numeric arrives, returning every line of the
+    /// other numeric collected on the way. Used to assert a WHO/NAMES answer
+    /// carries no roster rows before its end marker.
+    fn collect_until(&mut self, collect: &str, end: &str) -> Vec<String> {
+        let mut rows = Vec::new();
+        loop {
+            let line = self.expect(
+                |l| {
+                    let code = l.split_whitespace().nth(1);
+                    code == Some(collect) || code == Some(end)
+                },
+                &format!("{collect} or {end}"),
+            );
+            if line.split_whitespace().nth(1) == Some(end) {
+                return rows;
+            }
+            rows.push(line);
+        }
+    }
+}
+
+/// Create a channel with the given restrictive mode and one member (alice).
+fn restricted_channel(addr: SocketAddr, channel: &str, mode: &str) -> C {
+    let mut alice = C::connect(addr, "alice");
+    alice.reg();
+    alice.send(&format!("JOIN {channel}"));
+    alice.num("366");
+    alice.send(&format!("MODE {channel} {mode}"));
+    alice.expect(
+        |l| l.contains("MODE") && l.contains(channel),
+        "mode confirmation",
+    );
+    alice
+}
+
+#[tokio::test]
+async fn names_on_keyed_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("NAMES #priv");
+        let rows = bob.collect_until("353", "366");
+        for row in rows {
+            assert!(
+                !row.contains("alice"),
+                "non-member NAMES leaked roster: {row}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn names_on_invite_only_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#invite", "+i");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("NAMES #invite");
+        let rows = bob.collect_until("353", "366");
+        for row in rows {
+            assert!(
+                !row.contains("alice"),
+                "non-member NAMES leaked roster: {row}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn names_on_restricted_channel_matches_nonexistent_channel() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+
+        bob.send("NAMES #priv");
+        let restricted_rows = bob.collect_until("353", "366");
+        bob.send("NAMES #no-such-channel");
+        let missing_rows = bob.collect_until("353", "366");
+
+        let strip = |rows: Vec<String>| -> Vec<String> {
+            rows.into_iter()
+                .map(|r| r.split(':').next_back().unwrap_or_default().to_string())
+                .collect()
+        };
+        assert_eq!(
+            strip(restricted_rows),
+            strip(missing_rows),
+            "restricted channel is distinguishable from a nonexistent one"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn who_on_keyed_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("WHO #priv");
+        let rows = bob.collect_until("352", "315");
+        assert!(rows.is_empty(), "non-member WHO leaked roster: {rows:?}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn who_on_invite_only_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#invite", "+i");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("WHO #invite");
+        let rows = bob.collect_until("352", "315");
+        assert!(rows.is_empty(), "non-member WHO leaked roster: {rows:?}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn members_still_see_restricted_channel_roster() {
+    run(|addr| {
+        let mut alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("JOIN #priv sekrit");
+        bob.num("366");
+
+        bob.send("NAMES #priv");
+        let names = bob.collect_until("353", "366");
+        assert!(
+            names.iter().any(|r| r.contains("alice")),
+            "member NAMES lost the roster: {names:?}"
+        );
+
+        bob.send("WHO #priv");
+        let who = bob.collect_until("352", "315");
+        assert!(
+            who.iter().any(|r| r.contains("alice")),
+            "member WHO lost the roster: {who:?}"
+        );
+
+        // The member who set the mode still sees it too.
+        alice.send("NAMES #priv");
+        let names = alice.collect_until("353", "366");
+        assert!(names.iter().any(|r| r.contains("bob")));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn public_channel_roster_stays_visible_to_non_members() {
+    run(|addr| {
+        let mut alice = C::connect(addr, "alice");
+        alice.reg();
+        alice.send("JOIN #open");
+        alice.num("366");
+
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+
+        bob.send("NAMES #open");
+        let names = bob.collect_until("353", "366");
+        assert!(
+            names.iter().any(|r| r.contains("alice")),
+            "public NAMES broke for non-members: {names:?}"
+        );
+
+        bob.send("WHO #open");
+        let who = bob.collect_until("352", "315");
+        assert!(
+            who.iter().any(|r| r.contains("alice")),
+            "public WHO broke for non-members: {who:?}"
+        );
+    })
+    .await;
+}

--- a/freeq-server/tests/names_who_restricted.rs
+++ b/freeq-server/tests/names_who_restricted.rs
@@ -1,7 +1,8 @@
 //! Non-members must not be able to enumerate the roster of a restricted
-//! (+i/+k/+E) channel via NAMES or WHO. Both answer exactly as they would
-//! for a channel that does not exist, so the reply also does not reveal
-//! whether the name is in use.
+//! (+i/+k/+E) channel via NAMES or WHO, nor reach the same names from the
+//! other side with WHOIS. NAMES and WHO answer exactly as they would for a
+//! channel that does not exist, so the reply also does not reveal whether
+//! the name is in use.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
@@ -178,6 +179,92 @@ async fn names_on_restricted_channel_matches_nonexistent_channel() {
             strip(restricted_rows),
             strip(missing_rows),
             "restricted channel is distinguishable from a nonexistent one"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn names_on_encrypted_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#enc", "+E");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("NAMES #enc");
+        let rows = bob.collect_until("353", "366");
+        for row in rows {
+            assert!(
+                !row.contains("alice"),
+                "non-member NAMES leaked roster: {row}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn who_on_encrypted_channel_hides_members_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#enc", "+E");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("WHO #enc");
+        let rows = bob.collect_until("352", "315");
+        assert!(rows.is_empty(), "non-member WHO leaked roster: {rows:?}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn whois_hides_restricted_channel_from_non_members() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("WHOIS alice");
+        let rows = bob.collect_until("319", "318");
+        assert!(
+            rows.iter().all(|r| !r.contains("#priv")),
+            "non-member WHOIS leaked the channel: {rows:?}"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn whois_still_shows_shared_restricted_channel_to_a_member() {
+    run(|addr| {
+        let _alice = restricted_channel(addr, "#priv", "+k sekrit");
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("JOIN #priv sekrit");
+        bob.num("366");
+
+        bob.send("WHOIS alice");
+        let rows = bob.collect_until("319", "318");
+        assert!(
+            rows.iter().any(|r| r.contains("#priv")),
+            "member WHOIS lost the shared channel: {rows:?}"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn whois_still_shows_public_channels_to_non_members() {
+    run(|addr| {
+        let mut alice = C::connect(addr, "alice");
+        alice.reg();
+        alice.send("JOIN #open");
+        alice.num("366");
+
+        let mut bob = C::connect(addr, "bob");
+        bob.reg();
+        bob.send("WHOIS alice");
+        let rows = bob.collect_until("319", "318");
+        assert!(
+            rows.iter().any(|r| r.contains("#open")),
+            "public WHOIS broke for non-members: {rows:?}"
         );
     })
     .await;


### PR DESCRIPTION
Right now any connected user, including guests, can view a restricted channels (+i, +k, or +E) roster with DIDs by guessing the channel name.

This PR applies LIST's visibility rules to `handle_names` and `handle_who` so that NAMES and WHO will only include the member roster if the channel is discoverable or the requester is a member.