### PR TITLE
Stop phantom channel creation when joining with a key

### DIFF
--- a/freeq-android/freeq/src/main/java/com/freeq/model/JoinTarget.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/JoinTarget.kt
@@ -1,0 +1,23 @@
+package com.freeq.model
+
+/**
+ * A `/join` argument split into the channel to track and the parameter to send.
+ */
+internal data class JoinTarget(
+    /** The channel the server's JOIN echo will name (the first, for a list). */
+    val channel: String,
+    /** The JOIN argument as it goes on the wire, key included. */
+    val line: String,
+) {
+    companion object {
+        /** Null when there is no channel to join. */
+        fun parse(input: String): JoinTarget? {
+            val parts = input.trim().split(" ", limit = 2)
+            val names = parts[0].let { if (it.startsWith("#")) it else "#$it" }
+            val first = names.substringBefore(',')
+            if (first.length <= 1) return null
+            val key = parts.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() }
+            return JoinTarget(first, if (key != null) "$names $key" else names)
+        }
+    }
+}

--- a/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
+++ b/freeq-android/freeq/src/main/java/com/freeq/model/Models.kt
@@ -716,14 +716,14 @@ class AppState(application: Application) : AndroidViewModel(application) {
     // ── Channel operations ──
 
     fun joinChannel(channel: String, navigate: Boolean = true) {
-        val ch = if (channel.startsWith("#")) channel else "#$channel"
+        val target = JoinTarget.parse(channel) ?: return
         // Track for navigation after JOIN confirmation (only for user-initiated joins)
-        if (navigate) pendingJoinChannel = ch
+        if (navigate) pendingJoinChannel = target.channel
         try {
-            client?.join(ch)
+            client?.join(target.line)
         } catch (_: Exception) {
             if (navigate) pendingJoinChannel = null
-            errorMessage.value = "Failed to join $ch"
+            errorMessage.value = "Failed to join ${target.channel}"
         }
     }
 

--- a/freeq-android/freeq/src/test/java/com/freeq/model/JoinTargetTest.kt
+++ b/freeq-android/freeq/src/test/java/com/freeq/model/JoinTargetTest.kt
@@ -1,0 +1,51 @@
+package com.freeq.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for JoinTarget.parse().
+ *
+ * A channel key belongs in the JOIN parameter, not in the channel name. The
+ * name is what the server's JOIN echo carries and what navigation matches on.
+ */
+class JoinTargetTest {
+
+    @Test fun key_goes_on_the_wire_but_not_into_the_channel_name() {
+        val target = JoinTarget.parse("#general hunter2")!!
+        assertEquals("#general", target.channel)
+        assertEquals("#general hunter2", target.line)
+    }
+
+    @Test fun a_channel_with_no_key_is_left_alone() {
+        val target = JoinTarget.parse("#general")!!
+        assertEquals("#general", target.channel)
+        assertEquals("#general", target.line)
+    }
+
+    @Test fun a_bare_name_gets_its_hash() {
+        val target = JoinTarget.parse("general hunter2")!!
+        assertEquals("#general", target.channel)
+        assertEquals("#general hunter2", target.line)
+    }
+
+    @Test fun a_list_joins_whole_but_navigates_to_the_first() {
+        val target = JoinTarget.parse("#a,#b k1,k2")!!
+        assertEquals("#a", target.channel)
+        assertEquals("#a,#b k1,k2", target.line)
+    }
+
+    @Test fun surrounding_space_is_not_a_key() {
+        val target = JoinTarget.parse("  #general  ")!!
+        assertEquals("#general", target.channel)
+        assertEquals("#general", target.line)
+    }
+
+    @Test fun nothing_to_join_is_null() {
+        assertNull(JoinTarget.parse(""))
+        assertNull(JoinTarget.parse("   "))
+        assertNull(JoinTarget.parse("#"))
+        assertNull(JoinTarget.parse("# hunter2"))
+    }
+}

--- a/freeq-app/e2e/channels.spec.ts
+++ b/freeq-app/e2e/channels.spec.ts
@@ -129,4 +129,30 @@ test.describe('Channels', () => {
 
     await ctx.close();
   });
+
+  test('joining with a key does not leave a channel named after the key', async ({ page }) => {
+    const nick = uniqueNick('key');
+    const ch1 = uniqueChannel();
+    const keyed = uniqueChannel();
+    await connectGuest(page, nick, ch1);
+
+    // Own the channel, lock it, leave it.
+    await sendMessage(page, `/join ${keyed}`);
+    await expect((await openSidebar(page)).getByText(keyed)).toBeVisible({ timeout: 10_000 });
+    await sendMessage(page, `/mode ${keyed} +k s3cret`);
+    await page.waitForTimeout(500);
+    await sendMessage(page, `/part ${keyed}`);
+    await page.waitForTimeout(500);
+
+    await sendMessage(page, `/join ${keyed} s3cret`);
+
+    const sidebar = await openSidebar(page);
+    await expect(sidebar.getByText(keyed)).toBeVisible({ timeout: 10_000 });
+    await expect(sidebar).not.toContainText('s3cret');
+
+    // And the key actually got us in: the channel takes messages.
+    await switchChannel(page, keyed);
+    await sendMessage(page, 'inside the locked channel');
+    await expect(page.getByTestId('message-list').getByText('inside the locked channel')).toBeVisible({ timeout: 10_000 });
+  });
 });

--- a/freeq-app/src/components/ComposeBox.join.test.tsx
+++ b/freeq-app/src/components/ComposeBox.join.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/**
+ * Tests for /join argument parsing in ComposeBox.
+ *
+ * Covers the comma-separated channel list, the per-channel keys that follow
+ * it, and the # prefix added to a bare channel name.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('../irc/client', () => ({
+  sendMessage: vi.fn(),
+  sendReply: vi.fn(),
+  sendEdit: vi.fn(),
+  sendMarkdown: vi.fn(),
+  sendAction: vi.fn(),
+  joinChannel: vi.fn(),
+  partChannel: vi.fn(),
+  setTopic: vi.fn(),
+  setMode: vi.fn(),
+  kickUser: vi.fn(),
+  inviteUser: vi.fn(),
+  setAway: vi.fn(),
+  rawCommand: vi.fn(),
+  sendWhois: vi.fn(),
+  startTyping: vi.fn(),
+  stopTyping: vi.fn(),
+  getClient: () => null,
+}));
+
+const { ComposeBox } = await import('./ComposeBox');
+const { useStore } = await import('../store');
+const client = await import('../irc/client');
+
+const s = () => useStore.getState();
+
+/** Type a command into the composer and submit it. */
+function run(command: string) {
+  const input = render(<ComposeBox />).getByTestId('compose-input') as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: command } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  s().reset();
+  s().setNick('me');
+  s().addChannel('#room');
+  s().setActiveChannel('#room');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('/join', () => {
+  it('passes a key as a key, not as part of the channel name', () => {
+    run('/join #general hunter2');
+    expect(client.joinChannel).toHaveBeenCalledWith('#general', 'hunter2');
+  });
+
+  it('joins without a key when none is given', () => {
+    run('/join #general');
+    expect(client.joinChannel).toHaveBeenCalledWith('#general', undefined);
+  });
+
+  it('pairs each key with the channel in the same position', () => {
+    run('/join #a,#b,#c k1,,k3');
+    expect(client.joinChannel).toHaveBeenNthCalledWith(1, '#a', 'k1');
+    expect(client.joinChannel).toHaveBeenNthCalledWith(2, '#b', undefined);
+    expect(client.joinChannel).toHaveBeenNthCalledWith(3, '#c', 'k3');
+  });
+
+  it('still prefixes a bare channel name with #', () => {
+    run('/join general hunter2');
+    expect(client.joinChannel).toHaveBeenCalledWith('#general', 'hunter2');
+  });
+
+  it('reads a space after a comma as part of the list, not as a key', () => {
+    run('/join #a, #b');
+    expect(client.joinChannel).toHaveBeenNthCalledWith(1, '#a', undefined);
+    expect(client.joinChannel).toHaveBeenNthCalledWith(2, '#b', undefined);
+  });
+
+  it('takes spaced-out channels and keys together', () => {
+    run('/join #a , #b k1, k2');
+    expect(client.joinChannel).toHaveBeenNthCalledWith(1, '#a', 'k1');
+    expect(client.joinChannel).toHaveBeenNthCalledWith(2, '#b', 'k2');
+  });
+});

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -852,11 +852,15 @@ function handleCommand(text: string, activeChannel: string) {
     : '';
 
   switch (cmd) {
-    case 'join': case 'j':
-      args.split(',').map((s) => s.trim()).filter(Boolean).forEach((c) =>
-        joinChannel(c.startsWith('#') ? c : `#${c}`)
+    case 'join': case 'j': {
+      // Trim spaces around the commas for multiple channel lists.
+      const [chanList = '', keyList = ''] = args.trim().replace(/\s*,\s*/g, ',').split(/\s+/);
+      const keys = keyList.split(',');
+      chanList.split(',').filter(Boolean).forEach((c, i) =>
+        joinChannel(c.startsWith('#') ? c : `#${c}`, keys[i] || undefined)
       );
       break;
+    }
     case 'part': case 'leave':
       partChannel(args || target);
       break;

--- a/freeq-app/src/irc/client-join.test.ts
+++ b/freeq-app/src/irc/client-join.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * Tests for joinChannel() in irc/client.ts.
+ *
+ * A channel key is sent as a separate JOIN parameter. The channel name,
+ * without the key, is what the store uses to key the channel buffer.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'uuid-' + Math.random().toString(36).slice(2), subtle: {} },
+  writable: true, configurable: true,
+});
+
+type Handler = (...args: unknown[]) => void;
+
+class MockFreeqClient {
+  static latest: MockFreeqClient | null = null;
+  handlers = new Map<string, Handler[]>();
+  joins: Array<[string, string | undefined]> = [];
+  nick = 'me';
+  joinedChannels = new Set<string>();
+  nickToDid: unknown = null;
+  constructor(public opts: unknown) { MockFreeqClient.latest = this; }
+  on(event: string, fn: Handler) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(fn);
+    this.handlers.set(event, list);
+  }
+  join(channel: string, key?: string) { this.joins.push([channel, key]); }
+  requestHistory() { /* not under test */ }
+  requestHistoryTargets() { /* not under test */ }
+  setSaslCredentials() { /* not under test */ }
+  connect() { /* no-op */ }
+  disconnect() { /* no-op */ }
+  getNickForDid() { return undefined; }
+}
+
+vi.mock('@freeq/sdk', () => ({
+  FreeqClient: MockFreeqClient,
+  format: {},
+  prefetchProfiles: () => {},
+  claimForMessage: () => undefined,
+}));
+
+const bridge = await import('./client');
+const { useStore } = await import('../store');
+
+const s = () => useStore.getState();
+
+function connected(): MockFreeqClient {
+  bridge.connect('wss://test/irc', 'me', []);
+  return MockFreeqClient.latest!;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  s().reset();
+  MockFreeqClient.latest = null;
+});
+
+describe('joining a channel that has a key', () => {
+  it('sends the key alongside the channel', () => {
+    const client = connected();
+    bridge.joinChannel('#general', 'hunter2');
+    expect(client.joins.at(-1)).toEqual(['#general', 'hunter2']);
+  });
+
+  it('opens a buffer named for the channel alone', () => {
+    connected();
+    bridge.joinChannel('#general', 'hunter2');
+    expect([...s().channels.keys()]).toContain('#general');
+    expect([...s().channels.keys()]).not.toContain('#general hunter2');
+    expect(s().activeChannel).toBe('#general');
+  });
+
+  it('splits a key that arrives inside the channel string', () => {
+    const client = connected();
+    bridge.joinChannel('#general hunter2');
+    expect(client.joins.at(-1)).toEqual(['#general', 'hunter2']);
+    expect([...s().channels.keys()]).not.toContain('#general hunter2');
+  });
+
+  it('joins without a key when none is given', () => {
+    const client = connected();
+    bridge.joinChannel('#general');
+    expect(client.joins.at(-1)).toEqual(['#general', undefined]);
+  });
+
+  it('ignores an empty channel', () => {
+    const client = connected();
+    bridge.joinChannel('   ');
+    expect(client.joins).toHaveLength(0);
+  });
+});

--- a/freeq-app/src/irc/client.ts
+++ b/freeq-app/src/irc/client.ts
@@ -300,10 +300,13 @@ export function stopTyping(target: string) {
   client?.stopTyping(target);
 }
 
-export function joinChannel(channel: string) {
-  client?.join(channel);
-  useStore.getState().addChannel(channel);
-  useStore.getState().setActiveChannel(channel);
+export function joinChannel(channel: string, key?: string) {
+  // Text is sent with channel and key as one string ("#secretchat hunter2").
+  const [name, inlineKey] = channel.trim().split(/\s+/);
+  if (!name) return;
+  client?.join(name, key ?? inlineKey);
+  useStore.getState().addChannel(name);
+  useStore.getState().setActiveChannel(name);
 }
 
 export function partChannel(channel: string) {

--- a/freeq-sdk-js/src/client.ts
+++ b/freeq-sdk-js/src/client.ts
@@ -678,8 +678,8 @@ export class FreeqClient extends EventEmitter {
   // ── Channel management ──
 
   /** Join a channel. */
-  join(channel: string): void {
-    this.raw(`JOIN ${channel}`);
+  join(channel: string, key?: string): void {
+    this.raw(key ? `JOIN ${channel} ${key}` : `JOIN ${channel}`);
   }
 
   /** Leave a channel. */


### PR DESCRIPTION
When attempting to join a channel with a key (eg. `/join #privatechat secretkey`) the channel will be joined correctly, but another channel called `#privatechat secretkey` is also created. This PR just splits the text on whitespace to correctly separate the channel and key (spaces aren't allowed in channel names anyway). Adds a fix for both the web and android 