### PR TITLE
fix(server): resolve the handle so the domain allowlist can match it

### DIFF
--- a/freeq-sdk/src/did.rs
+++ b/freeq-sdk/src/did.rs
@@ -117,6 +117,29 @@ impl DidDocument {
     }
 }
 
+/// Is this a syntactically valid AT Protocol handle?
+///
+/// A handle is a bare domain name. Anything else names a different host once
+/// it lands in a URL or gets suffix-matched against an allowed domain.
+pub fn is_valid_handle(handle: &str) -> bool {
+    if handle.len() > 253 {
+        return false;
+    }
+    let labels: Vec<&str> = handle.split('.').collect();
+    if labels.len() < 2 {
+        return false;
+    }
+    labels.iter().enumerate().all(|(i, label)| {
+        let valid_chars = label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        let is_tld = i + 1 == labels.len();
+        (1..=63).contains(&label.len())
+            && valid_chars
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && (!is_tld || label.starts_with(|c: char| c.is_ascii_alphabetic()))
+    })
+}
+
 /// DID resolver — resolves DIDs to DID documents.
 ///
 /// Use `DidResolver::http()` for production, `DidResolver::static_map()` for tests.
@@ -137,7 +160,20 @@ impl DidResolver {
 
     /// Create a resolver with pre-loaded DID documents (for testing).
     pub fn static_map(documents: HashMap<String, DidDocument>) -> Self {
-        DidResolver::Static(StaticResolver { documents })
+        DidResolver::Static(StaticResolver {
+            documents,
+            handles: HashMap::new(),
+        })
+    }
+
+    /// Like `static_map`, plus an explicit handle to DID table (for testing).
+    /// When two documents claim the same handle and the test needs to know who
+    /// owns it.
+    pub fn static_map_with_handles(
+        documents: HashMap<String, DidDocument>,
+        handles: HashMap<String, String>,
+    ) -> Self {
+        DidResolver::Static(StaticResolver { documents, handles })
     }
 
     /// Resolve a DID to its DID document.
@@ -152,7 +188,7 @@ impl DidResolver {
     pub async fn resolve_handle(&self, handle: &str) -> Result<String> {
         match self {
             DidResolver::Http(r) => r.resolve_handle(handle).await,
-            DidResolver::Static(_) => bail!("Handle resolution not supported in static mode"),
+            DidResolver::Static(r) => r.resolve_handle(handle),
         }
     }
 }
@@ -236,6 +272,9 @@ impl HttpResolver {
     }
 
     async fn resolve_handle(&self, handle: &str) -> Result<String> {
+        if !is_valid_handle(handle) {
+            bail!("Not a valid handle: {handle}");
+        }
         // Try HTTP well-known first (self-hosted domains)
         let url = format!("https://{handle}/.well-known/atproto-did");
         tracing::debug!("Resolving handle {handle} via {url}");
@@ -295,6 +334,7 @@ impl HttpResolver {
 #[derive(Clone)]
 pub struct StaticResolver {
     documents: HashMap<String, DidDocument>,
+    handles: HashMap<String, String>,
 }
 
 impl StaticResolver {
@@ -307,6 +347,20 @@ impl StaticResolver {
             .get(did)
             .cloned()
             .context(format!("DID not found in static resolver: {did}"))
+    }
+
+    /// Check the explicit handle table first, then fall back to the
+    /// document that claims `handle` in its `alsoKnownAs`.
+    fn resolve_handle(&self, handle: &str) -> Result<String> {
+        if let Some(did) = self.handles.get(handle) {
+            return Ok(did.clone());
+        }
+        let aka = format!("at://{handle}");
+        self.documents
+            .values()
+            .find(|doc| doc.also_known_as.contains(&aka))
+            .map(|doc| doc.id.clone())
+            .context(format!("Handle not found in static resolver: {handle}"))
     }
 }
 
@@ -455,9 +509,55 @@ mod tests {
     }
 
     #[test]
+    fn accepts_ordinary_handles() {
+        assert!(is_valid_handle("alice.bsky.social"));
+        assert!(is_valid_handle("acme.com"));
+        assert!(is_valid_handle("a-b.acme.com"));
+        assert!(is_valid_handle("xn--80ak6aa92e.com"));
+        assert!(is_valid_handle("8bit.acme.com"));
+    }
+
+    #[test]
+    fn rejects_anything_that_would_redirect_the_url_to_another_host() {
+        assert!(!is_valid_handle("evil.com/x.acme.com"));
+        assert!(!is_valid_handle("evil.com?x.acme.com"));
+        assert!(!is_valid_handle("evil.com#x.acme.com"));
+        assert!(!is_valid_handle("evil.com:8443"));
+        assert!(!is_valid_handle("user@evil.com"));
+        assert!(!is_valid_handle("evil.com\\x.acme.com"));
+    }
+
+    #[test]
+    fn rejects_malformed_domains() {
+        assert!(!is_valid_handle("acme"));
+        assert!(!is_valid_handle("acme.com."));
+        assert!(!is_valid_handle(".acme.com"));
+        assert!(!is_valid_handle("alice..acme.com"));
+        assert!(!is_valid_handle("-alice.acme.com"));
+        assert!(!is_valid_handle("alice-.acme.com"));
+        assert!(!is_valid_handle("alice.acme.123"));
+        assert!(!is_valid_handle(&format!("{}.com", "a".repeat(64))));
+        assert!(!is_valid_handle(&format!("{}.com", "a.".repeat(200))));
+    }
+
+    #[tokio::test]
+    async fn resolve_handle_refuses_to_build_a_url_from_a_bad_handle() {
+        let resolver = HttpResolver {
+            client: reqwest::Client::new(),
+            plc_directory: "https://plc.directory".to_string(),
+        };
+        let err = resolver
+            .resolve_handle("evil.com/x.acme.com")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Not a valid handle"));
+    }
+
+    #[test]
     fn static_resolver_handles_did_key() {
         let resolver = StaticResolver {
             documents: HashMap::new(),
+            handles: HashMap::new(),
         };
         let key = PrivateKey::generate_ed25519();
         let did = format!("did:key:{}", key.public_key_multibase());

--- a/freeq-server/src/connection/cap.rs
+++ b/freeq-server/src/connection/cap.rs
@@ -219,13 +219,15 @@ pub(super) async fn handle_authenticate(
     } else if conn.sasl_in_progress {
         if let Some(response) = sasl::decode_response(param) {
             // Check for web-token method first (server-side OAuth pre-verified)
+            let mut web_handle: Option<String> = None;
             let web_token_result = if response.method.as_deref() == Some("web-token") {
                 let mut tokens = state.web_auth_tokens.lock();
-                if let Some((did, _handle, created)) = tokens.remove(&response.signature) {
+                if let Some((did, handle, created)) = tokens.remove(&response.signature) {
                     // Single-use: token consumed on first authentication.
                     // 5-minute TTL limits exposure if a token is leaked.
                     // Broker issues fresh tokens on each /session call for reconnects.
                     if created.elapsed() < std::time::Duration::from_secs(300) {
+                        web_handle = Some(handle);
                         Some(Ok(did.clone()))
                     } else {
                         Some(Err("Web auth token expired".to_string()))
@@ -251,13 +253,18 @@ pub(super) async fn handle_authenticate(
                         )
                         .await
                     };
+                    // Connect-time allowlist, if the instance opted in. A web
+                    // token brings its handle along; the challenge path doesn't.
+                    let allowed = match &verify_result {
+                        Ok(did) => {
+                            state
+                                .did_is_allowed_resolved(did, web_handle.as_deref())
+                                .await
+                        }
+                        Err(_) => true,
+                    };
                     match verify_result {
-                        // Connect-time allowlist (opt-in): reject verified DIDs
-                        // that aren't permitted on this instance. Handle isn't
-                        // resolved on the challenge path, so domain-only
-                        // allowlists gate here by DID only — use the OAuth flow
-                        // for handle-domain matching.
-                        Ok(did) if !state.did_is_allowed(&did, None) => {
+                        Ok(did) if !allowed => {
                             conn.sasl_in_progress = false;
                             conn.sasl_failures += 1;
                             crate::server::Metrics::bump(&state.metrics.sasl_failure_total);
@@ -270,7 +277,11 @@ pub(super) async fn handle_authenticate(
                                 ],
                             );
                             send(state, session_id, format!("{fail}\r\n"));
-                            tracing::warn!(%did, "connection denied by connect allowlist (challenge SASL)");
+                            tracing::warn!(
+                                %did,
+                                method = response.method.as_deref().unwrap_or("crypto"),
+                                "connection denied by connect allowlist"
+                            );
                         }
                         Ok(did) => {
                             conn.authenticated_did = Some(did.clone());

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -104,6 +104,10 @@ pub(crate) fn did_allowed(
     }
     if let Some(h) = handle {
         let h = h.trim_start_matches('@').to_lowercase();
+        // "evil.com/x.acme.com" ends with an allowed domain but isn't in it.
+        if !freeq_sdk::did::is_valid_handle(&h) {
+            return false;
+        }
         if allowed_domains.iter().any(|dom| {
             let dom = dom
                 .trim_start_matches('@')
@@ -926,6 +930,47 @@ impl SharedState {
             did,
             handle,
         )
+    }
+
+    /// Handles the case where the allowlist rejected a DID because the handle
+    /// wasn't in an allowed domain. Admits the DID if any claimed handles match.
+    pub async fn did_is_allowed_resolved(&self, did: &str, handle: Option<&str>) -> bool {
+        if self.did_is_allowed(did, handle) {
+            return true;
+        }
+        if self.config.allowed_did_domains.is_empty() {
+            return false;
+        }
+        let doc = match self.did_resolver.resolve(did).await {
+            Ok(doc) => doc,
+            Err(e) => {
+                tracing::warn!(%did, "allowlist: DID document resolution failed: {e}");
+                return false;
+            }
+        };
+        for aka in &doc.also_known_as {
+            let Some(claimed) = aka.strip_prefix("at://") else {
+                continue;
+            };
+            if self.did_is_allowed(did, Some(claimed)) && self.handle_owned_by(claimed, did).await {
+                return true;
+            }
+        }
+        false
+    }
+
+    async fn handle_owned_by(&self, handle: &str, did: &str) -> bool {
+        match self.did_resolver.resolve_handle(handle).await {
+            Ok(resolved) if resolved == did => true,
+            Ok(resolved) => {
+                tracing::warn!(%did, %handle, %resolved, "allowlist: handle belongs to another DID");
+                false
+            }
+            Err(e) => {
+                tracing::warn!(%did, %handle, "allowlist: handle resolution failed: {e}");
+                false
+            }
+        }
     }
 
     /// Run a closure with the database, if persistence is enabled.
@@ -7720,25 +7765,43 @@ mod s2s_adversarial_tests {
 
     /// Build a minimal SharedState for testing (no DB, no iroh).
     pub(crate) fn test_state() -> Arc<SharedState> {
-        test_state_inner(None, None)
+        test_state_inner(None, None, None)
     }
 
     /// Like `test_state` but with an in-memory SQLite DB attached, so
     /// persistence paths (`identities`, `messages`, …) are exercised. Shared
     /// with other modules' tests (e.g. web endpoints) via the re-export below.
     pub(crate) fn test_state_with_db() -> Arc<SharedState> {
-        test_state_inner(Some(crate::db::Db::open_memory().unwrap()), None)
+        test_state_inner(Some(crate::db::Db::open_memory().unwrap()), None, None)
     }
 
     /// Like `test_state_with_db`, for the flags a test needs to set — the
     /// config is read at runtime, so it cannot be adjusted after construction.
     pub(crate) fn test_state_with_config(config: crate::config::ServerConfig) -> Arc<SharedState> {
-        test_state_inner(Some(crate::db::Db::open_memory().unwrap()), Some(config))
+        test_state_inner(
+            Some(crate::db::Db::open_memory().unwrap()),
+            Some(config),
+            None,
+        )
+    }
+
+    /// Like `test_state_with_config`, for tests where the resolver actually
+    /// needs to answer.
+    pub(crate) fn test_state_with_resolver(
+        config: crate::config::ServerConfig,
+        resolver: freeq_sdk::did::DidResolver,
+    ) -> Arc<SharedState> {
+        test_state_inner(
+            Some(crate::db::Db::open_memory().unwrap()),
+            Some(config),
+            Some(resolver),
+        )
     }
 
     fn test_state_inner(
         db: Option<crate::db::Db>,
         config: Option<crate::config::ServerConfig>,
+        resolver: Option<freeq_sdk::did::DidResolver>,
     ) -> Arc<SharedState> {
         let config = config.unwrap_or_else(|| crate::config::ServerConfig {
             listen_addr: "127.0.0.1:0".to_string(),
@@ -7750,7 +7813,8 @@ mod s2s_adversarial_tests {
         Arc::new(SharedState {
             server_name: config.server_name.clone(),
             challenge_store: crate::sasl::ChallengeStore::new(60),
-            did_resolver: freeq_sdk::did::DidResolver::static_map(HashMap::new()),
+            did_resolver: resolver
+                .unwrap_or_else(|| freeq_sdk::did::DidResolver::static_map(HashMap::new())),
             connections: Mutex::new(HashMap::new()),
             nick_to_session: Mutex::new(NickMap::new()),
             session_dids: Mutex::new(HashMap::new()),
@@ -12996,9 +13060,183 @@ mod allowlist_tests {
 
     #[test]
     fn no_handle_denies_domain_only_allowlist() {
-        // Challenge SASL has no handle → domain-only allowlists can't match.
+        // A domain can't match without a handle; callers fetch one first.
         let doms = v(&["acme.com"]);
         assert!(!did_allowed(&[], &doms, "did:plc:x", None));
+    }
+
+    #[test]
+    fn a_handle_naming_another_host_denies_the_domain_match() {
+        // These end with ".acme.com" but resolve against evil.com.
+        let doms = v(&["acme.com"]);
+        for h in [
+            "evil.com/x.acme.com",
+            "evil.com?x.acme.com",
+            "evil.com#x.acme.com",
+            "127.0.0.1/x.acme.com",
+        ] {
+            assert!(!did_allowed(&[], &doms, "did:plc:mallory", Some(h)), "{h}");
+        }
+    }
+
+    #[test]
+    fn an_exact_did_is_allowed_even_with_a_malformed_handle() {
+        let dids = v(&["did:plc:alice"]);
+        let doms = v(&["acme.com"]);
+        assert!(did_allowed(
+            &dids,
+            &doms,
+            "did:plc:alice",
+            Some("evil.com/x.acme.com")
+        ));
+    }
+}
+
+#[cfg(test)]
+mod allowlist_resolution_tests {
+    //! Covers the handle lookup for a domain allowlist, including the
+    //! case where a claimed handle belongs to someone else's DID.
+
+    use super::s2s_adversarial_tests::test_state_with_resolver;
+    use freeq_sdk::did::{DidDocument, DidResolver};
+    use std::collections::HashMap;
+
+    fn doc(did: &str, handles: &[&str]) -> DidDocument {
+        DidDocument {
+            id: did.to_string(),
+            also_known_as: handles.iter().map(|h| format!("at://{h}")).collect(),
+            verification_method: vec![],
+            authentication: vec![],
+            assertion_method: vec![],
+            service: vec![],
+        }
+    }
+
+    fn resolver(docs: &[DidDocument]) -> DidResolver {
+        DidResolver::static_map(
+            docs.iter()
+                .map(|d| (d.id.clone(), d.clone()))
+                .collect::<HashMap<_, _>>(),
+        )
+    }
+
+    fn config(domains: &[&str]) -> crate::config::ServerConfig {
+        crate::config::ServerConfig {
+            listen_addr: "127.0.0.1:0".to_string(),
+            server_name: "test".to_string(),
+            allowed_did_domains: domains.iter().map(|d| d.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn domain_allowlist_admits_a_did_whose_handle_is_in_the_domain() {
+        let state = test_state_with_resolver(
+            config(&["acme.com"]),
+            resolver(&[doc("did:plc:alice", &["alice.acme.com"])]),
+        );
+        assert!(state.did_is_allowed_resolved("did:plc:alice", None).await);
+    }
+
+    #[tokio::test]
+    async fn a_claimed_handle_naming_another_host_does_not_admit() {
+        // The static resolver would confirm ownership here, so the syntax
+        // check is all that stands between mallory and admission.
+        let state = test_state_with_resolver(
+            config(&["acme.com"]),
+            resolver(&[doc("did:plc:mallory", &["evil.com/x.acme.com"])]),
+        );
+        assert!(!state.did_is_allowed_resolved("did:plc:mallory", None).await);
+    }
+
+    #[tokio::test]
+    async fn a_supplied_handle_naming_another_host_does_not_admit() {
+        // The web token carries whatever handle the user typed at login.
+        let state = test_state_with_resolver(config(&["acme.com"]), resolver(&[]));
+        assert!(
+            !state
+                .did_is_allowed_resolved("did:plc:mallory", Some("evil.com?x.acme.com"))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn domain_allowlist_rejects_a_handle_outside_the_domain() {
+        let state = test_state_with_resolver(
+            config(&["acme.com"]),
+            resolver(&[doc("did:plc:mallory", &["mallory.evil.com"])]),
+        );
+        assert!(!state.did_is_allowed_resolved("did:plc:mallory", None).await);
+    }
+
+    #[tokio::test]
+    async fn unverified_also_known_as_does_not_admit() {
+        // Mallory claims a handle that really belongs to alice.
+        let docs = [doc("did:plc:mallory", &["alice.acme.com"])];
+        let resolver = DidResolver::static_map_with_handles(
+            docs.iter()
+                .map(|d| (d.id.clone(), d.clone()))
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([("alice.acme.com".to_string(), "did:plc:alice".to_string())]),
+        );
+        let state = test_state_with_resolver(config(&["acme.com"]), resolver);
+        assert!(!state.did_is_allowed_resolved("did:plc:mallory", None).await);
+    }
+
+    #[tokio::test]
+    async fn a_second_claimed_handle_admits_when_the_first_is_out_of_domain() {
+        // The PDS lists the personal handle first, but membership rests on the
+        // other one.
+        let state = test_state_with_resolver(
+            config(&["pds.acme.com"]),
+            resolver(&[doc(
+                "did:plc:alice",
+                &["alice.example.com", "alice.pds.acme.com"],
+            )]),
+        );
+        assert!(state.did_is_allowed_resolved("did:plc:alice", None).await);
+    }
+
+    #[tokio::test]
+    async fn a_supplied_handle_outside_the_domain_still_checks_the_others() {
+        // A web login carries this handle from OAuth; both paths must agree.
+        let state = test_state_with_resolver(
+            config(&["pds.acme.com"]),
+            resolver(&[doc(
+                "did:plc:alice",
+                &["alice.example.com", "alice.pds.acme.com"],
+            )]),
+        );
+        assert!(
+            state
+                .did_is_allowed_resolved("did:plc:alice", Some("alice.example.com"))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn supplied_handle_skips_resolution() {
+        let state = test_state_with_resolver(config(&["acme.com"]), resolver(&[]));
+        assert!(
+            state
+                .did_is_allowed_resolved("did:plc:alice", Some("alice.acme.com"))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn open_instance_never_resolves() {
+        let state = test_state_with_resolver(config(&[]), resolver(&[]));
+        assert!(state.did_is_allowed_resolved("did:plc:anyone", None).await);
+    }
+
+    #[tokio::test]
+    async fn did_allowlist_alone_still_decides_without_resolution() {
+        let mut cfg = config(&[]);
+        cfg.allowed_dids = vec!["did:plc:alice".to_string()];
+        let state = test_state_with_resolver(cfg, resolver(&[]));
+        assert!(state.did_is_allowed_resolved("did:plc:alice", None).await);
+        assert!(!state.did_is_allowed_resolved("did:plc:mallory", None).await);
     }
 }
 


### PR DESCRIPTION
This fixes the support for FREEQ_ALLOWED_DID_DOMAINS so that a server can restrict access by handle domain. Previously using this blocked all access to non-guest users.

The handle was being discarded on the web path, this PR now passes the handle through to the domain allowlist for verification.

There's still a UI issue that's not addressed - but belongs in a different PR / issue - users (authenticated and guests) that are rejected have no visibility into what happened, they're just taken back to the login page with no errors.