### PR TITLE
PoC: private per-channel media via atproto spaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ BROKER_SHARED_SECRET=
 # Create at https://github.com/settings/developers
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# Private media via AT Protocol spaces (docs/PRIVATE-MEDIA-SPACES.md).
+# Leave unset to keep the feature off. The DID is an account for this server
+# on a spaces-capable PDS.
+FREEQ_MEDIA_SPACE_DID=
+FREEQ_MEDIA_SPACE_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,5 @@ GITHUB_CLIENT_SECRET=
 # on a spaces-capable PDS.
 FREEQ_MEDIA_SPACE_DID=
 FREEQ_MEDIA_SPACE_PASSWORD=
+# Optional: defaults to the space DID's PDS.
+FREEQ_MEDIA_SPACE_PDS=

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -15,21 +15,24 @@ concepts.
 Today, private attachments are held by the freeq server instead. It stores
 the files, holds the key, and access rides on possession of a link. That
 works, but the files are not yours in any atproto sense: you cannot take
-them with you, truly delete them, or keep the server operator out of them.
+them with you or truly delete them.
 
-With spaces, a private file stays in your own repo on your PDS. The
-channel decides who may read it (joining grants access, a kick or ban
-removes it), the freeq server stores nothing, and deleting your file from
-your own repo is a real deletion.
+With spaces, a private file stays in your own repo on your PDS. The channel
+decides who may read it (joining grants access, a kick or ban removes it),
+the freeq server stores nothing, and deleting your file from your own repo
+is a real deletion. The server still handles the management of the media.
 
 ## How it works
 
-The server gets its own AT Protocol account, which acts as the gatekeeper
-for one private "space" per channel. Members' clients put media into the
-channel's space instead of uploading it publicly. Whenever someone tries to
-read from a space, the gatekeeper asks the freeq server "is this person in
-the channel right now?" and the server answers from its live member list.
-There is no separate access list to manage; the channel is the access list.
+The server gets its own AT Protocol account. That account is the gatekeeper,
+and owns a private "space" per channel.
+
+When you attach a file, it goes into your own repo inside that channel's
+space. The browser has no PDS credentials of its own, so freeq writes
+the media.
+
+Reading is the same, freeq confirms the member and fetches the file on
+their behalf.
 
 ## Using it
 
@@ -64,9 +67,7 @@ Two things to know when enabling it:
   `server_name` must be the server's public hostname, reachable over HTTPS.
   If a front proxy handles `/.well-known/` for certificate renewal, make
   sure `did.json` still reaches freeq.
-- Users who want private media need accounts on a Spaces-capable PDS, and
-  web users who were already logged in must log out and back in once to
-  grant the extra permission. Everyone else just keeps using public media.
+- Posting private media requires a Spaces-capable PDS. Viewing media does not.
 
 Uploads are a per-message choice in the client, opt-in per file.
 

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -1,0 +1,69 @@
+# Private Media via AT Protocol Spaces
+
+**Status: experimental.** This is built on the AT Protocol Spaces alpha
+([proposal 0016](https://github.com/bluesky-social/proposals/tree/main/0016-permissioned-data)),
+which is itself not production-ready. The feature is off by default and
+everything about it may change.
+
+## Why
+
+Media shared through freeq is public. Attachments are uploaded to the
+sender's PDS as public blobs, so anyone with the link can fetch them,
+forever, no matter how locked down the channel is. An image posted in an
+invite-only channel is exactly as public as one posted in #freeq, and
+deleting the message does not delete the file.
+
+With this feature on, media shared in a channel is visible to exactly the
+people who are in that channel. Joining grants access, being kicked or
+banned removes it, and the uploader can genuinely delete their files. The
+freeq server never stores or even sees the media itself: files live on
+each uploader's own PDS, and clients fetch them from there directly.
+
+## How it works, briefly
+
+The server gets its own AT Protocol account, which acts as the gatekeeper
+for one private "space" per channel. Members' clients put media into the
+channel's space instead of uploading it publicly. Whenever someone tries to
+read from a space, the gatekeeper asks the freeq server "is this person in
+the channel right now?" and the server answers from its live member list.
+There is no separate access list to manage; the channel is the access list.
+
+## Using it
+
+You need an account for the server on a PDS that supports the Spaces alpha.
+Then configure:
+
+```toml
+# server.toml
+media_space_did = "did:plc:..."        # the server's spaces account
+media_space_password = "..."
+```
+
+(Or use the matching CLI flags / `FREEQ_MEDIA_SPACE_*` environment
+variables.) Leave these unset and the feature is completely off; media
+works exactly as before.
+
+Two things to know when enabling it:
+
+- The server publishes an identity document at
+  `https://{server_name}/.well-known/did.json` so the PDS can find it.
+  `server_name` must be the server's public hostname, reachable over HTTPS.
+  If a front proxy handles `/.well-known/` for certificate renewal, make
+  sure `did.json` still reaches freeq.
+- Users who want private media need accounts on a Spaces-capable PDS, and
+  web users who were already logged in must log out and back in once to
+  grant the extra permission. Everyone else just keeps using public media.
+
+Uploads are a per-message choice in the client: private is the default in
+invite-only or keyed channels, public elsewhere, and either can be picked
+explicitly. A private upload that fails is never quietly turned into a
+public one.
+
+## Limitations
+
+- Access control, not encryption: files sit unencrypted on the uploader's
+  PDS, readable by anyone the gatekeeper authorizes. Encrypted (+E)
+  channels are not supported yet.
+- Someone kicked from a channel may keep access for up to about two hours,
+  until their last-issued credential expires.
+- DMs and federated (S2S) members are not supported yet.

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -7,19 +7,22 @@ everything about it may change.
 
 ## Why
 
-Media shared through freeq is public. Attachments are uploaded to the
-sender's PDS as public blobs, so anyone with the link can fetch them,
-forever, no matter how locked down the channel is. An image posted in an
-invite-only channel is exactly as public as one posted in #freeq, and
-deleting the message does not delete the file.
+freeq can already put your public media on your own PDS ("save a public
+copy to my PDS"). This feature is the other side of that: your private
+media on your own PDS too, under your control, following AT Protocol
+concepts.
 
-With this feature on, media shared in a channel is visible to exactly the
-people who are in that channel. Joining grants access, being kicked or
-banned removes it, and the uploader can genuinely delete their files. The
-freeq server never stores or even sees the media itself: files live on
-each uploader's own PDS, and clients fetch them from there directly.
+Today, private attachments are held by the freeq server instead. It stores
+the files, holds the key, and access rides on possession of a link. That
+works, but the files are not yours in any atproto sense: you cannot take
+them with you, truly delete them, or keep the server operator out of them.
 
-## How it works, briefly
+With spaces, a private file stays in your own repo on your PDS. The
+channel decides who may read it (joining grants access, a kick or ban
+removes it), the freeq server never stores or even sees the bytes, and
+deleting your file is a real deletion.
+
+## How it works
 
 The server gets its own AT Protocol account, which acts as the gatekeeper
 for one private "space" per channel. Members' clients put media into the
@@ -42,6 +45,17 @@ media_space_password = "..."
 (Or use the matching CLI flags / `FREEQ_MEDIA_SPACE_*` environment
 variables.) Leave these unset and the feature is completely off; media
 works exactly as before.
+
+To enable it under docker compose, ensure the variables are set in your
+`.env` and add these to the freeq service:
+
+```yaml
+environment:
+  - FREEQ_MEDIA_SPACE_DID=${FREEQ_MEDIA_SPACE_DID:-}
+  - FREEQ_MEDIA_SPACE_PASSWORD=${FREEQ_MEDIA_SPACE_PASSWORD:-}
+```
+
+and set the values in your `.env`.
 
 Two things to know when enabling it:
 

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -68,20 +68,19 @@ Two things to know when enabling it:
   web users who were already logged in must log out and back in once to
   grant the extra permission. Everyone else just keeps using public media.
 
-Uploads are a per-message choice in the client: private is the default in
-invite-only or keyed channels, public elsewhere, and either can be picked
-explicitly. A private upload that fails is never quietly turned into a
-public one.
+Uploads are a per-message choice in the client, opt-in per file.
 
 ## Limitations
 
 - Access control, not encryption: files sit unencrypted on the uploader's
   PDS, readable by anyone the gatekeeper authorizes. Encrypted (+E)
   channels are not supported yet.
-- Someone kicked from a channel may keep access for up to about two hours,
-  until the read credential in play expires.
+- Access is checked per request against live channel membership, so losing
+  the channel simultaneously stops media access.
 - Private media spaces are per channel: DMs and federated (S2S) members are
   not currently supported.
+- In a public channel, media is readable by anyone who can read the channel,
+  including anonymous readers.
 - The server can read the media it serves, since it fetches on each
   viewer's behalf. The difference from server-side storage is custody: the
   file is in your repo, portable and deletable by you, and access is

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -19,8 +19,8 @@ them with you, truly delete them, or keep the server operator out of them.
 
 With spaces, a private file stays in your own repo on your PDS. The
 channel decides who may read it (joining grants access, a kick or ban
-removes it), the freeq server never stores or even sees the bytes, and
-deleting your file is a real deletion.
+removes it), the freeq server stores nothing, and deleting your file from
+your own repo is a real deletion.
 
 ## How it works
 
@@ -79,5 +79,10 @@ public one.
   PDS, readable by anyone the gatekeeper authorizes. Encrypted (+E)
   channels are not supported yet.
 - Someone kicked from a channel may keep access for up to about two hours,
-  until their last-issued credential expires.
-- DMs and federated (S2S) members are not supported yet.
+  until the read credential in play expires.
+- Private media spaces are per channel: DMs and federated (S2S) members are
+  not currently supported.
+- The server can read the media it serves, since it fetches on each
+  viewer's behalf. The difference from server-side storage is custody: the
+  file is in your repo, portable and deletable by you, and access is
+  decided by live channel membership rather than by whoever holds a link.

--- a/docs/PRIVATE-MEDIA-SPACES.md
+++ b/docs/PRIVATE-MEDIA-SPACES.md
@@ -28,11 +28,12 @@ The server gets its own AT Protocol account. That account is the gatekeeper,
 and owns a private "space" per channel.
 
 When you attach a file, it goes into your own repo inside that channel's
-space. The browser has no PDS credentials of its own, so freeq writes
-the media.
+space. Your browser never holds your PDS tokens — they live on the freeq
+server from the OAuth flow — so freeq performs the write on your behalf.
 
-Reading is the same, freeq confirms the member and fetches the file on
-their behalf.
+Reading is the same: freeq confirms the member and fetches the file on
+their behalf. Fetched files are cached in memory for five minutes so a
+scrolling message list does not hammer the uploader's PDS.
 
 ## Using it
 
@@ -76,8 +77,19 @@ Uploads are a per-message choice in the client, opt-in per file.
 - Access control, not encryption: files sit unencrypted on the uploader's
   PDS, readable by anyone the gatekeeper authorizes. Encrypted (+E)
   channels are not supported yet.
-- Access is checked per request against live channel membership, so losing
-  the channel simultaneously stops media access.
+- Access is checked against live channel membership when a space credential
+  is *minted*, and the server caches that credential for up to 30 minutes.
+  A kick or ban therefore stops access eventually, not instantly: it takes
+  effect on the next mint. Treat revocation as bounded-lag, not immediate.
+- A file goes to exactly one place. Private-space upload and the public
+  "save a copy to my PDS" / "post to Bluesky" options are mutually
+  exclusive, and the server rejects a request asking for both.
+- Encrypted-only (`+E`) channels are refused server-side: space media sits
+  unencrypted in the author's repo and is proxied in the clear through the
+  server, which is the thing `+E` exists to prevent.
+- A server holds at most 500 media spaces (`MAX_MEDIA_SPACES`). Minting is a
+  write to the operator's own PDS account, and anyone who can create a
+  channel can ask for one.
 - Private media spaces are per channel: DMs and federated (S2S) members are
   not currently supported.
 - In a public channel, media is readable by anyone who can read the channel,

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -54,6 +54,10 @@ export function ComposeBox() {
   // and/or also post it to their Bluesky feed (which implies the PDS copy).
   const [sharePds, setSharePds] = useState(false);
   const [shareBluesky, setShareBluesky] = useState(false);
+  // Store the file in the user's own repo inside this channel's media space.
+  // Offered only when the server has the feature configured.
+  const [spaceMedia, setSpaceMedia] = useState(false);
+  const [spacesAvailable, setSpacesAvailable] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const emojiRef = useRef<HTMLButtonElement>(null);
@@ -191,7 +195,18 @@ export function ComposeBox() {
     setPendingUpload(null);
     setSharePds(false);
     setShareBluesky(false);
+    setSpaceMedia(false);
   };
+
+  // Does this server offer private media spaces?
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/v1/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((h) => { if (!cancelled && h?.media_spaces) setSpacesAvailable(true); })
+      .catch(() => { /* keep option hidden */ });
+    return () => { cancelled = true; };
+  }, []);
 
   const doUpload = useCallback(async () => {
     if (!pendingUpload || !authDid) return;
@@ -207,6 +222,7 @@ export function ComposeBox() {
         // share_bluesky implies share_pds (feed embed references the PDS blob).
         if (sharePds || shareBluesky) f.append('share_pds', 'true');
         if (shareBluesky) f.append('share_bluesky', 'true');
+        if (spaceMedia) f.append('space_media', 'true');
         return f;
       };
 
@@ -217,19 +233,20 @@ export function ComposeBox() {
       // once with a fresh form. This is the Phase 2 incremental-auth
       // path — we never asked for blob upload at sign-in time.
       const purpose = await detectStepUpRequired(resp);
-      if (purpose === 'blob_upload') {
-        const outcome = await requestStepUp('blob_upload', authDid);
+      if (purpose === 'blob_upload' || purpose === 'media_space') {
+        const outcome = await requestStepUp(purpose, authDid);
         if (outcome.ok) {
           resp = await fetch('/api/v1/upload', { method: 'POST', body: buildForm() });
         } else {
           // Tailor the message to *why* it failed so the user knows
           // whether to allow popups, retry, or wait less next time.
+          const what = purpose === 'media_space' ? 'private media' : 'a public copy';
           const msg =
             outcome.reason === 'popup_blocked'
-              ? 'Allow popups for this site so freeq can request the image-upload permission, then retry.'
+              ? `Allow popups for this site so freeq can ask your PDS for permission to save ${what}, then retry.`
               : outcome.reason === 'timeout'
-                ? 'The Bluesky permission popup timed out. Try the upload again.'
-                : 'Image upload needs one extra Bluesky permission. Try again and complete the popup.';
+                ? 'The permission popup timed out. Try the upload again.'
+                : `Saving ${what} to your PDS needs one extra permission. Try again and complete the popup.`;
           throw new Error(msg);
         }
       }
@@ -287,10 +304,11 @@ export function ComposeBox() {
       setText('');
       setSharePds(false);
       setShareBluesky(false);
+      setSpaceMedia(false);
     } catch (e: any) {
       setPendingUpload((p) => p ? { ...p, uploading: false, error: e.message || 'Upload failed' } : null);
     }
-  }, [pendingUpload, authDid, activeChannel, text, ch, sharePds, shareBluesky]);
+  }, [pendingUpload, authDid, activeChannel, text, ch, sharePds, shareBluesky, spaceMedia]);
 
   // ── Drag & drop ──
 
@@ -612,6 +630,17 @@ export function ComposeBox() {
                   <span>🔒</span>
                   <span>Private to {ch?.name || activeChannel} by default</span>
                 </div>
+                {spacesAvailable && activeChannel.startsWith('#') && (
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={spaceMedia}
+                      onChange={(e) => setSpaceMedia(e.target.checked)}
+                      className="w-3 h-3 rounded accent-blue"
+                    />
+                    <span className="text-sm text-fg-dim">Keep it on my PDS (private to this channel)</span>
+                  </label>
+                )}
                 <label className="flex items-center gap-1.5 cursor-pointer">
                   <input
                     type="checkbox"

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -219,10 +219,16 @@ export function ComposeBox() {
         f.append('did', authDid);
         if (activeChannel !== 'server' && activeChannel.startsWith('#')) f.append('channel', activeChannel);
         if (text.trim()) f.append('alt', text.trim());
+        // A file goes to exactly one destination: the channel's private
+        // space, or a public PDS/Bluesky copy. The server rejects both at
+        // once, so never send both.
+        if (spaceMedia) {
+          f.append('space_media', 'true');
+          return f;
+        }
         // share_bluesky implies share_pds (feed embed references the PDS blob).
         if (sharePds || shareBluesky) f.append('share_pds', 'true');
         if (shareBluesky) f.append('share_bluesky', 'true');
-        if (spaceMedia) f.append('space_media', 'true');
         return f;
       };
 
@@ -635,7 +641,13 @@ export function ComposeBox() {
                     <input
                       type="checkbox"
                       checked={spaceMedia}
-                      onChange={(e) => setSpaceMedia(e.target.checked)}
+                      // A file goes to one place. Choosing the private space
+                      // clears the public options rather than letting the
+                      // server silently drop them.
+                      onChange={(e) => {
+                        setSpaceMedia(e.target.checked);
+                        if (e.target.checked) { setSharePds(false); setShareBluesky(false); }
+                      }}
                       className="w-3 h-3 rounded accent-blue"
                     />
                     <span className="text-sm text-fg-dim">
@@ -645,20 +657,21 @@ export function ComposeBox() {
                     </span>
                   </label>
                 )}
-                <label className="flex items-center gap-1.5 cursor-pointer">
+                <label className={`flex items-center gap-1.5 ${spaceMedia ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}>
                   <input
                     type="checkbox"
-                    checked={sharePds || shareBluesky}
-                    disabled={shareBluesky}
+                    checked={!spaceMedia && (sharePds || shareBluesky)}
+                    disabled={shareBluesky || spaceMedia}
                     onChange={(e) => setSharePds(e.target.checked)}
                     className="w-3 h-3 rounded accent-blue"
                   />
                   <span className="text-sm text-fg-dim">Save a public copy to my PDS</span>
                 </label>
-                <label className="flex items-center gap-1.5 cursor-pointer">
+                <label className={`flex items-center gap-1.5 ${spaceMedia ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}>
                   <input
                     type="checkbox"
-                    checked={shareBluesky}
+                    checked={!spaceMedia && shareBluesky}
+                    disabled={spaceMedia}
                     onChange={(e) => setShareBluesky(e.target.checked)}
                     className="w-3 h-3 rounded accent-blue"
                   />

--- a/freeq-app/src/components/ComposeBox.tsx
+++ b/freeq-app/src/components/ComposeBox.tsx
@@ -630,7 +630,7 @@ export function ComposeBox() {
                   <span>🔒</span>
                   <span>Private to {ch?.name || activeChannel} by default</span>
                 </div>
-                {spacesAvailable && activeChannel.startsWith('#') && (
+                {spacesAvailable && activeChannel.startsWith('#') && !ch?.isEncrypted && (
                   <label className="flex items-center gap-1.5 cursor-pointer">
                     <input
                       type="checkbox"
@@ -638,7 +638,11 @@ export function ComposeBox() {
                       onChange={(e) => setSpaceMedia(e.target.checked)}
                       className="w-3 h-3 rounded accent-blue"
                     />
-                    <span className="text-sm text-fg-dim">Keep it on my PDS (private to this channel)</span>
+                    <span className="text-sm text-fg-dim">
+                      Keep it on my PDS ({ch?.modes.has('i') || ch?.modes.has('k')
+                        ? 'private to this channel'
+                        : 'anyone who can read this channel'})
+                    </span>
                   </label>
                 )}
                 <label className="flex items-center gap-1.5 cursor-pointer">

--- a/freeq-app/src/components/MessageList.media.test.tsx
+++ b/freeq-app/src/components/MessageList.media.test.tsx
@@ -27,6 +27,14 @@ describe('private media (capability URL) rendering', () => {
     expect(img?.getAttribute('src')).toBe(url);
   });
 
+  it('renders an inline <img> for a /api/v1/space-media/*.png URL', () => {
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9leGFtcGxl/photo.png`;
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe(url);
+  });
+
   it('renders an inline <video> for a /api/v1/media/*.mp4 URL', () => {
     const url = `${ORIGIN}/api/v1/media/def456/SIGSIGSIG/clip.mp4`;
     const { container } = render(<MessageContent msg={msg(url)} />);

--- a/freeq-app/src/components/MessageList.media.test.tsx
+++ b/freeq-app/src/components/MessageList.media.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
 import { MessageContent } from './MessageList';
 import type { Message } from '../store';
 
-afterEach(cleanup);
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
 function msg(text: string): Message {
   return {
@@ -27,12 +27,56 @@ describe('private media (capability URL) rendering', () => {
     expect(img?.getAttribute('src')).toBe(url);
   });
 
-  it('renders an inline <img> for a /api/v1/space-media/*.png URL', () => {
+  it('fetches space media with the session bearer instead of using the raw URL', async () => {
+    // The server serves space media only to channel members, and membership
+    // rides on the Authorization header, which an <img src> cannot send. The
+    // bytes are fetched and handed to the tag as an object URL instead.
     const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9leGFtcGxl/photo.png`;
+    // A hand-rolled stand-in: jsdom's Blob is not the one undici's Response
+    // accepts, and only `ok` and `blob()` are read here.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['bytes'], { type: 'image/png' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-object-url');
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = vi.fn();
+
     const { container } = render(<MessageContent msg={msg(url)} />);
-    const img = container.querySelector('img');
-    expect(img).not.toBeNull();
-    expect(img?.getAttribute('src')).toBe(url);
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+
+    expect(fetchMock).toHaveBeenCalledWith(url, expect.anything());
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:mock-object-url');
+  });
+
+  it('says who can see it when space media is refused', async () => {
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9leGFtcGxl/secret.png`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 403, blob: async () => new Blob() }),
+    );
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    await waitFor(() =>
+      expect(container.textContent).toContain('only visible to members of this channel'),
+    );
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('does not blame the viewer when the fetch itself breaks', async () => {
+    // A 502 says nothing about who is asking, so telling them they are not a
+    // member would be a guess, and a wrong one for a member reading history.
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9leGFtcGxl/oops.png`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 502, blob: async () => new Blob() }),
+    );
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    await waitFor(() => expect(container.textContent).toContain('could not be loaded'));
+    expect(container.textContent).not.toContain('members of this channel');
   });
 
   it('renders an inline <video> for a /api/v1/media/*.mp4 URL', () => {

--- a/freeq-app/src/components/MessageList.media.test.tsx
+++ b/freeq-app/src/components/MessageList.media.test.tsx
@@ -1,10 +1,29 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
+
+// The fetch helper reads the bearer off the singleton SDK client, so the
+// bearer race is only reproducible with that module stubbed.
+const mockClient: { apiBearer: string | null } | null = { apiBearer: null };
+let currentClient: typeof mockClient = null;
+vi.mock('../irc/client', () => ({
+  getClient: () => currentClient,
+  getNick: () => 'me',
+  requestHistory: vi.fn(),
+  sendReaction: vi.fn(),
+  sendUnreact: vi.fn(),
+  joinChannel: vi.fn(),
+}));
+
 import { MessageContent } from './MessageList';
 import type { Message } from '../store';
 
-afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  currentClient = null;
+  mockClient!.apiBearer = null;
+});
 
 function msg(text: string): Message {
   return {
@@ -92,5 +111,89 @@ describe('private media (capability URL) rendering', () => {
     const url = `${ORIGIN}/api/v1/media/ghi789/SIGSIGSIG/cat.png`;
     const { container } = render(<MessageContent msg={msg(url)} />);
     expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('plays private space audio through the bearer, not a bare <audio src>', async () => {
+    // An <audio src> cannot carry the Authorization header any more than an
+    // <img src> can, so the same fetch-and-object-URL path has to cover it.
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9hdWRpbw/note.m4a`;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['bytes'], { type: 'audio/mp4' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:audio-object-url');
+    URL.revokeObjectURL = vi.fn();
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    await waitFor(() => expect(container.querySelector('audio')).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(url, expect.anything());
+    expect(container.querySelector('audio')?.getAttribute('src')).toBe('blob:audio-object-url');
+  });
+
+  it('offers a private attachment with no inline renderer as a real link', async () => {
+    // A .pdf has no player; a plain <a href> would 403 on click in exactly
+    // the restricted channels this feature exists for.
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9kb2M/report.pdf`;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['bytes'], { type: 'application/pdf' }),
+    }));
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:doc-object-url');
+    URL.revokeObjectURL = vi.fn();
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    await waitFor(() => expect(container.querySelector('a')).not.toBeNull());
+    const a = container.querySelector('a')!;
+    expect(a.getAttribute('href')).toBe('blob:doc-object-url');
+    expect(a.getAttribute('download')).toBe('report.pdf');
+  });
+
+  it('retries once the session bearer lands instead of calling a member a stranger', async () => {
+    // History renders before the API-BEARER notice arrives, so the first
+    // fetch can lose the race. Reporting "not a member" then would be both
+    // wrong and permanent.
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9yYWNl/late.png`;
+    currentClient = mockClient;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403, blob: async () => new Blob() })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(['bytes'], { type: 'image/png' }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:late-object-url');
+    URL.revokeObjectURL = vi.fn();
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    // The bearer turns up a moment later, exactly as it does in the app.
+    setTimeout(() => { mockClient!.apiBearer = 'sess-late'; }, 250);
+
+    await waitFor(
+      () => expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:late-object-url'),
+      { timeout: 3000 },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain('members of this channel');
+  });
+
+  it('does not stall on the bearer when there is no connection to wait for', async () => {
+    // A logged-out reader has no client at all. Waiting several seconds to
+    // tell them something we already know would be pure delay.
+    const url = `${ORIGIN}/api/v1/space-media/YXQ6Ly9ndWVzdA/nope.png`;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 403, blob: async () => new Blob() });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = render(<MessageContent msg={msg(url)} />);
+    await waitFor(() =>
+      expect(container.textContent).toContain('only visible to members of this channel'),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -288,7 +288,6 @@ function isTrustedImageUrl(url: string): boolean {
   }
 }
 
-
 /** Why space media could not be shown: the viewer is not a member, or the
  *  fetch itself broke. */
 type MediaFailure = 'refused' | 'error' | null;
@@ -344,7 +343,7 @@ function useAuthedMedia(url: string): { src: string | null; failure: MediaFailur
 }
 
 /** Image that respects the "Load external media" setting. */
-function GatedImage({ url, onOpen }: { url: string; onOpen: () => void }) {
+function GatedImage({ url, onOpen }: { url: string; onOpen: (src: string) => void }) {
   const loadMedia = useStore((s) => s.loadExternalMedia);
   const [revealed, setRevealed] = useState(false);
   const trusted = isTrustedImageUrl(url);
@@ -370,7 +369,7 @@ function GatedImage({ url, onOpen }: { url: string; onOpen: () => void }) {
       );
     }
     return (
-      <button onClick={onOpen} className="block cursor-zoom-in">
+      <button onClick={() => onOpen(src)} className="block cursor-zoom-in">
         <img
           src={src}
           alt=""
@@ -630,7 +629,7 @@ function MessageContentImpl({ msg, channel, onNickClick }: {
       {imageUrls.length > 0 && (
         <div className="mt-1.5 flex flex-wrap gap-2">
           {imageUrls.map((url) => (
-            <GatedImage key={url} url={url} onOpen={() => setLightbox(url)} />
+            <GatedImage key={url} url={url} onOpen={(src) => setLightbox(src)} />
           ))}
         </div>
       )}

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -300,7 +300,8 @@ function isTrustedImageUrl(url: string): boolean {
 type MediaFailure = 'refused' | 'error' | null;
 
 /** Is this one of our authenticated space-media URLs? */
-function isSpaceMediaUrl(url: string): boolean {
+function isSpaceMediaUrl(url: string | undefined): url is string {
+  if (!url) return false;
   try {
     const u = new URL(url, window.location.origin);
     return u.origin === window.location.origin && u.pathname.startsWith('/api/v1/space-media/');

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -273,7 +273,10 @@ function isTrustedImageUrl(url: string): boolean {
     const u = new URL(url, window.location.origin);
     // Private freeq media served from our own origin is always first-party —
     // never gate it behind the "load external media" setting.
-    if (u.origin === window.location.origin && u.pathname.startsWith('/api/v1/media/')) {
+    if (
+      u.origin === window.location.origin &&
+      (u.pathname.startsWith('/api/v1/media/') || u.pathname.startsWith('/api/v1/space-media/'))
+    ) {
       return true;
     }
     const h = u.hostname;

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -8,7 +8,7 @@ import { isDid, isPeerBlocked } from '../lib/identity';
 import { claimForMessage } from '@freeq/sdk';
 import type { RowEvidence } from './UserPopover';
 import { displayNameForKey } from '../lib/display-name';
-import { apiFetch } from '../lib/api';
+import { apiFetch, bearerPending, hasBearer, waitForBearer } from '../lib/api';
 import { EmojiPicker } from './EmojiPicker';
 import { UserPopover } from './UserPopover';
 import { BlueskyEmbed } from './BlueskyEmbed';
@@ -219,6 +219,13 @@ function renderTextSafe(text: string, ctx?: RenderCtx): React.ReactElement {
         const content = seg.content;
         switch (seg.type) {
           case 'link':
+            // A space-media link has no renderer of its own (a .pdf, a .zip)
+            // and a plain anchor cannot send the bearer that proves
+            // membership, so a restricted channel's attachment would just
+            // 403 on click. Fetch it the same way the players do.
+            if (isSpaceMediaUrl(seg.href)) {
+              return <SpaceMediaLink key={i} url={seg.href} label={content} />;
+            }
             return <a key={i} href={seg.href} target="_blank" rel="noopener noreferrer" className="text-accent hover:underline break-all">{content}</a>;
           case 'mention':
             return (
@@ -303,43 +310,114 @@ function isSpaceMediaUrl(url: string): boolean {
 }
 
 /**
+ * Object URLs for space media, shared across every mount of the same file.
+ *
+ * The message list is virtualized, so a row unmounts as soon as it scrolls
+ * out of view. Revoking there meant two things went wrong: every scroll-back
+ * re-fetched the file from the *author's* PDS, and the lightbox — which
+ * outlives the row that opened it — was handed a URL already revoked out
+ * from under it. Entries are kept until pushed out by newer ones.
+ */
+const SPACE_MEDIA_CACHE_MAX = 32;
+const spaceMediaCache = new Map<string, string>();
+
+function rememberSpaceMedia(url: string, objectUrl: string): void {
+  spaceMediaCache.set(url, objectUrl);
+  while (spaceMediaCache.size > SPACE_MEDIA_CACHE_MAX) {
+    const oldest = spaceMediaCache.keys().next();
+    if (oldest.done) break;
+    const stale = spaceMediaCache.get(oldest.value);
+    spaceMediaCache.delete(oldest.value);
+    if (stale) URL.revokeObjectURL(stale);
+  }
+}
+
+/**
  * Space media is served only to channel members, and membership is proven by
  * the session bearer, which an `<img src>` cannot send. Fetch those URLs with
  * the header and hand back an object URL; everything else passes through.
  */
 function useAuthedMedia(url: string): { src: string | null; failure: MediaFailure } {
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [objectUrl, setObjectUrl] = useState<string | null>(() => spaceMediaCache.get(url) ?? null);
   const [failure, setFailure] = useState<MediaFailure>(null);
 
   useEffect(() => {
     if (!isSpaceMediaUrl(url)) return;
-    let revoked = false;
-    let made: string | null = null;
+    const cached = spaceMediaCache.get(url);
+    if (cached) {
+      setObjectUrl(cached);
+      setFailure(null);
+      return;
+    }
+    let cancelled = false;
     setFailure(null);
-    apiFetch(url)
-      .then((r) => {
-        if (r.ok) return r.blob();
-        // Being refused is a different thing to tell someone than a fetch
-        // that broke: one is about who they are, the other about the server.
-        throw new Error(r.status === 403 || r.status === 404 ? 'refused' : 'error');
-      })
-      .then((b) => {
-        if (revoked) return;
-        made = URL.createObjectURL(b);
+    (async () => {
+      try {
+        let resp = await apiFetch(url);
+        // The bearer lands asynchronously, shortly after `registered`. A
+        // fetch that beats it gets a 403 and would otherwise tell a member
+        // they are not a member, permanently, until the row remounts.
+        if (resp.status === 403 && bearerPending()) {
+          await waitForBearer();
+          if (hasBearer()) resp = await apiFetch(url);
+        }
+        if (!resp.ok) {
+          // Being refused is a different thing to tell someone than a fetch
+          // that broke: one is about who they are, the other about the server.
+          throw new Error(resp.status === 403 || resp.status === 404 ? 'refused' : 'error');
+        }
+        const blob = await resp.blob();
+        if (cancelled) return;
+        const made = URL.createObjectURL(blob);
+        rememberSpaceMedia(url, made);
         setObjectUrl(made);
-      })
-      .catch((e) => {
-        if (!revoked) setFailure(e?.message === 'refused' ? 'refused' : 'error');
-      });
+      } catch (e: any) {
+        if (!cancelled) setFailure(e?.message === 'refused' ? 'refused' : 'error');
+      }
+    })();
     return () => {
-      revoked = true;
-      if (made) URL.revokeObjectURL(made);
-      setObjectUrl(null);
+      cancelled = true;
     };
   }, [url]);
 
   if (!isSpaceMediaUrl(url)) return { src: url, failure: null };
   return { src: objectUrl, failure };
+}
+
+/**
+ * A private-space attachment with no inline renderer. Resolves to the fetched
+ * blob so the browser can open or download it without a bearer of its own.
+ */
+function SpaceMediaLink({ url, label }: { url: string; label: string }) {
+  const { src, failure } = useAuthedMedia(url);
+  const filename = (() => {
+    try {
+      return decodeURIComponent(new URL(url, window.location.origin).pathname.split('/').pop() || 'file');
+    } catch {
+      return 'file';
+    }
+  })();
+  if (failure) {
+    return (
+      <span className="text-fg-dim" title={label}>
+        🔒 {failure === 'refused'
+          ? 'Private file, only visible to members of this channel'
+          : 'Private file could not be loaded'}
+      </span>
+    );
+  }
+  if (!src) return <span className="text-fg-dim">🔒 Loading…</span>;
+  return (
+    <a
+      href={src}
+      download={filename}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-accent hover:underline break-all"
+    >
+      🔒 {filename}
+    </a>
+  );
 }
 
 /** Image that respects the "Load external media" setting. */
@@ -408,6 +486,9 @@ function InlineAudioPlayer({ url, label }: { url: string; label?: string }) {
   const [duration, setDuration] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  // Same reason as images and video: an <audio src> cannot carry the bearer
+  // that proves channel membership.
+  const { src, failure } = useAuthedMedia(url);
 
   const toggle = () => {
     const el = audioRef.current;
@@ -428,6 +509,18 @@ function InlineAudioPlayer({ url, label }: { url: string; label?: string }) {
     if (!s || !isFinite(s)) return '0:00';
     return `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
   };
+
+  if (failure || !src) {
+    return (
+      <div className="mt-1.5 max-w-[300px] px-3 py-2 rounded-xl border border-border bg-bg-tertiary text-fg-dim text-sm">
+        {failure === 'refused'
+          ? 'Private audio, only visible to members of this channel'
+          : failure
+            ? 'Private audio could not be loaded'
+            : 'Loading…'}
+      </div>
+    );
+  }
 
   return (
     <div className="mt-1.5 flex items-center gap-3 bg-bg-tertiary border border-border rounded-xl px-3 py-2.5 max-w-[300px]">
@@ -469,7 +562,7 @@ function InlineAudioPlayer({ url, label }: { url: string; label?: string }) {
       </div>
       <audio
         ref={audioRef}
-        src={url}
+        src={src ?? undefined}
         preload="metadata"
         onLoadedMetadata={() => setDuration(audioRef.current?.duration || 0)}
         onTimeUpdate={() => setProgress(audioRef.current?.currentTime || 0)}

--- a/freeq-app/src/components/MessageList.tsx
+++ b/freeq-app/src/components/MessageList.tsx
@@ -8,6 +8,7 @@ import { isDid, isPeerBlocked } from '../lib/identity';
 import { claimForMessage } from '@freeq/sdk';
 import type { RowEvidence } from './UserPopover';
 import { displayNameForKey } from '../lib/display-name';
+import { apiFetch } from '../lib/api';
 import { EmojiPicker } from './EmojiPicker';
 import { UserPopover } from './UserPopover';
 import { BlueskyEmbed } from './BlueskyEmbed';
@@ -287,17 +288,91 @@ function isTrustedImageUrl(url: string): boolean {
   }
 }
 
+
+/** Why space media could not be shown: the viewer is not a member, or the
+ *  fetch itself broke. */
+type MediaFailure = 'refused' | 'error' | null;
+
+/** Is this one of our authenticated space-media URLs? */
+function isSpaceMediaUrl(url: string): boolean {
+  try {
+    const u = new URL(url, window.location.origin);
+    return u.origin === window.location.origin && u.pathname.startsWith('/api/v1/space-media/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Space media is served only to channel members, and membership is proven by
+ * the session bearer, which an `<img src>` cannot send. Fetch those URLs with
+ * the header and hand back an object URL; everything else passes through.
+ */
+function useAuthedMedia(url: string): { src: string | null; failure: MediaFailure } {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [failure, setFailure] = useState<MediaFailure>(null);
+
+  useEffect(() => {
+    if (!isSpaceMediaUrl(url)) return;
+    let revoked = false;
+    let made: string | null = null;
+    setFailure(null);
+    apiFetch(url)
+      .then((r) => {
+        if (r.ok) return r.blob();
+        // Being refused is a different thing to tell someone than a fetch
+        // that broke: one is about who they are, the other about the server.
+        throw new Error(r.status === 403 || r.status === 404 ? 'refused' : 'error');
+      })
+      .then((b) => {
+        if (revoked) return;
+        made = URL.createObjectURL(b);
+        setObjectUrl(made);
+      })
+      .catch((e) => {
+        if (!revoked) setFailure(e?.message === 'refused' ? 'refused' : 'error');
+      });
+    return () => {
+      revoked = true;
+      if (made) URL.revokeObjectURL(made);
+      setObjectUrl(null);
+    };
+  }, [url]);
+
+  if (!isSpaceMediaUrl(url)) return { src: url, failure: null };
+  return { src: objectUrl, failure };
+}
+
 /** Image that respects the "Load external media" setting. */
 function GatedImage({ url, onOpen }: { url: string; onOpen: () => void }) {
   const loadMedia = useStore((s) => s.loadExternalMedia);
   const [revealed, setRevealed] = useState(false);
   const trusted = isTrustedImageUrl(url);
+  const { src, failure } = useAuthedMedia(url);
+
+  if (failure) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg-tertiary text-fg-dim text-sm">
+        <span className="text-lg">🔒</span>
+        <span>
+          {failure === 'refused'
+            ? 'Private media, only visible to members of this channel'
+            : 'Private media could not be loaded'}
+        </span>
+      </div>
+    );
+  }
 
   if (trusted || loadMedia || revealed) {
+    if (!src) {
+      return (
+        <div className="w-40 h-24 rounded-lg border border-border bg-bg-tertiary animate-pulse" />
+      );
+    }
     return (
       <button onClick={onOpen} className="block cursor-zoom-in">
         <img
-          src={url}
+          src={src}
           alt=""
           className="max-w-sm max-h-80 rounded-lg border border-border object-contain bg-bg-tertiary hover:opacity-90 transition-opacity"
           loading="lazy"
@@ -323,7 +398,7 @@ function GatedImage({ url, onOpen }: { url: string; onOpen: () => void }) {
 
 // Bluesky post URL pattern
 const BSKY_POST_RE = /https?:\/\/bsky\.app\/profile\/([^/]+)\/post\/([a-zA-Z0-9]+)/;
-// YouTube URL pattern  
+// YouTube URL pattern
 const YT_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
 
 /** Inline audio player for voice messages and audio files */
@@ -408,10 +483,22 @@ function InlineAudioPlayer({ url, label }: { url: string; label?: string }) {
 
 /** Inline video player */
 function InlineVideoPlayer({ url }: { url: string }) {
+  const { src, failure } = useAuthedMedia(url);
+  if (failure || !src) {
+    return (
+      <div className="mt-1.5 max-w-sm px-3 py-2 rounded-lg border border-border bg-bg-tertiary text-fg-dim text-sm">
+        {failure === 'refused'
+          ? 'Private video, only visible to members of this channel'
+          : failure
+            ? 'Private video could not be loaded'
+            : 'Loading...'}
+      </div>
+    );
+  }
   return (
     <div className="mt-1.5 max-w-sm">
       <video
-        src={url}
+        src={src}
         controls
         preload="metadata"
         className="rounded-lg border border-border max-h-72 bg-black"

--- a/freeq-app/src/lib/api.test.ts
+++ b/freeq-app/src/lib/api.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // The helper reads the bearer off the singleton SDK client, so stub that module.
 const mockClient: { apiBearer: string | null } = { apiBearer: null };
+let currentClient: typeof mockClient | null = mockClient;
 vi.mock('../irc/client', () => ({
-  getClient: () => mockClient,
+  getClient: () => currentClient,
 }));
 
-import { authHeaders, apiFetch } from './api';
+import { authHeaders, apiFetch, bearerPending, hasBearer, waitForBearer } from './api';
 
 describe('authHeaders', () => {
   beforeEach(() => {
@@ -63,5 +64,46 @@ describe('apiFetch', () => {
       .mock.calls[0];
     expect(init.method).toBe('PUT');
     expect(init.body).toBe('{"favorites":[]}');
+  });
+});
+
+describe('bearer readiness', () => {
+  beforeEach(() => {
+    currentClient = mockClient;
+    mockClient.apiBearer = null;
+  });
+  afterEach(() => {
+    currentClient = mockClient;
+  });
+
+  it('reports a bearer only once it has actually arrived', () => {
+    expect(hasBearer()).toBe(false);
+    mockClient.apiBearer = 'sess-abc';
+    expect(hasBearer()).toBe(true);
+  });
+
+  // The window between `registered` and the API-BEARER notice. A caller that
+  // 403s here should wait rather than report a member as a stranger.
+  it('treats a connected client with no bearer yet as still pending', () => {
+    expect(bearerPending()).toBe(true);
+    mockClient.apiBearer = 'sess-abc';
+    expect(bearerPending()).toBe(false);
+  });
+
+  // A logged-out reader has no client at all; there is nothing coming, so
+  // waiting would be pure delay in front of an answer we already have.
+  it('is not pending when there is no connection at all', () => {
+    currentClient = null;
+    expect(bearerPending()).toBe(false);
+    expect(hasBearer()).toBe(false);
+  });
+
+  it('resolves as soon as the bearer lands', async () => {
+    setTimeout(() => { mockClient.apiBearer = 'sess-late'; }, 250);
+    expect(await waitForBearer(3000)).toBe('sess-late');
+  });
+
+  it('gives up rather than waiting forever for a bearer that never comes', async () => {
+    expect(await waitForBearer(300)).toBeNull();
   });
 });

--- a/freeq-app/src/lib/api.ts
+++ b/freeq-app/src/lib/api.ts
@@ -28,3 +28,39 @@ export function authHeaders(extra?: HeadersInit): HeadersInit {
 export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
   return fetch(path, { ...init, headers: authHeaders(init.headers) });
 }
+
+/** Is there a session bearer right now? */
+export function hasBearer(): boolean {
+  return !!getClient()?.apiBearer;
+}
+
+/**
+ * Is a bearer plausibly still on its way?
+ *
+ * True only when a client exists but has no bearer yet — the window between
+ * `registered` and the API-BEARER notice. A guest connection also lands here
+ * briefly and then simply times out, which costs one wait and nothing else.
+ * With no client at all there is nothing to wait for.
+ */
+export function bearerPending(): boolean {
+  const c = getClient();
+  return !!c && !c.apiBearer;
+}
+
+/**
+ * Resolve once a session bearer exists, or give up after `timeoutMs`.
+ *
+ * The API-BEARER notice arrives shortly after `registered`, so anything that
+ * fires on mount can race it. Callers that would otherwise report "you are
+ * not allowed" should wait here first and retry, rather than tell an
+ * authenticated member they are a stranger.
+ */
+export async function waitForBearer(timeoutMs = 4000): Promise<string | null> {
+  const step = 200;
+  for (let waited = 0; waited < timeoutMs; waited += step) {
+    const b = getClient()?.apiBearer;
+    if (b) return b;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  return getClient()?.apiBearer ?? null;
+}

--- a/freeq-app/src/lib/oauth-step-up.test.ts
+++ b/freeq-app/src/lib/oauth-step-up.test.ts
@@ -215,6 +215,14 @@ describe('detectStepUpRequired', () => {
     expect(await detectStepUpRequired(r)).toBeNull();
   });
 
+  it('recognizes the media_space purpose', async () => {
+    const r = jsonResp(403, {
+      error: 'step_up_required',
+      purpose: 'media_space',
+    });
+    expect(await detectStepUpRequired(r)).toBe('media_space');
+  });
+
   it('does not consume the original response body', async () => {
     const r = jsonResp(403, { error: 'step_up_required', purpose: 'blob_upload' });
     await detectStepUpRequired(r);

--- a/freeq-app/src/lib/oauth-step-up.ts
+++ b/freeq-app/src/lib/oauth-step-up.ts
@@ -9,7 +9,7 @@
  * "ok" signal from the callback page, and resolves so the caller can
  * retry the original action.
  */
-export type StepUpPurpose = 'blob_upload' | 'bluesky_post';
+export type StepUpPurpose = 'blob_upload' | 'bluesky_post' | 'media_space';
 
 /**
  * Returns the base URL of the freeq HTTP server. The web app is normally
@@ -111,7 +111,7 @@ export async function detectStepUpRequired(
     const body = await resp.clone().json();
     if (body?.error === 'step_up_required' && body?.purpose) {
       const p = body.purpose as string;
-      if (p === 'blob_upload' || p === 'bluesky_post') return p;
+      if (p === 'blob_upload' || p === 'bluesky_post' || p === 'media_space') return p;
     }
   } catch {
     // Not JSON, or wrong shape. Treat as a regular 403.

--- a/freeq-oauth/src/lib.rs
+++ b/freeq-oauth/src/lib.rs
@@ -63,21 +63,36 @@ pub fn urlencode(s: &str) -> String {
 }
 
 /// Build the OAuth `client_id`.
-///
-/// Loopback origins (`http://127.*`, `http://192.168.*`, `http://10.*`)
-/// use the `http://localhost?redirect_uri=…&scope=…` form the AT Protocol
-/// spec defines for development clients; everything else uses the URL of
-/// the hosted `client-metadata.json` document. The advertised scope is the
-/// full [`CLIENT_METADATA_SCOPE`] union in both cases.
 pub fn build_client_id(web_origin: &str, redirect_uri: &str) -> String {
+    build_client_id_with_scopes(web_origin, redirect_uri, None)
+}
+
+/// Build the OAuth `client_id` with `extra_scopes`.
+///
+/// Loopback origins (`http://127.*`, `http://192.168.*`, `http://10.*`) take
+/// the `http://localhost?redirect_uri=…&scope=…` form the AT Protocol spec
+/// defines for development clients; everything else names the hosted
+/// `client-metadata.json`. A loopback client carries its scope list inside
+/// the id, matched token for token against what a flow requests, so a scope
+/// absent here cannot be requested at all. The id is the client's identity,
+/// so callers pass the same extras across login and step-up alike.
+pub fn build_client_id_with_scopes(
+    web_origin: &str,
+    redirect_uri: &str,
+    extra_scopes: Option<&str>,
+) -> String {
     if web_origin.starts_with("http://127.")
         || web_origin.starts_with("http://192.168.")
         || web_origin.starts_with("http://10.")
     {
+        let scopes = match extra_scopes {
+            Some(extra) if !extra.is_empty() => format!("{CLIENT_METADATA_SCOPE} {extra}"),
+            _ => CLIENT_METADATA_SCOPE.to_string(),
+        };
         format!(
             "http://localhost?redirect_uri={}&scope={}",
             urlencode(redirect_uri),
-            urlencode(CLIENT_METADATA_SCOPE),
+            urlencode(&scopes),
         )
     } else {
         format!("{web_origin}/client-metadata.json")

--- a/freeq-sdk/src/media.rs
+++ b/freeq-sdk/src/media.rs
@@ -587,6 +587,110 @@ async fn dpop_post(
     anyhow::bail!("Request failed after retries")
 }
 
+/// Upload media into one of a freeq server's private media spaces, on behalf
+/// of the user whose OAuth session is supplied.
+///
+/// Spaces have no upload method of their own: the blob goes up through the
+/// normal `uploadBlob` (where it stays untethered and unreachable) and becomes
+/// permanent, and private to the space, once a space record references it.
+///
+/// Returns the `at://` URI of the record.
+#[allow(clippy::too_many_arguments)]
+pub async fn upload_media_to_space(
+    pds_url: &str,
+    did: &str,
+    access_token: &str,
+    dpop_key: Option<&crate::oauth::DpopKey>,
+    dpop_nonce: Option<&str>,
+    space: &str,
+    collection: &str,
+    content_type: &str,
+    data: &[u8],
+    alt_text: Option<&str>,
+) -> Result<SpaceUploadResult> {
+    let client = reqwest::Client::new();
+    let base = pds_url.trim_end_matches('/');
+    let mut current_nonce = dpop_nonce.map(|s| s.to_string());
+
+    let blob_json = dpop_post(
+        &client,
+        base,
+        "com.atproto.repo.uploadBlob",
+        dpop_key,
+        access_token,
+        &mut current_nonce,
+        Some(content_type),
+        data.to_vec(),
+    )
+    .await
+    .context("Blob upload to PDS failed — your session may have expired.")?;
+
+    let blob = &blob_json["blob"];
+    let cid = blob["ref"]["$link"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("No CID in upload response"))?
+        .to_string();
+    let size = blob["size"].as_u64().unwrap_or(data.len() as u64);
+    let mime = blob["mimeType"]
+        .as_str()
+        .unwrap_or(content_type)
+        .to_string();
+
+    // The record both pins the blob and describes it, so the media stays
+    // meaningful on its own once the chat message is gone.
+    let now = chrono::Utc::now().to_rfc3339();
+    let body = serde_json::json!({
+        "space": space,
+        "repo": did,
+        "collection": collection,
+        "record": {
+            "$type": collection,
+            "blob": blob.clone(),
+            "mimeType": mime,
+            "alt": alt_text.unwrap_or(""),
+            "createdAt": now,
+        }
+    });
+
+    let created = dpop_post(
+        &client,
+        base,
+        "com.atproto.space.createRecord",
+        dpop_key,
+        access_token,
+        &mut current_nonce,
+        None,
+        serde_json::to_vec(&body)?,
+    )
+    .await
+    .context("Space record creation failed")?;
+
+    let uri = created["uri"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("No uri in space createRecord response"))?
+        .to_string();
+
+    Ok(SpaceUploadResult {
+        uri,
+        cid,
+        size,
+        mime_type: mime,
+        updated_nonce: current_nonce,
+    })
+}
+
+/// Result of a space media upload.
+#[derive(Debug, Clone)]
+pub struct SpaceUploadResult {
+    /// `at://` URI of the record holding the blob.
+    pub uri: String,
+    /// Content identifier of the blob itself.
+    pub cid: String,
+    pub size: u64,
+    pub mime_type: String,
+    pub updated_nonce: Option<String>,
+}
+
 /// Result of a media upload.
 #[derive(Debug, Clone)]
 pub struct MediaUploadResult {

--- a/freeq-server/src/config.rs
+++ b/freeq-server/src/config.rs
@@ -239,6 +239,19 @@ pub struct ServerConfig {
     #[arg(long, env = "BROKER_SHARED_SECRET")]
     pub broker_shared_secret: Option<String>,
 
+    /// DID of the private-media space authority. The account must be on a
+    /// spaces-capable PDS. Enables private media via AT Protocol spaces.
+    #[arg(long, env = "FREEQ_MEDIA_SPACE_DID")]
+    pub media_space_did: Option<String>,
+
+    /// Password for the space authority account.
+    #[arg(long, env = "FREEQ_MEDIA_SPACE_PASSWORD")]
+    pub media_space_password: Option<String>,
+
+    /// Base URL of the spaces PDS.
+    #[arg(long, env = "FREEQ_MEDIA_SPACE_PDS")]
+    pub media_space_pds: Option<String>,
+
     /// Server operator password. If set, the OPER command is enabled.
     /// OPER grants global operator privileges (can kick/ban in any channel, etc.)
     /// Can also be set via OPER_PASSWORD environment variable.
@@ -383,6 +396,9 @@ impl Default for ServerConfig {
             github_client_id: None,
             github_client_secret: None,
             broker_shared_secret: None,
+            media_space_did: None,
+            media_space_password: None,
+            media_space_pds: None,
             oper_password: None,
             oper_dids: vec![],
             allowed_dids: vec![],
@@ -524,6 +540,9 @@ struct FileConfig {
     github_client_id: Option<String>,
     github_client_secret: Option<String>,
     broker_shared_secret: Option<String>,
+    media_space_did: Option<String>,
+    media_space_password: Option<String>,
+    media_space_pds: Option<String>,
     oper_password: Option<String>,
     oper_dids: Option<Vec<String>>,
     allowed_dids: Option<Vec<String>>,
@@ -666,6 +685,9 @@ fn apply_file(cfg: &mut ServerConfig, matches: &clap::ArgMatches, file: FileConf
         github_client_id,
         github_client_secret,
         broker_shared_secret,
+        media_space_did,
+        media_space_password,
+        media_space_pds,
         oper_password,
         llm_provider,
         llm_base_url,

--- a/freeq-server/src/db.rs
+++ b/freeq-server/src/db.rs
@@ -740,8 +740,8 @@ impl Db {
         let did_ops_json = serde_json::to_string(&ch.did_ops.iter().collect::<Vec<_>>())
             .unwrap_or_else(|_| "[]".to_string());
         self.conn.execute(
-            "INSERT INTO channels (name, topic_text, topic_set_by, topic_set_at, topic_locked, invite_only, no_ext_msg, moderated, key, founder_did, did_ops_json, encrypted_only)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            "INSERT INTO channels (name, topic_text, topic_set_by, topic_set_at, topic_locked, invite_only, no_ext_msg, moderated, key, founder_did, did_ops_json, encrypted_only, media_space_key)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
              ON CONFLICT(name) DO UPDATE SET
                 topic_text=excluded.topic_text,
                 topic_set_by=excluded.topic_set_by,
@@ -753,7 +753,8 @@ impl Db {
                 key=excluded.key,
                 founder_did=excluded.founder_did,
                 did_ops_json=excluded.did_ops_json,
-                encrypted_only=excluded.encrypted_only",
+                encrypted_only=excluded.encrypted_only,
+                media_space_key=excluded.media_space_key",
             params![
                 name,
                 ch.topic.as_ref().map(|t| &t.text),
@@ -767,6 +768,7 @@ impl Db {
                 ch.founder_did.as_deref(),
                 did_ops_json,
                 ch.encrypted_only as i32,
+                ch.media_space_key.as_deref(),
             ],
         )?;
         Ok(())
@@ -791,7 +793,7 @@ impl Db {
         let mut channels = HashMap::new();
 
         let mut stmt = self.conn.prepare(
-            "SELECT name, topic_text, topic_set_by, topic_set_at, topic_locked, invite_only, key, no_ext_msg, moderated, founder_did, did_ops_json, encrypted_only
+            "SELECT name, topic_text, topic_set_by, topic_set_at, topic_locked, invite_only, key, no_ext_msg, moderated, founder_did, did_ops_json, encrypted_only, media_space_key
              FROM channels"
         )?;
         let rows = stmt.query_map([], |row| {
@@ -809,6 +811,7 @@ impl Db {
                 .get::<_, Option<String>>(10)?
                 .unwrap_or_else(|| "[]".to_string());
             let encrypted_only: bool = row.get::<_, Option<i32>>(11)?.unwrap_or(0) != 0;
+            let media_space_key: Option<String> = row.get(12)?;
 
             let topic = match (topic_text, topic_set_by, topic_set_at) {
                 (Some(text), Some(set_by), Some(set_at)) => Some(TopicInfo {
@@ -832,6 +835,7 @@ impl Db {
                 founder_did,
                 did_ops,
                 encrypted_only,
+                media_space_key,
                 ..Default::default()
             };
             Ok((name, ch))

--- a/freeq-server/src/lib.rs
+++ b/freeq-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod irc;
 pub mod iroh;
 pub mod manifest;
+pub mod media_space;
 pub mod media_store;
 pub mod migrations;
 pub mod model_proxy;

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -94,7 +94,10 @@ impl MediaSpaceManager {
     }
 
     /// The creation lock for one channel key, minted on first use.
-    pub async fn create_lock_for(&self, channel_key: &str) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    pub async fn create_lock_for(
+        &self,
+        channel_key: &str,
+    ) -> std::sync::Arc<tokio::sync::Mutex<()>> {
         self.create_locks
             .lock()
             .await

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -18,10 +18,15 @@ pub const SPACE_TYPE: &str = "at.freeq.media";
 /// this server's `did:web` document.
 pub const MANAGING_APP_FRAGMENT: &str = "freeq_media";
 
-/// The OAuth scope token granting full access to this server's media spaces.
-/// Explicit `collection=*` spares the PDS resolving the space type's lexicon.
+/// Collection holding one media item per record inside a media space.
+pub const MEDIA_COLLECTION: &str = "at.freeq.media.item";
+
+/// The OAuth scope token granting access to this server's media spaces.
+///
+/// The type is `*` because a named one must resolve to a published lexicon
+/// and [`SPACE_TYPE`] is not published.
 pub fn space_scope(authority_did: &str) -> String {
-    format!("space:{SPACE_TYPE}?authority={authority_did}&collection=*")
+    format!("space:*?authority={authority_did}&collection=*")
 }
 
 /// Client for the spaces PDS plus the identity this server manages spaces as.
@@ -33,6 +38,7 @@ pub struct MediaSpaceManager {
     pds_url: tokio::sync::Mutex<Option<String>>,
     session: tokio::sync::Mutex<Option<String>>,
     pub create_lock: tokio::sync::Mutex<()>,
+    credentials: tokio::sync::Mutex<std::collections::HashMap<String, CachedCredential>>,
     http: reqwest::Client,
     server_name: String,
 }
@@ -51,6 +57,7 @@ impl MediaSpaceManager {
             pds_url: tokio::sync::Mutex::new(None),
             session: tokio::sync::Mutex::new(None),
             create_lock: tokio::sync::Mutex::new(()),
+            credentials: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             http: reqwest::Client::new(),
             server_name,
         }
@@ -175,6 +182,262 @@ impl MediaSpaceManager {
         }
         unreachable!("createSpace retry loop always returns or bails");
     }
+
+    /// Parse a record URI naming a record in one of this server's spaces:
+    /// `at://{authority}/space/{type}/{skey}/{author}/{collection}/{rkey}`.
+    pub fn parse_record_uri(&self, uri: &str) -> Option<SpaceRecordRef> {
+        let rest = uri.strip_prefix("at://")?;
+        let parts: Vec<&str> = rest.split('/').collect();
+        let [did, marker, space_type, skey, author, collection, rkey] = parts[..] else {
+            return None;
+        };
+        if did != self.authority_did
+            || marker != "space"
+            || space_type != SPACE_TYPE
+            || skey.is_empty()
+            || !author.starts_with("did:")
+            || collection.is_empty()
+            || rkey.is_empty()
+        {
+            return None;
+        }
+        Some(SpaceRecordRef {
+            space: self.space_ref(skey),
+            space_key: skey.to_string(),
+            author_did: author.to_string(),
+            collection: collection.to_string(),
+            rkey: rkey.to_string(),
+        })
+    }
+
+    /// A space credential for reading `space`, minted for this server's own
+    /// authority identity and bound to a DPoP key.
+    ///
+    /// The server reads on behalf of members it has already authorized.
+    async fn space_credential(
+        &self,
+        resolver: &DidResolver,
+        space: &str,
+    ) -> Result<(String, freeq_sdk::oauth::DpopKey)> {
+        {
+            let cache = self.credentials.lock().await;
+            if let Some(entry) = cache.get(space)
+                && entry.good_until > now_secs()
+            {
+                return Ok((
+                    entry.credential.clone(),
+                    freeq_sdk::oauth::DpopKey::from_base64url(&entry.dpop_key_b64)?,
+                ));
+            }
+        }
+
+        let pds = self.pds_url(resolver).await?;
+        let token = self.session_token(resolver).await?;
+        // Step 1: our own PDS mints a delegation token for the space.
+        let res = self
+            .http
+            .get(format!("{pds}/xrpc/com.atproto.space.getDelegationToken"))
+            .query(&[("space", space)])
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("getDelegationToken request")?;
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            bail!("getDelegationToken failed: {status} {body}");
+        }
+        let delegation = res.json::<serde_json::Value>().await?["token"]
+            .as_str()
+            .context("getDelegationToken response missing token")?
+            .to_string();
+
+        // Step 2: the authority exchanges it for a credential bound to our
+        // DPoP key. Presenting the proof here is what sets that binding.
+        let dpop_key = freeq_sdk::oauth::DpopKey::generate();
+        let url = format!("{pds}/xrpc/com.atproto.space.getSpaceCredential");
+        let mut nonce: Option<String> = None;
+        let mut credential = None;
+        for attempt in 0..3 {
+            let proof = dpop_key.proof("POST", &url, nonce.as_deref(), Some(&delegation))?;
+            let res = self
+                .http
+                .post(&url)
+                .header("Authorization", format!("DPoP {delegation}"))
+                .header("DPoP", proof)
+                .json(&serde_json::json!({ "space": space }))
+                .send()
+                .await
+                .context("getSpaceCredential request")?;
+            if let Some(n) = res
+                .headers()
+                .get("dpop-nonce")
+                .and_then(|v| v.to_str().ok())
+            {
+                nonce = Some(n.to_string());
+            }
+            let status = res.status();
+            if status.is_success() {
+                credential = res.json::<serde_json::Value>().await?["credential"]
+                    .as_str()
+                    .map(str::to_string);
+                break;
+            }
+            let body = res.text().await.unwrap_or_default();
+            // The first call to a host has no nonce yet and is expected to
+            // fail once with the nonce we then use.
+            if (status == 401 || status == 400) && attempt < 2 {
+                continue;
+            }
+            bail!("getSpaceCredential failed: {status} {body}");
+        }
+        let credential = credential.context("getSpaceCredential returned no credential")?;
+
+        self.credentials.lock().await.insert(
+            space.to_string(),
+            CachedCredential {
+                credential: credential.clone(),
+                dpop_key_b64: dpop_key.to_base64url(),
+                good_until: now_secs() + 1800,
+            },
+        );
+        Ok((credential, dpop_key))
+    }
+
+    /// Fetch a media record and its blob from the author's PDS. Returns the
+    /// bytes and the MIME type the record declares.
+    pub async fn fetch_media(
+        &self,
+        resolver: &DidResolver,
+        rec: &SpaceRecordRef,
+    ) -> Result<(Vec<u8>, String)> {
+        let (credential, dpop_key) = self.space_credential(resolver, &rec.space).await?;
+        let author_doc = resolver
+            .resolve(&rec.author_did)
+            .await
+            .context("resolving media author's DID")?;
+        let repo_host = author_doc
+            .service
+            .iter()
+            .find(|s| s.id.ends_with("#atproto_pds"))
+            .map(|s| s.service_endpoint.trim_end_matches('/').to_string())
+            .context("media author's DID document has no PDS")?;
+
+        let record = self
+            .space_get_json(
+                &format!("{repo_host}/xrpc/com.atproto.space.getRecord"),
+                &[
+                    ("space", rec.space.as_str()),
+                    ("repo", rec.author_did.as_str()),
+                    ("collection", rec.collection.as_str()),
+                    ("rkey", rec.rkey.as_str()),
+                ],
+                &credential,
+                &dpop_key,
+            )
+            .await
+            .context("fetching space media record")?;
+        let value = &record["value"];
+        let cid = value["blob"]["ref"]["$link"]
+            .as_str()
+            .context("media record has no blob reference")?;
+        let mime = value["mimeType"]
+            .as_str()
+            .unwrap_or("application/octet-stream")
+            .to_string();
+
+        let bytes = self
+            .space_get_bytes(
+                &format!("{repo_host}/xrpc/com.atproto.space.getBlob"),
+                &[
+                    ("space", rec.space.as_str()),
+                    ("repo", rec.author_did.as_str()),
+                    ("cid", cid),
+                ],
+                &credential,
+                &dpop_key,
+            )
+            .await
+            .context("fetching space media blob")?;
+        Ok((bytes, mime))
+    }
+
+    async fn space_get_json(
+        &self,
+        url: &str,
+        params: &[(&str, &str)],
+        credential: &str,
+        dpop_key: &freeq_sdk::oauth::DpopKey,
+    ) -> Result<serde_json::Value> {
+        let bytes = self
+            .space_get_bytes(url, params, credential, dpop_key)
+            .await?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// A credential-authenticated XRPC GET, with the DPoP nonce handshake the
+    /// first call to a host always needs.
+    async fn space_get_bytes(
+        &self,
+        url: &str,
+        params: &[(&str, &str)],
+        credential: &str,
+        dpop_key: &freeq_sdk::oauth::DpopKey,
+    ) -> Result<Vec<u8>> {
+        let mut nonce: Option<String> = None;
+        for attempt in 0..3 {
+            let proof = dpop_key.proof("GET", url, nonce.as_deref(), Some(credential))?;
+            let res = self
+                .http
+                .get(url)
+                .query(params)
+                .header("Authorization", format!("DPoP {credential}"))
+                .header("DPoP", proof)
+                .send()
+                .await?;
+            if let Some(n) = res
+                .headers()
+                .get("dpop-nonce")
+                .and_then(|v| v.to_str().ok())
+            {
+                nonce = Some(n.to_string());
+            }
+            let status = res.status();
+            if status.is_success() {
+                return Ok(res.bytes().await?.to_vec());
+            }
+            if (status == 401 || status == 400) && attempt < 2 {
+                continue;
+            }
+            let body = res.text().await.unwrap_or_default();
+            bail!("{status}: {body}");
+        }
+        bail!("space request failed after retries")
+    }
+}
+
+/// A record inside one of this server's spaces, as named by an `at://` URI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpaceRecordRef {
+    /// The space the record lives in, without the record tail.
+    pub space: String,
+    pub space_key: String,
+    pub author_did: String,
+    pub collection: String,
+    pub rkey: String,
+}
+
+struct CachedCredential {
+    credential: String,
+    dpop_key_b64: String,
+    good_until: u64,
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 pub async fn verify_service_auth(
@@ -300,6 +563,52 @@ mod tests {
         );
         assert_eq!(m.parse_space_key("not-a-uri"), None);
         assert_eq!(m.parse_space_key("at://did:plc:authority123"), None);
+    }
+
+    #[test]
+    fn parses_a_record_uri_in_one_of_our_spaces() {
+        let m = mgr();
+        let rec = m
+            .parse_record_uri(
+                "at://did:plc:authority123/space/at.freeq.media/K1/did:plc:alice/at.freeq.media.item/3kx",
+            )
+            .expect("well-formed record uri");
+        assert_eq!(rec.space_key, "K1");
+        assert_eq!(rec.author_did, "did:plc:alice");
+        assert_eq!(rec.collection, "at.freeq.media.item");
+        assert_eq!(rec.rkey, "3kx");
+        assert_eq!(rec.space, m.space_ref("K1"));
+    }
+
+    #[test]
+    fn record_uri_parsing_rejects_anything_not_ours() {
+        let m = mgr();
+        for uri in [
+            // Someone else's authority.
+            "at://did:plc:other/space/at.freeq.media/K1/did:plc:alice/at.freeq.media.item/3kx",
+            // A different space type.
+            "at://did:plc:authority123/space/com.example.other/K1/did:plc:alice/c/3kx",
+            // A bare space ref carries no record.
+            "at://did:plc:authority123/space/at.freeq.media/K1",
+            // The author must be a DID.
+            "at://did:plc:authority123/space/at.freeq.media/K1/alice/at.freeq.media.item/3kx",
+            // Trailing junk beyond the record tail.
+            "at://did:plc:authority123/space/at.freeq.media/K1/did:plc:alice/c/3kx/extra",
+            "not-a-uri",
+        ] {
+            assert!(
+                m.parse_record_uri(uri).is_none(),
+                "must not parse as one of our records: {uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn space_scope_names_this_authority() {
+        assert_eq!(
+            space_scope("did:plc:authority123"),
+            "space:*?authority=did:plc:authority123&collection=*"
+        );
     }
 
     #[test]

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -18,6 +18,12 @@ pub const SPACE_TYPE: &str = "at.freeq.media";
 /// this server's `did:web` document.
 pub const MANAGING_APP_FRAGMENT: &str = "freeq_media";
 
+/// The OAuth scope token granting full access to this server's media spaces.
+/// Explicit `collection=*` spares the PDS resolving the space type's lexicon.
+pub fn space_scope(authority_did: &str) -> String {
+    format!("space:{SPACE_TYPE}?authority={authority_did}&collection=*")
+}
+
 /// Client for the spaces PDS plus the identity this server manages spaces as.
 pub struct MediaSpaceManager {
     pub authority_did: String,

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -26,6 +26,18 @@ pub const MEDIA_COLLECTION: &str = "at.freeq.media.item";
 /// Call timeout on a repo host.
 const REPO_HOST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
+/// How long a fetched blob stays in the in-process cache.
+///
+/// Matches the `max-age` we hand the browser. Without this, a virtualized
+/// message list re-fetches an image from the *author's* PDS every time the
+/// row scrolls back into view, and a public channel's media URL is an
+/// unauthenticated amplifier pointed at a third party.
+const MEDIA_CACHE_TTL_SECS: u64 = 300;
+
+/// Total bytes the media cache may hold before the oldest entries are
+/// dropped. Six or so files at the [`MAX_MEDIA_BYTES`] ceiling.
+const MEDIA_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
+
 /// The OAuth scopes an upload to this server's media spaces takes:
 /// `blob:*/*` for the bytes, which go up through the ordinary uploadBlob,
 /// and the space scope for the record that pins them.
@@ -49,8 +61,13 @@ pub struct MediaSpaceManager {
     pds_override: Option<String>,
     pds_url: tokio::sync::Mutex<Option<String>>,
     session: tokio::sync::Mutex<Option<String>>,
-    pub create_lock: tokio::sync::Mutex<()>,
+    /// One creation lock per channel key. A global lock would let a single
+    /// slow `createSpace` stall every other channel's first upload.
+    create_locks: tokio::sync::Mutex<
+        std::collections::HashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>,
+    >,
     credentials: tokio::sync::Mutex<std::collections::HashMap<String, CachedCredential>>,
+    media_cache: tokio::sync::Mutex<std::collections::HashMap<String, CachedMedia>>,
     http: reqwest::Client,
     server_name: String,
 }
@@ -68,11 +85,22 @@ impl MediaSpaceManager {
             pds_override,
             pds_url: tokio::sync::Mutex::new(None),
             session: tokio::sync::Mutex::new(None),
-            create_lock: tokio::sync::Mutex::new(()),
+            create_locks: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             credentials: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            media_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             http: reqwest::Client::new(),
             server_name,
         }
+    }
+
+    /// The creation lock for one channel key, minted on first use.
+    pub async fn create_lock_for(&self, channel_key: &str) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        self.create_locks
+            .lock()
+            .await
+            .entry(channel_key.to_string())
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     pub fn managing_app(&self) -> String {
@@ -118,8 +146,33 @@ impl MediaSpaceManager {
             .find(|s| s.id.ends_with("#atproto_pds"))
             .map(|s| s.service_endpoint.trim_end_matches('/').to_string())
             .context("authority DID document has no #atproto_pds service")?;
+        // The PLC directory is outside our control and the very next request
+        // carries the authority account's password. Refuse to send it in the
+        // clear no matter what the document says.
+        if !url.starts_with("https://") {
+            bail!("authority DID document names a non-HTTPS PDS endpoint");
+        }
         *cached = Some(url.clone());
         Ok(url)
+    }
+
+    /// HTTP client for a call to the authority's own PDS.
+    ///
+    /// An explicitly configured `media_space_pds` is operator input and is
+    /// trusted as given — dev and test setups point it at loopback. A URL
+    /// resolved from the authority's DID document is attacker-influenceable
+    /// (a hijacked PLC record redirects it), and these are the requests that
+    /// carry the account password and mint space credentials, so they get the
+    /// same DNS-pinned, redirect-refusing guard as every other resolved
+    /// endpoint.
+    async fn authority_client(&self, url: &str) -> Result<reqwest::Client> {
+        if self.pds_override.is_some() {
+            return Ok(self.http.clone());
+        }
+        let (_, client) = crate::web::safe_outbound_client(url, REPO_HOST_TIMEOUT)
+            .await
+            .map_err(|(_, msg)| anyhow::anyhow!("{msg}"))?;
+        Ok(client)
     }
 
     async fn session_token(&self, resolver: &DidResolver) -> Result<String> {
@@ -128,9 +181,11 @@ impl MediaSpaceManager {
             return Ok(token.clone());
         }
         let pds = self.pds_url(resolver).await?;
+        let url = format!("{pds}/xrpc/com.atproto.server.createSession");
         let res = self
-            .http
-            .post(format!("{pds}/xrpc/com.atproto.server.createSession"))
+            .authority_client(&url)
+            .await?
+            .post(&url)
             .json(&serde_json::json!({
                 "identifier": self.authority_did,
                 "password": self.password,
@@ -157,15 +212,16 @@ impl MediaSpaceManager {
     /// space (crash after create, before persist) is success.
     pub async fn create_space(&self, resolver: &DidResolver, key: &str) -> Result<()> {
         let pds = self.pds_url(resolver).await?;
+        let url = format!("{pds}/xrpc/com.atproto.simplespace.createSpace");
+        let client = self.authority_client(&url).await?;
         // One retry with a fresh session: the cached token may have expired.
         for attempt in 0..2 {
             if attempt > 0 {
                 *self.session.lock().await = None;
             }
             let token = self.session_token(resolver).await?;
-            let res = self
-                .http
-                .post(format!("{pds}/xrpc/com.atproto.simplespace.createSpace"))
+            let res = client
+                .post(&url)
                 .bearer_auth(&token)
                 .json(&serde_json::json!({
                     "type": SPACE_TYPE,
@@ -245,15 +301,16 @@ impl MediaSpaceManager {
 
         let pds = self.pds_url(resolver).await?;
         // Step 1: our PDS creates a delegation token for the space.
+        let delegation_url = format!("{pds}/xrpc/com.atproto.space.getDelegationToken");
+        let client = self.authority_client(&delegation_url).await?;
         let mut delegation = None;
         for attempt in 0..2 {
             if attempt > 0 {
                 *self.session.lock().await = None;
             }
             let token = self.session_token(resolver).await?;
-            let res = self
-                .http
-                .get(format!("{pds}/xrpc/com.atproto.space.getDelegationToken"))
+            let res = client
+                .get(&delegation_url)
                 .query(&[("space", space)])
                 .bearer_auth(&token)
                 .send()
@@ -282,8 +339,7 @@ impl MediaSpaceManager {
         let mut credential = None;
         for attempt in 0..3 {
             let proof = dpop_key.proof("POST", &url, nonce.as_deref(), None)?;
-            let res = self
-                .http
+            let res = client
                 .post(&url)
                 .header("Authorization", format!("Bearer {delegation}"))
                 .header("DPoP", proof)
@@ -326,9 +382,70 @@ impl MediaSpaceManager {
         Ok((credential, dpop_key))
     }
 
+    /// Fetch a media record and its blob, memoized for [`MEDIA_CACHE_TTL_SECS`].
+    ///
+    /// Every miss costs two round trips to a *third party's* PDS and up to
+    /// [`MAX_MEDIA_BYTES`] of their bandwidth. A virtualized message list
+    /// re-mounts the same image constantly, and a public channel's media URL
+    /// is readable without a bearer, so an uncached fetch here is an
+    /// amplifier aimed at the uploader's host.
+    pub async fn fetch_media(
+        &self,
+        resolver: &DidResolver,
+        rec: &SpaceRecordRef,
+    ) -> Result<(Vec<u8>, String)> {
+        let cache_key = format!(
+            "{}/{}/{}/{}",
+            rec.space, rec.author_did, rec.collection, rec.rkey
+        );
+        {
+            let cache = self.media_cache.lock().await;
+            if let Some(hit) = cache.get(&cache_key)
+                && hit.good_until > now_secs()
+            {
+                return Ok((hit.bytes.clone(), hit.mime.clone()));
+            }
+        }
+        let (bytes, mime) = self.fetch_media_uncached(resolver, rec).await?;
+        self.remember_media(cache_key, &bytes, &mime).await;
+        Ok((bytes, mime))
+    }
+
+    /// Insert into the media cache, first dropping anything expired and then,
+    /// if still over the ceiling, the entries closest to expiry.
+    async fn remember_media(&self, key: String, bytes: &[u8], mime: &str) {
+        if bytes.len() > MEDIA_CACHE_MAX_BYTES {
+            return;
+        }
+        let now = now_secs();
+        let mut cache = self.media_cache.lock().await;
+        cache.retain(|_, e| e.good_until > now);
+        cache.insert(
+            key,
+            CachedMedia {
+                bytes: bytes.to_vec(),
+                mime: mime.to_string(),
+                good_until: now + MEDIA_CACHE_TTL_SECS,
+            },
+        );
+        let mut total: usize = cache.values().map(|e| e.bytes.len()).sum();
+        while total > MEDIA_CACHE_MAX_BYTES {
+            let Some(oldest) = cache
+                .iter()
+                .min_by_key(|(_, e)| e.good_until)
+                .map(|(k, _)| k.clone())
+            else {
+                break;
+            };
+            if let Some(dropped) = cache.remove(&oldest) {
+                total -= dropped.bytes.len();
+            }
+        }
+    }
+
     /// Fetch a media record and its blob from the author's PDS. Returns the
     /// bytes and the MIME type the record declares.
-    pub async fn fetch_media(
+    async fn fetch_media_uncached(
         &self,
         resolver: &DidResolver,
         rec: &SpaceRecordRef,
@@ -472,12 +589,27 @@ struct CachedCredential {
     good_until: u64,
 }
 
+struct CachedMedia {
+    bytes: Vec<u8>,
+    mime: String,
+    good_until: u64,
+}
+
 fn now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
 }
+
+/// Longest `exp` we will honour on a service-auth token, measured from now.
+/// atproto mints these for a minute or two; anything claiming hours is either
+/// broken or an attempt to make a captured token durable.
+const MAX_SERVICE_AUTH_LIFETIME_SECS: i64 = 15 * 60;
+
+/// Signature algorithms an atproto service-auth token may declare. Anything
+/// else — `none` above all — is refused before a key is ever consulted.
+const ALLOWED_SERVICE_AUTH_ALGS: [&str; 2] = ["ES256K", "EdDSA"];
 
 pub async fn verify_service_auth(
     resolver: &DidResolver,
@@ -491,6 +623,18 @@ pub async fn verify_service_auth(
     else {
         bail!("malformed JWT");
     };
+    let header_json: serde_json::Value = serde_json::from_slice(
+        &URL_SAFE_NO_PAD
+            .decode(header)
+            .context("JWT header base64")?,
+    )
+    .context("JWT header JSON")?;
+    let alg = header_json["alg"]
+        .as_str()
+        .context("service auth header has no alg")?;
+    if !ALLOWED_SERVICE_AUTH_ALGS.contains(&alg) {
+        bail!("service auth declares unsupported alg {alg}");
+    }
     let claims: serde_json::Value = serde_json::from_slice(
         &URL_SAFE_NO_PAD
             .decode(payload)
@@ -514,6 +658,9 @@ pub async fn verify_service_auth(
         .as_secs() as i64;
     if exp < now {
         bail!("service auth expired");
+    }
+    if exp > now + MAX_SERVICE_AUTH_LIFETIME_SECS {
+        bail!("service auth exp is further out than we accept");
     }
 
     let sig_bytes = URL_SAFE_NO_PAD

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -21,12 +21,19 @@ pub const MANAGING_APP_FRAGMENT: &str = "freeq_media";
 /// Collection holding one media item per record inside a media space.
 pub const MEDIA_COLLECTION: &str = "at.freeq.media.item";
 
-/// The OAuth scope token granting access to this server's media spaces.
+/// The OAuth scopes an upload to this server's media spaces takes:
+/// `blob:*/*` for the bytes, which go up through the ordinary uploadBlob,
+/// and the space scope for the record that pins them.
 ///
-/// The type is `*` because a named one must resolve to a published lexicon
+/// The type is `*` because a named one must resolve to a published lexicon,
 /// and [`SPACE_TYPE`] is not published.
 pub fn space_scope(authority_did: &str) -> String {
-    format!("space:*?authority={authority_did}&collection=*")
+    format!("blob:*/* space:*?authority={authority_did}&collection=*")
+}
+
+/// Check for a stale cached session token is stale.
+fn session_expired(status: reqwest::StatusCode, body: &str) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED || body.contains("ExpiredToken")
 }
 
 /// Client for the spaces PDS plus the identity this server manages spaces as.
@@ -175,7 +182,7 @@ impl MediaSpaceManager {
             if body.contains("SpaceAlreadyExists") {
                 return Ok(());
             }
-            if status.as_u16() == 401 && attempt == 0 {
+            if session_expired(status, &body) && attempt == 0 {
                 continue;
             }
             bail!("createSpace failed: {status} {body}");
@@ -232,25 +239,35 @@ impl MediaSpaceManager {
         }
 
         let pds = self.pds_url(resolver).await?;
-        let token = self.session_token(resolver).await?;
-        // Step 1: our own PDS mints a delegation token for the space.
-        let res = self
-            .http
-            .get(format!("{pds}/xrpc/com.atproto.space.getDelegationToken"))
-            .query(&[("space", space)])
-            .bearer_auth(&token)
-            .send()
-            .await
-            .context("getDelegationToken request")?;
-        if !res.status().is_success() {
+        // Step 1: our PDS creates a delegation token for the space.
+        let mut delegation = None;
+        for attempt in 0..2 {
+            if attempt > 0 {
+                *self.session.lock().await = None;
+            }
+            let token = self.session_token(resolver).await?;
+            let res = self
+                .http
+                .get(format!("{pds}/xrpc/com.atproto.space.getDelegationToken"))
+                .query(&[("space", space)])
+                .bearer_auth(&token)
+                .send()
+                .await
+                .context("getDelegationToken request")?;
             let status = res.status();
+            if status.is_success() {
+                delegation = res.json::<serde_json::Value>().await?["token"]
+                    .as_str()
+                    .map(str::to_string);
+                break;
+            }
             let body = res.text().await.unwrap_or_default();
+            if session_expired(status, &body) && attempt == 0 {
+                continue;
+            }
             bail!("getDelegationToken failed: {status} {body}");
         }
-        let delegation = res.json::<serde_json::Value>().await?["token"]
-            .as_str()
-            .context("getDelegationToken response missing token")?
-            .to_string();
+        let delegation = delegation.context("getDelegationToken returned no token")?;
 
         // Step 2: the authority exchanges it for a credential bound to our
         // DPoP key. Presenting the proof here is what sets that binding.
@@ -259,11 +276,11 @@ impl MediaSpaceManager {
         let mut nonce: Option<String> = None;
         let mut credential = None;
         for attempt in 0..3 {
-            let proof = dpop_key.proof("POST", &url, nonce.as_deref(), Some(&delegation))?;
+            let proof = dpop_key.proof("POST", &url, nonce.as_deref(), None)?;
             let res = self
                 .http
                 .post(&url)
-                .header("Authorization", format!("DPoP {delegation}"))
+                .header("Authorization", format!("Bearer {delegation}"))
                 .header("DPoP", proof)
                 .json(&serde_json::json!({ "space": space }))
                 .send()
@@ -607,7 +624,7 @@ mod tests {
     fn space_scope_names_this_authority() {
         assert_eq!(
             space_scope("did:plc:authority123"),
-            "space:*?authority=did:plc:authority123&collection=*"
+            "blob:*/* space:*?authority=did:plc:authority123&collection=*"
         );
     }
 

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -1,0 +1,303 @@
+//! Private media via AT Protocol spaces.
+//!
+//! Each channel that shares private media owns one space,
+//! `at://{authority}/space/at.freeq.media/{key}`, on the operator's
+//! spaces-capable PDS. The space is created the first time media
+//! is shared and the live channel roster is the access list.
+//! Clients write to and read from members' own permissioned repos.
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use freeq_sdk::did::DidResolver;
+
+/// NSID of the space type. Part of every space ref this server creates.
+pub const SPACE_TYPE: &str = "at.freeq.media";
+
+/// Service fragment under which the managing-app endpoint is published in
+/// this server's `did:web` document.
+pub const MANAGING_APP_FRAGMENT: &str = "freeq_media";
+
+/// Client for the spaces PDS plus the identity this server manages spaces as.
+pub struct MediaSpaceManager {
+    pub authority_did: String,
+    password: String,
+    /// PDS base URL; when unset, resolved from the authority's DID document.
+    pds_override: Option<String>,
+    pds_url: tokio::sync::Mutex<Option<String>>,
+    session: tokio::sync::Mutex<Option<String>>,
+    pub create_lock: tokio::sync::Mutex<()>,
+    http: reqwest::Client,
+    server_name: String,
+}
+
+impl MediaSpaceManager {
+    pub fn new(
+        authority_did: String,
+        password: String,
+        pds_override: Option<String>,
+        server_name: String,
+    ) -> Self {
+        Self {
+            authority_did,
+            password,
+            pds_override,
+            pds_url: tokio::sync::Mutex::new(None),
+            session: tokio::sync::Mutex::new(None),
+            create_lock: tokio::sync::Mutex::new(()),
+            http: reqwest::Client::new(),
+            server_name,
+        }
+    }
+
+    pub fn managing_app(&self) -> String {
+        format!("did:web:{}#{}", self.server_name, MANAGING_APP_FRAGMENT)
+    }
+
+    pub fn space_ref(&self, key: &str) -> String {
+        format!("at://{}/space/{}/{}", self.authority_did, SPACE_TYPE, key)
+    }
+
+    pub fn parse_space_key<'a>(&self, space: &'a str) -> Option<&'a str> {
+        let rest = space.strip_prefix("at://")?;
+        let mut parts = rest.split('/');
+        let did = parts.next()?;
+        let marker = parts.next()?;
+        let space_type = parts.next()?;
+        let key = parts.next()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        (did == self.authority_did
+            && marker == "space"
+            && space_type == SPACE_TYPE
+            && !key.is_empty())
+        .then_some(key)
+    }
+
+    async fn pds_url(&self, resolver: &DidResolver) -> Result<String> {
+        if let Some(ref url) = self.pds_override {
+            return Ok(url.trim_end_matches('/').to_string());
+        }
+        let mut cached = self.pds_url.lock().await;
+        if let Some(ref url) = *cached {
+            return Ok(url.clone());
+        }
+        let doc = resolver
+            .resolve(&self.authority_did)
+            .await
+            .context("resolving media space authority DID")?;
+        let url = doc
+            .service
+            .iter()
+            .find(|s| s.id.ends_with("#atproto_pds"))
+            .map(|s| s.service_endpoint.trim_end_matches('/').to_string())
+            .context("authority DID document has no #atproto_pds service")?;
+        *cached = Some(url.clone());
+        Ok(url)
+    }
+
+    async fn session_token(&self, resolver: &DidResolver) -> Result<String> {
+        let mut session = self.session.lock().await;
+        if let Some(ref token) = *session {
+            return Ok(token.clone());
+        }
+        let pds = self.pds_url(resolver).await?;
+        let res = self
+            .http
+            .post(format!("{pds}/xrpc/com.atproto.server.createSession"))
+            .json(&serde_json::json!({
+                "identifier": self.authority_did,
+                "password": self.password,
+            }))
+            .send()
+            .await
+            .context("createSession request to spaces PDS")?;
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            bail!("createSession failed: {status} {body}");
+        }
+        let body: serde_json::Value = res.json().await.context("createSession response")?;
+        let token = body["accessJwt"]
+            .as_str()
+            .context("createSession response missing accessJwt")?
+            .to_string();
+        *session = Some(token.clone());
+        Ok(token)
+    }
+
+    /// Create the space for a channel key on the spaces PDS, with the
+    /// managing-app policy pointing back at this server. An already-existing
+    /// space (crash after create, before persist) is success.
+    pub async fn create_space(&self, resolver: &DidResolver, key: &str) -> Result<()> {
+        let pds = self.pds_url(resolver).await?;
+        // One retry with a fresh session: the cached token may have expired.
+        for attempt in 0..2 {
+            if attempt > 0 {
+                *self.session.lock().await = None;
+            }
+            let token = self.session_token(resolver).await?;
+            let res = self
+                .http
+                .post(format!("{pds}/xrpc/com.atproto.simplespace.createSpace"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({
+                    "type": SPACE_TYPE,
+                    "skey": key,
+                    "policy": {
+                        "$type": "com.atproto.simplespace.defs#managingAppPolicy",
+                        "managingApp": self.managing_app(),
+                    },
+                    "appAccess": { "$type": "com.atproto.simplespace.defs#open" },
+                }))
+                .send()
+                .await
+                .context("createSpace request to spaces PDS")?;
+            let status = res.status();
+            if status.is_success() {
+                return Ok(());
+            }
+            let body = res.text().await.unwrap_or_default();
+            if body.contains("SpaceAlreadyExists") {
+                return Ok(());
+            }
+            if status.as_u16() == 401 && attempt == 0 {
+                continue;
+            }
+            bail!("createSpace failed: {status} {body}");
+        }
+        unreachable!("createSpace retry loop always returns or bails");
+    }
+}
+
+pub async fn verify_service_auth(
+    resolver: &DidResolver,
+    jwt: &str,
+    authority_did: &str,
+    expected_aud: &str,
+    expected_lxm: &str,
+) -> Result<()> {
+    let mut parts = jwt.splitn(3, '.');
+    let (Some(header), Some(payload), Some(sig)) = (parts.next(), parts.next(), parts.next())
+    else {
+        bail!("malformed JWT");
+    };
+    let claims: serde_json::Value = serde_json::from_slice(
+        &URL_SAFE_NO_PAD
+            .decode(payload)
+            .context("JWT payload base64")?,
+    )
+    .context("JWT payload JSON")?;
+
+    if claims["iss"].as_str() != Some(authority_did) {
+        bail!("service auth iss is not the space authority");
+    }
+    if claims["aud"].as_str() != Some(expected_aud) {
+        bail!("service auth aud is not this managing app");
+    }
+    if claims["lxm"].as_str() != Some(expected_lxm) {
+        bail!("service auth lxm mismatch");
+    }
+    let exp = claims["exp"].as_i64().context("service auth missing exp")?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    if exp < now {
+        bail!("service auth expired");
+    }
+
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(sig)
+        .context("JWT signature base64")?;
+    let signing_input = format!("{header}.{payload}");
+    let doc = resolver
+        .resolve(authority_did)
+        .await
+        .context("resolving space authority DID for service auth")?;
+    // The signing key is in verificationMethod (atproto documents publish it
+    // as #atproto). Accept any key the document lists.
+    let mut keys: Vec<freeq_sdk::crypto::PublicKey> = doc
+        .verification_method
+        .iter()
+        .filter_map(|vm| vm.public_key_multibase.as_deref())
+        .filter_map(|mb| freeq_sdk::crypto::PublicKey::from_multibase(mb).ok())
+        .collect();
+    keys.extend(doc.authentication_keys().into_iter().map(|(_, k)| k));
+    if keys.is_empty() {
+        bail!("authority DID document lists no usable keys");
+    }
+    for key in &keys {
+        if key.verify(signing_input.as_bytes(), &sig_bytes).is_ok() {
+            return Ok(());
+        }
+    }
+    bail!("service auth signature did not verify against any authority key")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mgr() -> MediaSpaceManager {
+        MediaSpaceManager::new(
+            "did:plc:authority123".to_string(),
+            "pw".to_string(),
+            None,
+            "irc.example.org".to_string(),
+        )
+    }
+
+    #[test]
+    fn space_ref_round_trips_through_parse() {
+        let m = mgr();
+        let r = m.space_ref("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        assert_eq!(
+            r,
+            "at://did:plc:authority123/space/at.freeq.media/01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        );
+        assert_eq!(m.parse_space_key(&r), Some("01ARZ3NDEKTSV4RRFFQ69G5FAV"));
+    }
+
+    #[test]
+    fn parse_rejects_foreign_authority() {
+        let m = mgr();
+        assert_eq!(
+            m.parse_space_key("at://did:plc:someoneelse/space/at.freeq.media/k1"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_rejects_other_space_type() {
+        let m = mgr();
+        assert_eq!(
+            m.parse_space_key("at://did:plc:authority123/space/com.example.other/k1"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_rejects_record_uris_and_malformed_refs() {
+        let m = mgr();
+        // A URI naming a record within the space is not a space ref.
+        assert_eq!(
+            m.parse_space_key(
+                "at://did:plc:authority123/space/at.freeq.media/k1/did:plc:x/at.freeq.media.item/3k"
+            ),
+            None
+        );
+        assert_eq!(
+            m.parse_space_key("at://did:plc:authority123/space/at.freeq.media/"),
+            None
+        );
+        assert_eq!(m.parse_space_key("not-a-uri"), None);
+        assert_eq!(m.parse_space_key("at://did:plc:authority123"), None);
+    }
+
+    #[test]
+    fn managing_app_is_did_web_of_this_server() {
+        assert_eq!(mgr().managing_app(), "did:web:irc.example.org#freeq_media");
+    }
+}

--- a/freeq-server/src/media_space.rs
+++ b/freeq-server/src/media_space.rs
@@ -11,6 +11,8 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use freeq_sdk::did::DidResolver;
 
+use crate::media_store::MAX_MEDIA_BYTES;
+
 /// NSID of the space type. Part of every space ref this server creates.
 pub const SPACE_TYPE: &str = "at.freeq.media";
 
@@ -20,6 +22,9 @@ pub const MANAGING_APP_FRAGMENT: &str = "freeq_media";
 
 /// Collection holding one media item per record inside a media space.
 pub const MEDIA_COLLECTION: &str = "at.freeq.media.item";
+
+/// Call timeout on a repo host.
+const REPO_HOST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// The OAuth scopes an upload to this server's media spaces takes:
 /// `blob:*/*` for the bytes, which go up through the ordinary uploadBlob,
@@ -31,7 +36,7 @@ pub fn space_scope(authority_did: &str) -> String {
     format!("blob:*/* space:*?authority={authority_did}&collection=*")
 }
 
-/// Check for a stale cached session token is stale.
+/// Check for a stale cached session token.
 fn session_expired(status: reqwest::StatusCode, body: &str) -> bool {
     status == reqwest::StatusCode::UNAUTHORIZED || body.contains("ExpiredToken")
 }
@@ -401,11 +406,14 @@ impl MediaSpaceManager {
         credential: &str,
         dpop_key: &freeq_sdk::oauth::DpopKey,
     ) -> Result<Vec<u8>> {
+        // An SSRF check is needed here as the DID document can point anywhere.
+        let (_, client) = crate::web::safe_outbound_client(url, REPO_HOST_TIMEOUT)
+            .await
+            .map_err(|(_, msg)| anyhow::anyhow!("{msg}"))?;
         let mut nonce: Option<String> = None;
         for attempt in 0..3 {
             let proof = dpop_key.proof("GET", url, nonce.as_deref(), Some(credential))?;
-            let res = self
-                .http
+            let res = client
                 .get(url)
                 .query(params)
                 .header("Authorization", format!("DPoP {credential}"))
@@ -421,7 +429,21 @@ impl MediaSpaceManager {
             }
             let status = res.status();
             if status.is_success() {
-                return Ok(res.bytes().await?.to_vec());
+                if let Some(len) = res.content_length()
+                    && len > MAX_MEDIA_BYTES as u64
+                {
+                    bail!("media is larger than the {} byte ceiling", MAX_MEDIA_BYTES);
+                }
+                // Read in chunks until we hit MAX_MEDIA_BYTES.
+                let mut res = res;
+                let mut body: Vec<u8> = Vec::new();
+                while let Some(chunk) = res.chunk().await? {
+                    if body.len() + chunk.len() > MAX_MEDIA_BYTES {
+                        bail!("media is larger than the {} byte ceiling", MAX_MEDIA_BYTES);
+                    }
+                    body.extend_from_slice(&chunk);
+                }
+                return Ok(body);
             }
             if (status == 401 || status == 400) && attempt < 2 {
                 continue;

--- a/freeq-server/src/media_store.rs
+++ b/freeq-server/src/media_store.rs
@@ -23,6 +23,10 @@ use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Cap on media size.
+/// Whole files are decrypted in memory, which is what keeps this modest.
+pub const MAX_MEDIA_BYTES: usize = 10 * 1024 * 1024;
+
 /// Derive a 32-byte key for `domain` from the server signing seed.
 /// Mirrors `server::derive_key_from_signing` but with per-use domain separation.
 fn derive(signing_seed: &[u8; 32], domain: &[u8]) -> [u8; 32] {

--- a/freeq-server/src/migrations/010_channel_media_space.rs
+++ b/freeq-server/src/migrations/010_channel_media_space.rs
@@ -1,0 +1,61 @@
+//! Migration 10: per-channel private-media space key.
+//!
+//! A channel that has shared private media owns an AT Protocol space named
+//! `at://{authority}/space/at.freeq.media/{key}`. The key is a ULID minted by
+//! this server on the channel's first private upload. NULL means the channel
+//! has no space yet.
+//!
+//! Down: drop the column. Spaces already created on the PDS become
+//! unreachable through this server until the column returns; their records
+//! remain in members' repos.
+
+use rusqlite::Transaction;
+use rusqlite_migration::{HookResult, M};
+
+pub(super) fn migration() -> M<'static> {
+    M::up_with_hook("", |tx: &Transaction| -> HookResult {
+        match tx.execute("ALTER TABLE channels ADD COLUMN media_space_key TEXT", []) {
+            Ok(_) => Ok(()),
+            Err(e) if e.to_string().contains("duplicate column name") => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    })
+    .down("ALTER TABLE channels DROP COLUMN media_space_key;")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::migration_ladder;
+    use rusqlite::Connection;
+
+    fn columns(conn: &Connection) -> Vec<String> {
+        conn.prepare("SELECT name FROM pragma_table_info('channels')")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn up_adds_the_column_and_down_removes_it() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 10).unwrap();
+        assert!(columns(&conn).iter().any(|c| c == "media_space_key"));
+
+        migration_ladder().to_version(&mut conn, 9).unwrap();
+        assert!(!columns(&conn).iter().any(|c| c == "media_space_key"));
+    }
+
+    /// The rung survives a re-run against a database that already has the
+    /// column — an older build's file whose stamp was lost still climbs.
+    #[test]
+    fn the_rung_survives_a_database_that_already_has_the_column() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migration_ladder().to_version(&mut conn, 10).unwrap();
+        conn.execute_batch("PRAGMA user_version = 9").unwrap();
+        migration_ladder()
+            .to_version(&mut conn, 10)
+            .expect("a converged schema with a lost stamp climbs anyway");
+    }
+}

--- a/freeq-server/src/migrations/mod.rs
+++ b/freeq-server/src/migrations/mod.rs
@@ -47,6 +47,8 @@ mod m007_act_replaces;
 mod m008_act_dropped_unchecked;
 #[path = "009_event_confirm_state.rs"]
 mod m009_event_confirm_state;
+#[path = "010_channel_media_space.rs"]
+mod m010_channel_media_space;
 
 // db.rs unit tests exercise the backfill directly against hand-built rows.
 // Production reaches it only as a rung of the ladder below.
@@ -66,6 +68,7 @@ fn rungs() -> Vec<rusqlite_migration::M<'static>> {
         m007_act_replaces::migration(),
         m008_act_dropped_unchecked::migration(),
         m009_event_confirm_state::migration(),
+        m010_channel_media_space::migration(),
     ]
 }
 
@@ -208,6 +211,7 @@ mod tests {
         migration_ladder().to_version(&mut stepped, 7).unwrap();
         migration_ladder().to_version(&mut stepped, 8).unwrap();
         migration_ladder().to_version(&mut stepped, 9).unwrap();
+        migration_ladder().to_version(&mut stepped, 10).unwrap();
 
         let mut direct = Connection::open_in_memory().unwrap();
         migration_ladder().to_latest(&mut direct).unwrap();

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -259,6 +259,10 @@ pub enum OauthPurpose {
     /// Cross-posting messages to Bluesky. Scope: adds `repo:app.bsky.feed.post`.
     /// Triggered the first time a user enables Bluesky mirroring on a channel.
     BlueskyPost,
+    /// Writing private media into this server's channel spaces. Scope: adds
+    /// `space:at.freeq.media` for this server's space authority. Triggered
+    /// the first time a user makes a private upload.
+    MediaSpace,
 }
 
 impl OauthPurpose {
@@ -268,6 +272,7 @@ impl OauthPurpose {
             "login" => Some(Self::Login),
             "blob_upload" => Some(Self::BlobUpload),
             "bluesky_post" => Some(Self::BlueskyPost),
+            "media_space" => Some(Self::MediaSpace),
             _ => None,
         }
     }
@@ -278,16 +283,19 @@ impl OauthPurpose {
             Self::Login => "login",
             Self::BlobUpload => "blob_upload",
             Self::BlueskyPost => "bluesky_post",
+            Self::MediaSpace => "media_space",
         }
     }
 
     /// The OAuth scope string we *request* for this purpose. The PDS may
     /// grant a different one — store that in [`WebSession::granted_scope`]
     /// and check it at use time via [`scope_satisfies_purpose`].
-    pub fn requested_scope(self) -> &'static str {
+    ///
+    /// `media_space_authority` is the server's space authority DID.
+    pub fn requested_scope(self, media_space_authority: Option<&str>) -> String {
         match self {
             // Identity-only. Same as a vanilla "Login with Bluesky" button.
-            Self::Login => "atproto",
+            Self::Login => "atproto".to_string(),
             // Upload images to the user's repo. Narrow MIME on purpose so
             // the consent screen says "upload images" instead of "upload
             // anything". Also requests `repo:blue.irc.media?action=create`
@@ -296,10 +304,17 @@ impl OauthPurpose {
             // alongside the blob — without this scope the PDS rejects
             // record creation with ScopeMissingError even though the blob
             // upload itself succeeds.
-            Self::BlobUpload => "atproto blob:image/* repo:blue.irc.media?action=create",
+            Self::BlobUpload => {
+                "atproto blob:image/* repo:blue.irc.media?action=create".to_string()
+            }
             // Cross-post to Bluesky's feed. Repo write narrowed to a single
             // collection.
-            Self::BlueskyPost => "atproto repo:app.bsky.feed.post",
+            Self::BlueskyPost => "atproto repo:app.bsky.feed.post".to_string(),
+            // Read and write this server's channel media spaces.
+            Self::MediaSpace => format!(
+                "atproto {}",
+                crate::media_space::space_scope(media_space_authority.unwrap_or("*")),
+            ),
         }
     }
 }
@@ -340,6 +355,12 @@ pub fn scope_satisfies_purpose(granted: &str, purpose: OauthPurpose) -> bool {
         OauthPurpose::BlueskyPost => granted
             .split_whitespace()
             .any(|s| s == "repo:app.bsky.feed.post" || s == "repo:*"),
+        OauthPurpose::MediaSpace => {
+            let prefix = format!("space:{}", crate::media_space::SPACE_TYPE);
+            granted.split_whitespace().any(|s| {
+                s == prefix || s.starts_with(&format!("{prefix}?")) || s.starts_with("space:*")
+            })
+        }
     }
 }
 

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -74,6 +74,8 @@ pub struct ChannelState {
     pub key: Option<String>,
     /// Pinned message IDs (msgid strings), most recent first.
     pub pins: Vec<PinnedMessage>,
+    /// Key for this channel's private-media space.
+    pub media_space_key: Option<String>,
 }
 
 /// A pinned message reference.
@@ -626,6 +628,8 @@ pub struct SharedState {
     pub server_name: String,
     pub challenge_store: ChallengeStore,
     pub did_resolver: DidResolver,
+    /// Private-media spaces. None = feature off.
+    pub media_space: Option<std::sync::Arc<crate::media_space::MediaSpaceManager>>,
     /// session_id -> sender for writing lines to that client
     pub connections: Mutex<HashMap<String, mpsc::Sender<String>>>,
     /// nick -> session_id (case-insensitive: keys are always lowercase)
@@ -1579,6 +1583,7 @@ impl Server {
                     && !ch.moderated
                     && ch.key.is_none()
                     && ch.bans.is_empty()
+                    && ch.media_space_key.is_none()
                 {
                     // Don't prune if channel has policy (check later)
                     let _ = db.delete_channel(name);
@@ -1628,10 +1633,36 @@ impl Server {
             bundles
         };
 
+        // Docker compose's `${VAR:-}` passes SET-BUT-EMPTY env vars, which
+        // clap surfaces as Some(""). Empty means unset here.
+        fn non_empty(v: &Option<String>) -> Option<&str> {
+            v.as_deref().filter(|s| !s.is_empty())
+        }
+        let media_space = match (
+            non_empty(&self.config.media_space_did),
+            non_empty(&self.config.media_space_password),
+        ) {
+            (Some(did), Some(password)) => Some(std::sync::Arc::new(
+                crate::media_space::MediaSpaceManager::new(
+                    did.to_string(),
+                    password.to_string(),
+                    non_empty(&self.config.media_space_pds).map(str::to_string),
+                    self.config.server_name.clone(),
+                ),
+            )),
+            (Some(_), None) => {
+                tracing::warn!(
+                    "media_space_did set without media_space_password; private media disabled"
+                );
+                None
+            }
+            _ => None,
+        };
         let state = Arc::new(SharedState {
             server_name: self.config.server_name.clone(),
             challenge_store: ChallengeStore::new(self.config.challenge_timeout_secs),
             did_resolver: self.resolver.clone(),
+            media_space,
             connections: Mutex::new(HashMap::new()),
             nick_to_session: Mutex::new(NickMap::new()),
             session_dids: Mutex::new(HashMap::new()),
@@ -7751,6 +7782,7 @@ mod s2s_adversarial_tests {
             server_name: config.server_name.clone(),
             challenge_store: crate::sasl::ChallengeStore::new(60),
             did_resolver: freeq_sdk::did::DidResolver::static_map(HashMap::new()),
+            media_space: None,
             connections: Mutex::new(HashMap::new()),
             nick_to_session: Mutex::new(NickMap::new()),
             session_dids: Mutex::new(HashMap::new()),

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -329,6 +329,38 @@ impl OauthPurpose {
 /// - bsky.social granular grants may include extra `blob:` MIME entries
 ///   beyond what we asked; we only need one `blob:image/*` (or the
 ///   wildcard `blob:*/*`) for upload.
+///
+/// Does one granted scope token grant space access over `authority`?
+///
+/// Accepts `space:<type>?authority=<did>&collection=<c>` in any parameter
+/// order, with `*` as the wildcard for type and collection. The authority
+/// must match exactly: a grant over someone else's spaces is worth nothing
+/// here, and `*` is not accepted for it.
+fn space_scope_covers_authority(token: &str, authority: &str) -> bool {
+    let Some(rest) = token.strip_prefix("space:") else {
+        return false;
+    };
+    let (space_type, query) = match rest.split_once('?') {
+        Some((t, q)) => (t, q),
+        None => return false,
+    };
+    if space_type != "*" && space_type != crate::media_space::SPACE_TYPE {
+        return false;
+    }
+    let mut names_authority = false;
+    let mut collection_ok = false;
+    for param in query.split('&') {
+        match param.split_once('=') {
+            Some(("authority", v)) if v == authority => names_authority = true,
+            Some(("collection", v)) => {
+                collection_ok = v == "*" || v == crate::media_space::MEDIA_COLLECTION;
+            }
+            _ => {}
+        }
+    }
+    names_authority && collection_ok
+}
+
 pub fn scope_satisfies_purpose(
     granted: &str,
     purpose: OauthPurpose,
@@ -366,15 +398,17 @@ pub fn scope_satisfies_purpose(
             // createRecord to file them in the space. The space half must
             // also name this server's authority, since a grant for someone
             // else's spaces buys nothing here.
+            //
+            // Matched by parts rather than as a literal string: a PDS is free
+            // to reorder or re-encode the query parameters when it echoes a
+            // grant back, and a literal comparison would turn that into an
+            // endless step-up loop for the user.
             let Some(authority) = media_space_authority else {
                 return false;
             };
-            let wanted = crate::media_space::space_scope(authority);
-            let has_space = granted.split_whitespace().any(|s| {
-                wanted
-                    .split_whitespace()
-                    .any(|w| w == s && s.starts_with("space:"))
-            });
+            let has_space = granted
+                .split_whitespace()
+                .any(|s| space_scope_covers_authority(s, authority));
             let has_blob = granted.split_whitespace().any(|s| s.starts_with("blob:*"));
             has_space && has_blob
         }

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -356,10 +356,16 @@ pub fn scope_satisfies_purpose(granted: &str, purpose: OauthPurpose) -> bool {
             .split_whitespace()
             .any(|s| s == "repo:app.bsky.feed.post" || s == "repo:*"),
         OauthPurpose::MediaSpace => {
+            // An upload is two PDS calls: uploadBlob for the bytes, then
+            // createRecord to file them in the space.
             let prefix = format!("space:{}", crate::media_space::SPACE_TYPE);
-            granted.split_whitespace().any(|s| {
+            let has_space = granted.split_whitespace().any(|s| {
                 s == prefix || s.starts_with(&format!("{prefix}?")) || s.starts_with("space:*")
-            })
+            });
+            let has_blob = granted
+                .split_whitespace()
+                .any(|s| s == "blob:*/*" || s.starts_with("blob:*"));
+            has_space && has_blob
         }
     }
 }

--- a/freeq-server/src/server.rs
+++ b/freeq-server/src/server.rs
@@ -329,10 +329,16 @@ impl OauthPurpose {
 /// - bsky.social granular grants may include extra `blob:` MIME entries
 ///   beyond what we asked; we only need one `blob:image/*` (or the
 ///   wildcard `blob:*/*`) for upload.
-pub fn scope_satisfies_purpose(granted: &str, purpose: OauthPurpose) -> bool {
-    if granted
-        .split_whitespace()
-        .any(|s| s == "transition:generic")
+pub fn scope_satisfies_purpose(
+    granted: &str,
+    purpose: OauthPurpose,
+    media_space_authority: Option<&str>,
+) -> bool {
+    // The legacy wide grant covers every purpose except spaces.
+    if !matches!(purpose, OauthPurpose::MediaSpace)
+        && granted
+            .split_whitespace()
+            .any(|s| s == "transition:generic")
     {
         return true;
     }
@@ -357,14 +363,19 @@ pub fn scope_satisfies_purpose(granted: &str, purpose: OauthPurpose) -> bool {
             .any(|s| s == "repo:app.bsky.feed.post" || s == "repo:*"),
         OauthPurpose::MediaSpace => {
             // An upload is two PDS calls: uploadBlob for the bytes, then
-            // createRecord to file them in the space.
-            let prefix = format!("space:{}", crate::media_space::SPACE_TYPE);
+            // createRecord to file them in the space. The space half must
+            // also name this server's authority, since a grant for someone
+            // else's spaces buys nothing here.
+            let Some(authority) = media_space_authority else {
+                return false;
+            };
+            let wanted = crate::media_space::space_scope(authority);
             let has_space = granted.split_whitespace().any(|s| {
-                s == prefix || s.starts_with(&format!("{prefix}?")) || s.starts_with("space:*")
+                wanted
+                    .split_whitespace()
+                    .any(|w| w == s && s.starts_with("space:"))
             });
-            let has_blob = granted
-                .split_whitespace()
-                .any(|s| s == "blob:*/*" || s.starts_with("blob:*"));
+            let has_blob = granted.split_whitespace().any(|s| s.starts_with("blob:*"));
             has_space && has_blob
         }
     }

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -27,7 +27,9 @@ use crate::server::SharedState;
 // is re-exported because `crate::web::generate_random_string` is referenced from
 // connection::login; `urlencod` is the local alias for the engine's `urlencode`.
 pub use freeq_oauth::generate_random_string;
-use freeq_oauth::{ClientProvider, build_client_id, generate_pkce, urlencode as urlencod};
+use freeq_oauth::{
+    ClientProvider, build_client_id_with_scopes, generate_pkce, urlencode as urlencod,
+};
 
 // ── WebSocket ↔ IRC bridge ─────────────────────────────────────────────
 
@@ -3108,6 +3110,14 @@ fn verify_broker_signature_raw(
 
 // ── OAuth client metadata ──────────────────────────────────────────────
 
+/// The media-space scope this server can request.
+fn media_space_scope(state: &SharedState) -> Option<String> {
+    state
+        .media_space
+        .as_ref()
+        .map(|m| crate::media_space::space_scope(&m.authority_did))
+}
+
 /// Serves the AT Protocol OAuth client-metadata.json document.
 /// The client_id for non-localhost origins is `{origin}/client-metadata.json`.
 async fn client_metadata(
@@ -3116,7 +3126,11 @@ async fn client_metadata(
 ) -> Json<serde_json::Value> {
     let (web_origin, _) = derive_web_origin(&headers);
     let redirect_uri = format!("{web_origin}/auth/callback");
-    let client_id = build_client_id(&web_origin, &redirect_uri);
+    let client_id = build_client_id_with_scopes(
+        &web_origin,
+        &redirect_uri,
+        media_space_scope(&state).as_deref(),
+    );
     // Advertise every scope any flow may request in the metadata.
     let mut scope = "atproto blob:image/* repo:blue.irc.media?action=create repo:app.bsky.feed.post transition:generic".to_string();
     if let Some(ref mgr) = state.media_space {
@@ -3428,7 +3442,11 @@ async fn auth_login(
     let redirect_uri = format!("{web_origin}/auth/callback");
     let purpose = crate::server::OauthPurpose::Login;
     let scope = purpose.requested_scope(None);
-    let client_id = build_client_id(&web_origin, &redirect_uri);
+    let client_id = build_client_id_with_scopes(
+        &web_origin,
+        &redirect_uri,
+        media_space_scope(&state).as_deref(),
+    );
 
     // Generate PKCE + DPoP key + state
     let dpop_key = freeq_sdk::oauth::DpopKey::generate();
@@ -3601,7 +3619,11 @@ async fn auth_step_up(
     let redirect_uri = format!("{web_origin}/auth/callback");
     let scope =
         purpose.requested_scope(state.media_space.as_ref().map(|m| m.authority_did.as_str()));
-    let client_id = build_client_id(&web_origin, &redirect_uri);
+    let client_id = build_client_id_with_scopes(
+        &web_origin,
+        &redirect_uri,
+        media_space_scope(&state).as_deref(),
+    );
 
     let dpop_key = freeq_sdk::oauth::DpopKey::generate();
     let (code_verifier, code_challenge) = generate_pkce();
@@ -4349,7 +4371,11 @@ async fn api_upload(
         use base64::Engine;
         let encoded =
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(result.uri.as_bytes());
-        let name = pick_media_filename(filename.as_deref(), &content_type);
+        // Strip spaces, .., etc.
+        let name = crate::media_store::sanitize_filename(&pick_media_filename(
+            filename.as_deref(),
+            &content_type,
+        ));
         return Ok(Json(serde_json::json!({
             "url": format!("{origin}/api/v1/space-media/{encoded}/{name}"),
             "uri": result.uri,

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -2425,11 +2425,51 @@ async fn api_media_space(
         return Err(StatusCode::NOT_FOUND);
     };
     let channel = authorize_channel_read(&state, &q.channel, &headers)?;
+    authorize_channel_member(&state, &channel, &headers)?;
     let key = channel_space_key(&state, &mgr, &channel).await?;
     Ok(Json(serde_json::json!({
         "space": mgr.space_ref(&key),
         "type": crate::media_space::SPACE_TYPE,
     })))
+}
+
+/// Check if the DID is a member, founder, or op of the channel.
+pub(crate) fn did_is_channel_member(state: &SharedState, channel: &str, did: &str) -> bool {
+    let key = channel.to_lowercase();
+    let (members, founder, did_ops) = {
+        let channels = state.channels.lock();
+        let Some(ch) = channels.get(&key) else {
+            return false;
+        };
+        (
+            ch.members.clone(),
+            ch.founder_did.clone(),
+            ch.did_ops.clone(),
+        )
+    };
+    if founder.as_deref() == Some(did) || did_ops.contains(did) {
+        return true;
+    }
+    let session_dids = state.session_dids.lock();
+    members
+        .iter()
+        .any(|sid| session_dids.get(sid).map(|d| d == did).unwrap_or(false))
+}
+
+/// Grab the DID and ensure it's a valid member.
+fn authorize_channel_member(
+    state: &SharedState,
+    channel: &str,
+    headers: &axum::http::HeaderMap,
+) -> Result<String, StatusCode> {
+    let Some(did) = caller_did_from_bearer(state, headers) else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+    if did_is_channel_member(state, channel, &did) {
+        Ok(did)
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
 }
 
 /// The channel's media space key.
@@ -2516,12 +2556,26 @@ async fn api_space_media(
             tracing::warn!(error = %err, uri = %uri, "space media fetch failed");
             StatusCode::BAD_GATEWAY
         })?;
+    // The type comes from the uploader's own record, which they can rewrite on
+    // their PDS at any time.
+    let renderable = matches!(mime.split('/').next(), Some("image" | "video" | "audio"))
+        && !mime.contains("svg");
+    let disposition = if renderable { "inline" } else { "attachment" };
+    let served_mime = if renderable {
+        mime
+    } else {
+        "application/octet-stream".to_string()
+    };
     Ok((
         [
-            (axum::http::header::CONTENT_TYPE, mime),
+            (axum::http::header::CONTENT_TYPE, served_mime),
             (
                 axum::http::header::CACHE_CONTROL,
                 "private, max-age=300".to_string(),
+            ),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                disposition.to_string(),
             ),
         ],
         bytes,
@@ -3183,7 +3237,7 @@ async fn client_metadata(
 /// is fully attacker-controlled in the worst case, so we validate at
 /// every hop. Returns a generic error message that does NOT echo the
 /// host or IP back to the requester (info-leak hardening).
-async fn safe_outbound_client(
+pub(crate) async fn safe_outbound_client(
     url_str: &str,
     timeout: std::time::Duration,
 ) -> Result<(url::Url, reqwest::Client), (StatusCode, &'static str)> {
@@ -4205,7 +4259,7 @@ async fn api_upload(
                     .bytes()
                     .await
                     .map_err(|e| (StatusCode::BAD_REQUEST, format!("File read error: {e}")))?;
-                if bytes.len() > 10 * 1024 * 1024 {
+                if bytes.len() > crate::media_store::MAX_MEDIA_BYTES {
                     return Err((
                         StatusCode::PAYLOAD_TOO_LARGE,
                         "File too large (max 10MB)".into(),
@@ -4300,13 +4354,25 @@ async fn api_upload(
                 "Private media spaces are per-channel; no channel given".into(),
             ));
         };
+        if !did_is_channel_member(&state, &channel, &did) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Only channel members can post private media".to_string(),
+            ));
+        }
         let session = {
             let sessions = state.web_sessions.lock();
             let purpose = crate::server::OauthPurpose::MediaSpace;
             sessions
                 .get(&(did.clone(), purpose))
                 .or_else(|| sessions.get(&(did.clone(), crate::server::OauthPurpose::Login)))
-                .filter(|s| crate::server::scope_satisfies_purpose(&s.granted_scope, purpose))
+                .filter(|s| {
+                    crate::server::scope_satisfies_purpose(
+                        &s.granted_scope,
+                        purpose,
+                        Some(mgr.authority_did.as_str()),
+                    )
+                })
                 .cloned()
         };
         let Some(session) = session else {
@@ -4366,6 +4432,17 @@ async fn api_upload(
             (StatusCode::BAD_GATEWAY, format!("{e}"))
         })?;
 
+        if let Some(nonce) = result.updated_nonce.clone() {
+            let mut sessions = state.web_sessions.lock();
+            for purpose in [
+                crate::server::OauthPurpose::MediaSpace,
+                crate::server::OauthPurpose::Login,
+            ] {
+                if let Some(s) = sessions.get_mut(&(did.clone(), purpose)) {
+                    s.dpop_nonce = Some(nonce.clone());
+                }
+            }
+        }
         tracing::info!(did = %did, channel = %channel, uri = %result.uri, "Space media stored");
         let (origin, _) = derive_web_origin(&headers);
         use base64::Engine;
@@ -4401,7 +4478,7 @@ async fn api_upload(
             if let Some(s) = sessions.get(&(did.clone(), purpose)) {
                 Some(s.clone())
             } else if let Some(s) = sessions.get(&(did.clone(), crate::server::OauthPurpose::Login))
-                && crate::server::scope_satisfies_purpose(&s.granted_scope, purpose)
+                && crate::server::scope_satisfies_purpose(&s.granted_scope, purpose, None)
             {
                 Some(s.clone())
             } else {

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -200,6 +200,7 @@ pub fn router(state: Arc<SharedState>) -> Router {
             get(xrpc_check_user_access),
         )
         .route("/api/v1/media-space", get(api_media_space))
+        .route("/api/v1/space-media/{ref}/{filename}", get(api_space_media))
         // REST API (read-only, v1)
         .route("/api/v1/health", get(api_health))
         // The mediated, metered model path: the server holds the provider
@@ -571,6 +572,8 @@ struct HealthResponse {
     /// and the web client all work — while every AV endpoint answers 503. That
     /// shipped to production once, and the only signal was a user trying a call.
     av: bool,
+    /// Whether private media spaces are configured.
+    media_spaces: bool,
 }
 
 #[derive(Serialize)]
@@ -1949,6 +1952,7 @@ async fn api_health(State(state): State<Arc<SharedState>>) -> Json<HealthRespons
         channels,
         uptime_secs: uptime,
         av: av_available(&state),
+        media_spaces: state.media_space.is_some(),
     })
 }
 
@@ -2370,6 +2374,11 @@ fn media_space_member(
     let Some(key) = mgr.parse_space_key(space) else {
         return false;
     };
+    // This server reads its own spaces to serve media to members it has
+    // already authorized.
+    if user_did == mgr.authority_did {
+        return true;
+    }
     // Snapshot under the channels lock, resolve sessions under session_dids
     // (same lock order as authorize_channel_read).
     let (members, founder, did_ops) = {
@@ -2414,29 +2423,35 @@ async fn api_media_space(
         return Err(StatusCode::NOT_FOUND);
     };
     let channel = authorize_channel_read(&state, &q.channel, &headers)?;
-    let key = channel.to_lowercase();
+    let key = channel_space_key(&state, &mgr, &channel).await?;
+    Ok(Json(serde_json::json!({
+        "space": mgr.space_ref(&key),
+        "type": crate::media_space::SPACE_TYPE,
+    })))
+}
 
-    let space_body = |space_key: &str| {
-        serde_json::json!({
-            "space": mgr.space_ref(space_key),
-            "type": crate::media_space::SPACE_TYPE,
-        })
-    };
-    let stored = |state: &SharedState, key: &str| {
+/// The channel's media space key.
+/// The space is created the first time media is uploaded.
+async fn channel_space_key(
+    state: &Arc<SharedState>,
+    mgr: &crate::media_space::MediaSpaceManager,
+    channel: &str,
+) -> Result<String, StatusCode> {
+    let key = channel.to_lowercase();
+    let stored = |key: &str| {
         state
             .channels
             .lock()
             .get(key)
             .and_then(|c| c.media_space_key.clone())
     };
-    if let Some(k) = stored(&state, &key) {
-        return Ok(Json(space_body(&k)));
+    if let Some(k) = stored(&key) {
+        return Ok(k);
     }
 
-    // First use: create exactly one space, even under concurrent requests.
     let _creating = mgr.create_lock.lock().await;
-    if let Some(k) = stored(&state, &key) {
-        return Ok(Json(space_body(&k)));
+    if let Some(k) = stored(&key) {
+        return Ok(k);
     }
     let new_key = ulid::Ulid::new().to_string();
     if let Err(err) = mgr.create_space(&state.did_resolver, &new_key).await {
@@ -2452,7 +2467,64 @@ async fn api_media_space(
         ch.clone()
     };
     state.with_db(|db| db.save_channel(&key, &snapshot));
-    Ok(Json(space_body(&new_key)))
+    Ok(new_key)
+}
+
+/// GET /api/v1/space-media/{ref}/{filename} — serve a private space media
+/// file to a member of the channel that owns the space.
+///
+/// `ref` is the record's `at://` URI, base64url-encoded so it survives a path
+/// segment; the trailing filename gives clients the extension they use to
+/// decide how to render, exactly like the private-store capability URLs.
+async fn api_space_media(
+    State(state): State<Arc<SharedState>>,
+    Path((encoded_ref, _filename)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
+) -> Result<axum::response::Response, StatusCode> {
+    let Some(mgr) = state.media_space.clone() else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+    use base64::Engine;
+    let uri = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded_ref.as_bytes())
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let Some(rec) = mgr.parse_record_uri(&uri) else {
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    // Which channel owns this space, and may the caller read it? Reuse the
+    // channel-history rule so restricted channels stay restricted.
+    let channel = {
+        let channels = state.channels.lock();
+        channels
+            .iter()
+            .find(|(_, c)| c.media_space_key.as_deref() == Some(rec.space_key.as_str()))
+            .map(|(name, _)| name.clone())
+    };
+    let Some(channel) = channel else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+    authorize_channel_read(&state, &channel, &headers)?;
+
+    let (bytes, mime) = mgr
+        .fetch_media(&state.did_resolver, &rec)
+        .await
+        .map_err(|err| {
+            tracing::warn!(error = %err, uri = %uri, "space media fetch failed");
+            StatusCode::BAD_GATEWAY
+        })?;
+    Ok((
+        [
+            (axum::http::header::CONTENT_TYPE, mime),
+            (
+                axum::http::header::CACHE_CONTROL,
+                "private, max-age=300".to_string(),
+            ),
+        ],
+        bytes,
+    )
+        .into_response())
 }
 
 /// GET /api/v1/messages/{msgid} — permalink resolution. Returns the message
@@ -4088,6 +4160,9 @@ async fn api_upload(
     // `share_bluesky` (feed post) implies `share_pds` since the feed embed
     // references the PDS blob. `cross_post` is the legacy alias for it.
     let mut share_pds = false;
+    // Store the file in the user's own repo inside this channel's media
+    // space instead of the server's private store.
+    let mut space_media = false;
     let mut share_bluesky = false;
 
     while let Some(field) = multipart
@@ -4144,6 +4219,10 @@ async fn api_upload(
                 let val = field.text().await.unwrap_or_default();
                 share_bluesky = val == "true" || val == "1";
             }
+            "space_media" => {
+                let val = field.text().await.unwrap_or_default();
+                space_media = val == "true" || val == "1";
+            }
             _ => {}
         }
     }
@@ -4181,6 +4260,104 @@ async fn api_upload(
             StatusCode::UNAUTHORIZED,
             "Upload requires an active connection for this DID".into(),
         ));
+    }
+
+    // ── Private media space ─────────────────────────────────────────────
+    // The file goes into the uploader's own repo inside the channel's space.
+    // Nothing is stored here, so this returns before the private store.
+    if space_media {
+        let Some(mgr) = state.media_space.clone() else {
+            return Err((
+                StatusCode::NOT_FOUND,
+                "Private media spaces are not enabled on this server".into(),
+            ));
+        };
+        let Some(channel) = channel.clone().filter(|c| c.starts_with('#')) else {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Private media spaces are per-channel; no channel given".into(),
+            ));
+        };
+        let session = {
+            let sessions = state.web_sessions.lock();
+            let purpose = crate::server::OauthPurpose::MediaSpace;
+            sessions
+                .get(&(did.clone(), purpose))
+                .or_else(|| sessions.get(&(did.clone(), crate::server::OauthPurpose::Login)))
+                .filter(|s| crate::server::scope_satisfies_purpose(&s.granted_scope, purpose))
+                .cloned()
+        };
+        let Some(session) = session else {
+            let has_login = state
+                .web_sessions
+                .lock()
+                .contains_key(&(did.clone(), crate::server::OauthPurpose::Login));
+            let body = if has_login {
+                serde_json::json!({
+                    "error": "step_up_required",
+                    "purpose": "media_space",
+                    "step_up_url": "/auth/step-up?purpose=media_space",
+                    "message": "Storing this file privately on your PDS needs an \
+                                additional permission. Authorize once and we'll proceed.",
+                })
+            } else {
+                serde_json::json!({
+                    "error": "not_authenticated",
+                    "message": "No active session for this DID — please log in.",
+                })
+            };
+            return Err((
+                if has_login {
+                    StatusCode::FORBIDDEN
+                } else {
+                    StatusCode::UNAUTHORIZED
+                },
+                body.to_string(),
+            ));
+        };
+
+        let space_key = channel_space_key(&state, &mgr, &channel)
+            .await
+            .map_err(|s| {
+                (
+                    s,
+                    "Could not resolve this channel's media space".to_string(),
+                )
+            })?;
+        let dpop_key = freeq_sdk::oauth::DpopKey::from_base64url(&session.dpop_key_b64)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DPoP key: {e}")))?;
+        let result = freeq_sdk::media::upload_media_to_space(
+            &session.pds_url,
+            &session.did,
+            &session.access_token,
+            Some(&dpop_key),
+            session.dpop_nonce.as_deref(),
+            &mgr.space_ref(&space_key),
+            crate::media_space::MEDIA_COLLECTION,
+            &content_type,
+            &file_data,
+            alt.as_deref(),
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!(did = %did, channel = %channel, error = %e, "space media upload failed");
+            (StatusCode::BAD_GATEWAY, format!("{e}"))
+        })?;
+
+        tracing::info!(did = %did, channel = %channel, uri = %result.uri, "Space media stored");
+        let (origin, _) = derive_web_origin(&headers);
+        use base64::Engine;
+        let encoded =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(result.uri.as_bytes());
+        let name = pick_media_filename(filename.as_deref(), &content_type);
+        return Ok(Json(serde_json::json!({
+            "url": format!("{origin}/api/v1/space-media/{encoded}/{name}"),
+            "uri": result.uri,
+            "private": true,
+            "space": true,
+            "mime": result.mime_type,
+            "size": result.size,
+        })));
     }
 
     // ── Opt-in PDS authorization ────────────────────────────────────────

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -2472,6 +2472,14 @@ fn authorize_channel_member(
     }
 }
 
+/// Ceiling on how many channels may own a media space on one server.
+///
+/// Minting is a write to the *operator's* PDS account, and anyone who can
+/// create a channel can ask for one. Without a cap, a single authenticated
+/// user turns "create N channels" into "create N spaces on someone else's
+/// hosting bill".
+pub(crate) const MAX_MEDIA_SPACES: usize = 500;
+
 /// The channel's media space key.
 /// The space is created the first time media is uploaded.
 async fn channel_space_key(
@@ -2491,9 +2499,24 @@ async fn channel_space_key(
         return Ok(k);
     }
 
-    let _creating = mgr.create_lock.lock().await;
+    // One lock per channel: a global one would let a slow createSpace on
+    // #busy stall the first upload in every other channel.
+    let create_lock = mgr.create_lock_for(&key).await;
+    let _creating = create_lock.lock().await;
     if let Some(k) = stored(&key) {
         return Ok(k);
+    }
+    // Check the cap and confirm the channel still exists *before* spending a
+    // PDS write, so a refusal never leaves an orphan space behind.
+    if !state.channels.lock().contains_key(&key) {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    if media_space_cap_reached(&state) {
+        tracing::warn!(
+            channel = %channel,
+            "media space cap reached; refusing to mint another"
+        );
+        return Err(StatusCode::INSUFFICIENT_STORAGE);
     }
     let new_key = ulid::Ulid::new().to_string();
     if let Err(err) = mgr.create_space(&state.did_resolver, &new_key).await {
@@ -2503,6 +2526,13 @@ async fn channel_space_key(
     let snapshot = {
         let mut channels = state.channels.lock();
         let Some(ch) = channels.get_mut(&key) else {
+            // The channel went away while the PDS was minting. The space is
+            // now orphaned there; say so loudly rather than losing it.
+            tracing::error!(
+                channel = %channel,
+                space_key = %new_key,
+                "channel vanished mid-create; space is orphaned on the PDS"
+            );
             return Err(StatusCode::NOT_FOUND);
         };
         ch.media_space_key = Some(new_key.clone());
@@ -2512,6 +2542,77 @@ async fn channel_space_key(
     Ok(new_key)
 }
 
+/// Whether this server already holds [`MAX_MEDIA_SPACES`] spaces.
+pub(crate) fn media_space_cap_reached(state: &SharedState) -> bool {
+    state
+        .channels
+        .lock()
+        .values()
+        .filter(|c| c.media_space_key.is_some())
+        .count()
+        >= MAX_MEDIA_SPACES
+}
+
+/// Whether the channel is `+E`. Space media sits unencrypted in a third
+/// party's repo and is proxied in the clear through us, which is the exact
+/// thing an encrypted-only channel exists to prevent.
+pub(crate) fn channel_is_encrypted_only(state: &SharedState, channel: &str) -> bool {
+    state
+        .channels
+        .lock()
+        .get(&channel.to_lowercase())
+        .is_some_and(|c| c.encrypted_only)
+}
+
+#[cfg(test)]
+mod media_space_gate_tests {
+    use super::*;
+
+    fn channel_named(state: &SharedState, name: &str, encrypted: bool, space: Option<&str>) {
+        state.channels.lock().insert(
+            name.to_string(),
+            crate::server::ChannelState {
+                encrypted_only: encrypted,
+                media_space_key: space.map(str::to_string),
+                ..Default::default()
+            },
+        );
+    }
+
+    /// `+E` promises the server never handles this channel's plaintext, and
+    /// space media is proxied in the clear. The lookup is case-insensitive
+    /// because REST callers spell channels however they like.
+    #[test]
+    fn an_encrypted_channel_is_recognized_however_it_is_spelled() {
+        let state = crate::server::test_state();
+        channel_named(&state, "#secret", true, None);
+        channel_named(&state, "#open", false, None);
+        assert!(channel_is_encrypted_only(&state, "#secret"));
+        assert!(channel_is_encrypted_only(&state, "#SeCrEt"));
+        assert!(!channel_is_encrypted_only(&state, "#open"));
+        assert!(!channel_is_encrypted_only(&state, "#nosuchchannel"));
+    }
+
+    /// Only channels that actually hold a space count against the ceiling;
+    /// an idle channel costs the operator's PDS account nothing.
+    #[test]
+    fn the_cap_counts_channels_that_hold_a_space_and_no_others() {
+        let state = crate::server::test_state();
+        for i in 0..MAX_MEDIA_SPACES - 1 {
+            channel_named(&state, &format!("#c{i}"), false, Some(&format!("K{i}")));
+        }
+        for i in 0..50 {
+            channel_named(&state, &format!("#idle{i}"), false, None);
+        }
+        assert!(
+            !media_space_cap_reached(&state),
+            "one short of the ceiling is still room"
+        );
+        channel_named(&state, "#last", false, Some("KLAST"));
+        assert!(media_space_cap_reached(&state), "the ceiling is a ceiling");
+    }
+}
+
 /// GET /api/v1/space-media/{ref}/{filename} — serve a private space media
 /// file to a member of the channel that owns the space.
 ///
@@ -2519,10 +2620,17 @@ async fn channel_space_key(
 /// segment; the trailing filename gives clients the extension they use to
 /// decide how to render, exactly like the private-store capability URLs.
 async fn api_space_media(
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
     State(state): State<Arc<SharedState>>,
     Path((encoded_ref, _filename)): Path<(String, String)>,
     headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, StatusCode> {
+    // A public channel's media URL needs no bearer, and a miss costs two
+    // round trips against the *uploader's* PDS. Meter it like every other
+    // expensive REST route.
+    if !state.rest_rate_limiter.check(addr.ip()) {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
     let Some(mgr) = state.media_space.clone() else {
         return Err(StatusCode::NOT_FOUND);
     };
@@ -4348,6 +4456,17 @@ async fn api_upload(
                 "Private media spaces are not enabled on this server".into(),
             ));
         };
+        // The two destinations are mutually exclusive: the space branch
+        // returns before the PDS-share path, so accepting both would silently
+        // drop the Bluesky post the user asked for.
+        if share_pds || share_bluesky {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "A file goes either into this channel's private space or into a public \
+                 PDS/Bluesky copy, not both"
+                    .into(),
+            ));
+        }
         let Some(channel) = channel.clone().filter(|c| c.starts_with('#')) else {
             return Err((
                 StatusCode::BAD_REQUEST,
@@ -4358,6 +4477,16 @@ async fn api_upload(
             return Err((
                 StatusCode::FORBIDDEN,
                 "Only channel members can post private media".to_string(),
+            ));
+        }
+        // +E promises the server never handles plaintext for this channel.
+        // Space media is unencrypted in the author's repo and is proxied in
+        // the clear through us, so it cannot live in an encrypted channel.
+        // The web client hides the option; this is the rule itself.
+        if channel_is_encrypted_only(&state, &channel) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Encrypted-only (+E) channels do not support private media spaces".to_string(),
             ));
         }
         let session = {
@@ -4442,6 +4571,29 @@ async fn api_upload(
                     s.dpop_nonce = Some(nonce.clone());
                 }
             }
+        }
+        // The URI is whatever the uploader's PDS said it was, and it becomes
+        // a link we hand to every reader. Confirm it names a record in *this*
+        // channel's space, authored by the DID that just uploaded, before it
+        // goes anywhere: a buggy PDS would otherwise mint a permanently dead
+        // link, and a hostile one a cross-channel reference.
+        let parsed = mgr.parse_record_uri(&result.uri);
+        let sound = parsed.as_ref().is_some_and(|rec| {
+            rec.space_key == space_key
+                && rec.author_did == did
+                && rec.collection == crate::media_space::MEDIA_COLLECTION
+        });
+        if !sound {
+            tracing::warn!(
+                did = %did,
+                channel = %channel,
+                uri = %result.uri,
+                "PDS returned a space record URI that is not this channel's space"
+            );
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                "Your PDS returned an unexpected record location for this upload".to_string(),
+            ));
         }
         tracing::info!(did = %did, channel = %channel, uri = %result.uri, "Space media stored");
         let (origin, _) = derive_web_origin(&headers);

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -3038,10 +3038,19 @@ fn verify_broker_signature_raw(
 
 /// Serves the AT Protocol OAuth client-metadata.json document.
 /// The client_id for non-localhost origins is `{origin}/client-metadata.json`.
-async fn client_metadata(headers: axum::http::HeaderMap) -> Json<serde_json::Value> {
+async fn client_metadata(
+    State(state): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
+) -> Json<serde_json::Value> {
     let (web_origin, _) = derive_web_origin(&headers);
     let redirect_uri = format!("{web_origin}/auth/callback");
     let client_id = build_client_id(&web_origin, &redirect_uri);
+    // Advertise every scope any flow may request in the metadata.
+    let mut scope = "atproto blob:image/* repo:blue.irc.media?action=create repo:app.bsky.feed.post transition:generic".to_string();
+    if let Some(ref mgr) = state.media_space {
+        scope.push(' ');
+        scope.push_str(&crate::media_space::space_scope(&mgr.authority_did));
+    }
 
     Json(serde_json::json!({
         "client_id": client_id,
@@ -3064,7 +3073,7 @@ async fn client_metadata(headers: axum::http::HeaderMap) -> Json<serde_json::Val
         // remains permitted by the current client metadata. We never ask
         // for it on a fresh /authorize. Remove this entry once the PDS
         // ecosystem has fully sunset transitional scopes.
-        "scope": "atproto blob:image/* repo:blue.irc.media?action=create repo:app.bsky.feed.post transition:generic",
+        "scope": scope,
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "token_endpoint_auth_method": "none",
@@ -3346,7 +3355,7 @@ async fn auth_login(
     // request additional scopes there.
     let redirect_uri = format!("{web_origin}/auth/callback");
     let purpose = crate::server::OauthPurpose::Login;
-    let scope = purpose.requested_scope();
+    let scope = purpose.requested_scope(None);
     let client_id = build_client_id(&web_origin, &redirect_uri);
 
     // Generate PKCE + DPoP key + state
@@ -3365,7 +3374,7 @@ async fn auth_login(
         &code_challenge,
         &oauth_state,
         &handle,
-        scope,
+        &scope,
         &dpop_key,
     )
     .await
@@ -3410,7 +3419,8 @@ async fn auth_login(
 
 #[derive(Deserialize)]
 struct AuthStepUpQuery {
-    /// `blob_upload` or `bluesky_post` — see [`crate::server::OauthPurpose`].
+    /// `blob_upload`, `bluesky_post`, or `media_space` — see
+    /// [`crate::server::OauthPurpose`].
     purpose: String,
     /// DID to step up. Must match an active Login session on this server,
     /// otherwise the step-up is refused (we'd have nothing to "upgrade").
@@ -3440,6 +3450,12 @@ async fn auth_step_up(
         StatusCode::BAD_REQUEST,
         format!("Unknown purpose: {}", q.purpose),
     ))?;
+    if matches!(purpose, crate::server::OauthPurpose::MediaSpace) && state.media_space.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Private media is not enabled on this server".to_string(),
+        ));
+    }
     if matches!(purpose, crate::server::OauthPurpose::Login) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -3511,7 +3527,8 @@ async fn auth_step_up(
     .map_err(map_outbound_err)?;
 
     let redirect_uri = format!("{web_origin}/auth/callback");
-    let scope = purpose.requested_scope();
+    let scope =
+        purpose.requested_scope(state.media_space.as_ref().map(|m| m.authority_did.as_str()));
     let client_id = build_client_id(&web_origin, &redirect_uri);
 
     let dpop_key = freeq_sdk::oauth::DpopKey::generate();
@@ -3529,7 +3546,7 @@ async fn auth_step_up(
         &code_challenge,
         &oauth_state,
         &login_session.handle,
-        scope,
+        &scope,
         &dpop_key,
     )
     .await

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -2511,7 +2511,7 @@ async fn channel_space_key(
     if !state.channels.lock().contains_key(&key) {
         return Err(StatusCode::NOT_FOUND);
     }
-    if media_space_cap_reached(&state) {
+    if media_space_cap_reached(state) {
         tracing::warn!(
             channel = %channel,
             "media space cap reached; refusing to mint another"

--- a/freeq-server/src/web.rs
+++ b/freeq-server/src/web.rs
@@ -193,6 +193,13 @@ pub fn router(state: Arc<SharedState>) -> Router {
         .route("/api/v1/openapi.json", get(crate::openapi::openapi_json))
         .route("/api/v1/openapi.yaml", get(crate::openapi::openapi_yaml))
         .route("/llms.txt", get(crate::openapi::llms_txt))
+        // Private media spaces. Returns a 404 if the feature is unconfigured.
+        .route("/.well-known/did.json", get(media_space_did_doc))
+        .route(
+            "/xrpc/com.atproto.simplespace.checkUserAccess",
+            get(xrpc_check_user_access),
+        )
+        .route("/api/v1/media-space", get(api_media_space))
         // REST API (read-only, v1)
         .route("/api/v1/health", get(api_health))
         // The mediated, metered model path: the server holds the provider
@@ -2276,6 +2283,176 @@ fn authorize_channel_read(
     } else {
         Err(StatusCode::FORBIDDEN)
     }
+}
+
+// ── Private media spaces ───────────────────────────────────────────────
+
+/// GET /.well-known/did.json — the did:web document for this server's
+/// managing-app identity. The spaces PDS resolves `did:web:{server_name}`
+/// here to find the checkUserAccess endpoint.
+async fn media_space_did_doc(
+    State(state): State<Arc<SharedState>>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if state.media_space.is_none() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    Ok(Json(serde_json::json!({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": format!("did:web:{}", state.server_name),
+        "service": [{
+            "id": format!("#{}", crate::media_space::MANAGING_APP_FRAGMENT),
+            "type": "FreeqMediaManagingApp",
+            "serviceEndpoint": format!("https://{}", state.server_name),
+        }],
+    })))
+}
+
+#[derive(serde::Deserialize)]
+struct CheckUserAccessParams {
+    space: String,
+    user: String,
+    #[serde(rename = "clientId")]
+    #[allow(dead_code)]
+    client_id: Option<String>,
+}
+
+/// GET /xrpc/com.atproto.simplespace.checkUserAccess — the managing-app
+/// callback the spaces PDS invokes when minting a space credential. The
+/// answer comes from the live channel roster: current member DID, founder,
+/// or DID-op of the channel owning the space.
+async fn xrpc_check_user_access(
+    State(state): State<Arc<SharedState>>,
+    Query(q): Query<CheckUserAccessParams>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let Some(mgr) = state.media_space.clone() else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "MethodNotImplemented"})),
+        ));
+    };
+    let jwt = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "AuthMissing"})),
+        ))?;
+    if let Err(err) = crate::media_space::verify_service_auth(
+        &state.did_resolver,
+        jwt,
+        &mgr.authority_did,
+        &mgr.managing_app(),
+        "com.atproto.simplespace.checkUserAccess",
+    )
+    .await
+    {
+        tracing::warn!(error = %err, space = %q.space, "rejected checkUserAccess service auth");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "AuthenticationRequired"})),
+        ));
+    }
+    let authorized = media_space_member(&state, &mgr, &q.space, &q.user);
+    Ok(Json(serde_json::json!({ "authorized": authorized })))
+}
+
+/// Whether `user_did` may access `space`: the space must be one this server
+/// is the authority for, and the DID must currently hold the owning channel
+/// (member session, founder, or DID-op). Guests have no DID and never match.
+fn media_space_member(
+    state: &SharedState,
+    mgr: &crate::media_space::MediaSpaceManager,
+    space: &str,
+    user_did: &str,
+) -> bool {
+    let Some(key) = mgr.parse_space_key(space) else {
+        return false;
+    };
+    // Snapshot under the channels lock, resolve sessions under session_dids
+    // (same lock order as authorize_channel_read).
+    let (members, founder, did_ops) = {
+        let channels = state.channels.lock();
+        let Some(ch) = channels
+            .values()
+            .find(|c| c.media_space_key.as_deref() == Some(key))
+        else {
+            return false;
+        };
+        (
+            ch.members.clone(),
+            ch.founder_did.clone(),
+            ch.did_ops.clone(),
+        )
+    };
+    if founder.as_deref() == Some(user_did) || did_ops.contains(user_did) {
+        return true;
+    }
+    let session_dids = state.session_dids.lock();
+    members.iter().any(|sid| {
+        session_dids
+            .get(sid)
+            .map(|d| d == user_did)
+            .unwrap_or(false)
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct MediaSpaceParams {
+    channel: String,
+}
+
+/// GET /api/v1/media-space?channel=… — the channel's space ref, creating the
+/// space on first use. Authorization mirrors channel history reads.
+async fn api_media_space(
+    State(state): State<Arc<SharedState>>,
+    Query(q): Query<MediaSpaceParams>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let Some(mgr) = state.media_space.clone() else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+    let channel = authorize_channel_read(&state, &q.channel, &headers)?;
+    let key = channel.to_lowercase();
+
+    let space_body = |space_key: &str| {
+        serde_json::json!({
+            "space": mgr.space_ref(space_key),
+            "type": crate::media_space::SPACE_TYPE,
+        })
+    };
+    let stored = |state: &SharedState, key: &str| {
+        state
+            .channels
+            .lock()
+            .get(key)
+            .and_then(|c| c.media_space_key.clone())
+    };
+    if let Some(k) = stored(&state, &key) {
+        return Ok(Json(space_body(&k)));
+    }
+
+    // First use: create exactly one space, even under concurrent requests.
+    let _creating = mgr.create_lock.lock().await;
+    if let Some(k) = stored(&state, &key) {
+        return Ok(Json(space_body(&k)));
+    }
+    let new_key = ulid::Ulid::new().to_string();
+    if let Err(err) = mgr.create_space(&state.did_resolver, &new_key).await {
+        tracing::error!(error = %err, channel = %channel, "media space creation failed");
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+    let snapshot = {
+        let mut channels = state.channels.lock();
+        let Some(ch) = channels.get_mut(&key) else {
+            return Err(StatusCode::NOT_FOUND);
+        };
+        ch.media_space_key = Some(new_key.clone());
+        ch.clone()
+    };
+    state.with_db(|db| db.save_channel(&key, &snapshot));
+    Ok(Json(space_body(&new_key)))
 }
 
 /// GET /api/v1/messages/{msgid} — permalink resolution. Returns the message

--- a/freeq-server/tests/agent_assist_security.rs
+++ b/freeq-server/tests/agent_assist_security.rs
@@ -154,6 +154,7 @@ fn make_channel(state: &Arc<SharedState>, name: &str) {
             encrypted_only: false,
             key: None,
             pins: vec![],
+            media_space_key: None,
         }
     });
 }

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -258,7 +258,7 @@ async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
     let (s, meta) = get(fx.web, "/client-metadata.json").await;
     assert_eq!(s, 200);
     let scope = meta["scope"].as_str().unwrap();
-    let expected = format!("space:at.freeq.media?authority={AUTHORITY_DID}&collection=*");
+    let expected = format!("space:*?authority={AUTHORITY_DID}&collection=*");
     assert!(
         scope.split_whitespace().any(|t| t == expected),
         "feature-on metadata must advertise the space scope; got: {scope}"
@@ -286,6 +286,126 @@ async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
         !meta["scope"].as_str().unwrap().contains("space:"),
         "feature-off metadata must not advertise any space scope"
     );
+    server.abort();
+}
+
+// ── Serving space media ────────────────────────────────────────────────
+
+/// base64url-encode a record URI the way the serve route expects it.
+fn encode_ref(uri: &str) -> String {
+    URL_SAFE_NO_PAD.encode(uri.as_bytes())
+}
+
+#[tokio::test]
+async fn space_media_route_rejects_refs_that_are_not_ours() {
+    let fx = fixture_with_ids(&[]).await;
+    for uri in [
+        "at://did:plc:someoneelse/space/at.freeq.media/K1/did:plc:a/at.freeq.media.item/3k",
+        "at://did:plc:mediaauthority/space/com.example.other/K1/did:plc:a/c/3k",
+        "at://did:plc:mediaauthority/space/at.freeq.media/K1",
+    ] {
+        let (status, _) = get(
+            fx.web,
+            &format!("/api/v1/space-media/{}/x.png", encode_ref(uri)),
+        )
+        .await;
+        assert_eq!(status, 400, "must refuse a ref that is not ours: {uri}");
+    }
+    // Not base64 at all.
+    let (status, _) = get(fx.web, "/api/v1/space-media/!!!not-base64!!!/x.png").await;
+    assert_eq!(status, 400);
+    fx.server.abort();
+}
+
+#[tokio::test]
+async fn space_media_route_404s_for_an_unknown_space() {
+    let fx = fixture_with_ids(&[]).await;
+    // Well-formed and ours, but no channel owns this space key.
+    let uri = format!(
+        "at://{AUTHORITY_DID}/space/at.freeq.media/NOSUCHKEY/did:plc:a/at.freeq.media.item/3k"
+    );
+    let (status, _) = get(
+        fx.web,
+        &format!("/api/v1/space-media/{}/x.png", encode_ref(&uri)),
+    )
+    .await;
+    assert_eq!(status, 404);
+    fx.server.abort();
+}
+
+#[tokio::test]
+async fn space_media_route_refuses_anonymous_reads_of_a_restricted_channel() {
+    let fx = fixture_with_ids(&[]).await;
+    let config = ConnectConfig {
+        server_addr: fx.irc.to_string(),
+        nick: "own".to_string(),
+        user: "own".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(config, None);
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join("#priv").await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+
+    // Mint the space while the channel is still public, then lock it.
+    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23priv").await;
+    assert_eq!(s, 200);
+    let space = body["space"].as_str().unwrap().to_string();
+    let key = space.rsplit('/').next().unwrap().to_string();
+    h.mode("#priv", "+k", Some("sekrit")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let uri =
+        format!("at://{AUTHORITY_DID}/space/at.freeq.media/{key}/did:plc:a/at.freeq.media.item/3k");
+    let (status, _) = get(
+        fx.web,
+        &format!("/api/v1/space-media/{}/x.png", encode_ref(&uri)),
+    )
+    .await;
+    assert_eq!(
+        status, 403,
+        "an anonymous caller must not read a restricted channel's media"
+    );
+
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+#[tokio::test]
+async fn health_reports_whether_media_spaces_are_configured() {
+    let fx = fixture_with_ids(&[]).await;
+    let (s, body) = get(fx.web, "/api/v1/health").await;
+    assert_eq!(s, 200);
+    assert_eq!(body["media_spaces"], true);
+    fx.server.abort();
+
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: "test-media-off".to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(":memory:".to_string()),
+        ..Default::default()
+    };
+    let (_irc, web, server) = freeq_server::server::Server::with_resolver(
+        config,
+        DidResolver::static_map(HashMap::new()),
+    )
+    .start_with_web()
+    .await
+    .unwrap();
+    let (s, body) = get(web, "/api/v1/health").await;
+    assert_eq!(s, 200);
+    assert_eq!(body["media_spaces"], false);
+    // And the serve route is gone entirely.
+    let (status, _) = get(web, "/api/v1/space-media/abc/x.png").await;
+    assert_eq!(status, 404);
     server.abort();
 }
 

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -989,7 +989,9 @@ fn service_jwt_with_alg(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs() as i64;
-    let header = b64(serde_json::json!({ "typ": "JWT", "alg": alg }).to_string().as_bytes());
+    let header = b64(serde_json::json!({ "typ": "JWT", "alg": alg })
+        .to_string()
+        .as_bytes());
     let payload = b64(serde_json::json!({
         "iss": AUTHORITY_DID,
         "aud": aud,
@@ -1054,7 +1056,12 @@ async fn service_auth_rejects_an_implausibly_distant_expiry() {
     let space = format!("at://{AUTHORITY_DID}/space/at.freeq.media/somekey");
     let (s, _) = check_access(
         fx.web,
-        Some(&service_jwt(&fx.authority_key, &managing_app(), LXM, 86_400)),
+        Some(&service_jwt(
+            &fx.authority_key,
+            &managing_app(),
+            LXM,
+            86_400,
+        )),
         &space,
         "did:plc:x",
     )

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -133,6 +133,89 @@ async fn fixture_with_ids(extra_ids: &[(&str, &PrivateKey)]) -> Fixture {
     }
 }
 
+const MEMBER_DID: &str = "did:plc:spacemember";
+
+/// Boot a fixture whose `#open` channel has one authenticated member, and
+/// return that member's handle, events and API bearer. Minting a space is a
+/// members-only action, so every test that mints one needs this.
+async fn fixture_with_member() -> (Fixture, freeq_sdk::client::ClientHandle, String) {
+    let key = PrivateKey::generate_ed25519();
+    let fx = fixture_with_ids(&[(MEMBER_DID, &key)]).await;
+    let (h, bearer) = join_as_member(&fx.irc, MEMBER_DID, &key, "member", "#open").await;
+    (fx, h, bearer)
+}
+
+/// Connect an authenticated client, join `channel`, and return its bearer.
+async fn join_as_member(
+    irc: &std::net::SocketAddr,
+    did: &str,
+    key: &PrivateKey,
+    nick: &str,
+    channel: &str,
+) -> (freeq_sdk::client::ClientHandle, String) {
+    let cfg = ConnectConfig {
+        server_addr: irc.to_string(),
+        nick: nick.to_string(),
+        user: nick.to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(cfg, Some(signer_for(did, key)));
+    let bearer = wait_for_bearer(&mut events).await;
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join(channel).await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    // The events receiver is dropped, so the session stays up but unread.
+    std::mem::forget(events);
+    (h, bearer)
+}
+
+/// The API bearer the server hands an authenticated session, from the
+/// `API-BEARER <session>` notice that follows SASL success. REST reads of a
+/// channel are authorized by this, so a test that wants to act as a member
+/// has to hold it.
+async fn wait_for_bearer(events: &mut mpsc::Receiver<Event>) -> String {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Some(Event::ServerNotice { text }) => {
+                    if let Some(b) = text.split_whitespace().nth(1)
+                        && text.starts_with("API-BEARER")
+                    {
+                        return b.to_string();
+                    }
+                }
+                Some(_) => continue,
+                None => panic!("stream ended before the API bearer arrived"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for the API bearer")
+}
+
+/// A member's GET: the session bearer is what proves channel membership.
+async fn get_as(web: std::net::SocketAddr, bearer: &str, path: &str) -> (u16, serde_json::Value) {
+    let r = reqwest::Client::new()
+        .get(format!("http://{web}{path}"))
+        .bearer_auth(bearer)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    (
+        status,
+        serde_json::from_str(&body).unwrap_or(serde_json::Value::Null),
+    )
+}
+
 fn signer_for(did: &str, key: &PrivateKey) -> Arc<dyn ChallengeSigner> {
     let key = PrivateKey::ed25519_from_bytes(&key.secret_bytes()).unwrap();
     Arc::new(KeySigner::new(did.to_string(), key))
@@ -320,10 +403,15 @@ async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
 async fn an_expired_authority_session_is_renewed_and_the_space_still_created() {
     let (pds_addr, created) = mock_pds_expiring_session().await;
     let authority_key = PrivateKey::generate_secp256k1();
+    let member_key = PrivateKey::generate_ed25519();
     let mut docs: HashMap<String, DidDocument> = HashMap::new();
     docs.insert(
         AUTHORITY_DID.to_string(),
         make_test_did_document(AUTHORITY_DID, &authority_key.public_key_multibase()),
+    );
+    docs.insert(
+        MEMBER_DID.to_string(),
+        make_test_did_document(MEMBER_DID, &member_key.public_key_multibase()),
     );
     let config = freeq_server::config::ServerConfig {
         listen_addr: "127.0.0.1:0".to_string(),
@@ -342,24 +430,9 @@ async fn an_expired_authority_session_is_renewed_and_the_space_still_created() {
             .await
             .unwrap();
 
-    let cfg = ConnectConfig {
-        server_addr: irc.to_string(),
-        nick: "guest1".to_string(),
-        user: "guest1".to_string(),
-        realname: "test".to_string(),
-        ..Default::default()
-    };
-    let (h, mut events) = client::connect(cfg, None);
-    expect_event(
-        &mut events,
-        |e| matches!(e, Event::Registered { .. }),
-        "registered",
-    )
-    .await;
-    h.join("#open").await.unwrap();
-    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    let (h, bearer) = join_as_member(&irc, MEMBER_DID, &member_key, "member", "#open").await;
 
-    let (status, body) = get(web, "/api/v1/media-space?channel=%23open").await;
+    let (status, body) = get_as(web, &bearer, "/api/v1/media-space?channel=%23open").await;
     assert_eq!(
         status, 200,
         "an expired session must not fail the request: {body}"
@@ -369,6 +442,80 @@ async fn an_expired_authority_session_is_renewed_and_the_space_still_created() {
 
     h.quit(None).await.ok();
     server.abort();
+}
+
+/// Ensure that an authenticated client can send media and non-members
+/// are refused.
+#[tokio::test]
+async fn only_members_can_post_space_media() {
+    let member_key = PrivateKey::generate_ed25519();
+    let outsider_key = PrivateKey::generate_ed25519();
+    let outsider_did = "did:plc:spaceoutsider";
+    let fx = fixture_with_ids(&[(MEMBER_DID, &member_key), (outsider_did, &outsider_key)]).await;
+    let (h, _bearer) = join_as_member(&fx.irc, MEMBER_DID, &member_key, "member", "#open").await;
+
+    let post = |did: &str| {
+        let form = reqwest::multipart::Form::new()
+            .text("did", did.to_string())
+            .text("channel", "#open".to_string())
+            .text("space_media", "true".to_string())
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(b"not really a png".to_vec())
+                    .file_name("x.png")
+                    .mime_str("image/png")
+                    .unwrap(),
+            );
+        reqwest::Client::new()
+            .post(format!("http://{}/api/v1/upload", fx.web))
+            .multipart(form)
+            .timeout(Duration::from_secs(5))
+            .send()
+    };
+
+    // A DID with no session at all cannot upload anywhere.
+    let r = post(outsider_did).await.unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    assert!(
+        status == 401 || status == 403,
+        "a stranger must not post: {status} {body}"
+    );
+    assert_eq!(fx.created.load(Ordering::SeqCst), 0, "nothing was created");
+
+    // An authenticated non-member is refused by the membership gate, not by
+    // the step-up path: they are told they are not in the channel.
+    let (outsider, _b) = join_as_member(
+        &fx.irc,
+        outsider_did,
+        &outsider_key,
+        "outsider",
+        "#elsewhere",
+    )
+    .await;
+    let r = post(outsider_did).await.unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    assert_eq!(status, 403, "non-member: {body}");
+    assert!(
+        body.contains("Only channel members"),
+        "a non-member must be told why, not sent to a step-up: {body}"
+    );
+    assert_eq!(fx.created.load(Ordering::SeqCst), 0);
+
+    // The member gets past membership and lands on the real next step: they
+    // have no space grant yet, so the server asks for one.
+    let r = post(MEMBER_DID).await.unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    assert!(
+        body.contains("step_up_required") || body.contains("not_authenticated"),
+        "a member must pass the gate and be asked for the grant: {status} {body}"
+    );
+
+    outsider.quit(None).await.ok();
+    h.quit(None).await.ok();
+    fx.server.abort();
 }
 
 #[tokio::test]
@@ -425,26 +572,12 @@ async fn space_media_route_404s_for_an_unknown_space() {
 
 #[tokio::test]
 async fn space_media_route_refuses_anonymous_reads_of_a_restricted_channel() {
-    let fx = fixture_with_ids(&[]).await;
-    let config = ConnectConfig {
-        server_addr: fx.irc.to_string(),
-        nick: "own".to_string(),
-        user: "own".to_string(),
-        realname: "test".to_string(),
-        ..Default::default()
-    };
-    let (h, mut events) = client::connect(config, None);
-    expect_event(
-        &mut events,
-        |e| matches!(e, Event::Registered { .. }),
-        "registered",
-    )
-    .await;
-    h.join("#priv").await.unwrap();
-    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    let member_key = PrivateKey::generate_ed25519();
+    let fx = fixture_with_ids(&[(MEMBER_DID, &member_key)]).await;
+    let (h, bearer) = join_as_member(&fx.irc, MEMBER_DID, &member_key, "own", "#priv").await;
 
     // Mint the space while the channel is still public, then lock it.
-    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23priv").await;
+    let (s, body) = get_as(fx.web, &bearer, "/api/v1/media-space?channel=%23priv").await;
     assert_eq!(s, 200);
     let space = body["space"].as_str().unwrap().to_string();
     let key = space.rsplit('/').next().unwrap().to_string();
@@ -503,30 +636,12 @@ async fn health_reports_whether_media_spaces_are_configured() {
 
 #[tokio::test]
 async fn first_use_creates_exactly_one_space_and_persists_it() {
-    let fx = fixture_with_ids(&[]).await;
-
-    // A guest keeps #open resident.
-    let config = ConnectConfig {
-        server_addr: fx.irc.to_string(),
-        nick: "guest1".to_string(),
-        user: "guest1".to_string(),
-        realname: "test".to_string(),
-        ..Default::default()
-    };
-    let (h, mut events) = client::connect(config, None);
-    expect_event(
-        &mut events,
-        |e| matches!(e, Event::Registered { .. }),
-        "registered",
-    )
-    .await;
-    h.join("#open").await.unwrap();
-    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    let (fx, h, bearer) = fixture_with_member().await;
 
     // Two concurrent first requests race the creation.
     let (a, b) = tokio::join!(
-        get(fx.web, "/api/v1/media-space?channel=%23open"),
-        get(fx.web, "/api/v1/media-space?channel=%23open"),
+        get_as(fx.web, &bearer, "/api/v1/media-space?channel=%23open"),
+        get_as(fx.web, &bearer, "/api/v1/media-space?channel=%23open"),
     );
     assert_eq!(a.0, 200, "first: {:?}", a.1);
     assert_eq!(b.0, 200, "second: {:?}", b.1);
@@ -543,9 +658,41 @@ async fn first_use_creates_exactly_one_space_and_persists_it() {
     assert_eq!(fx.created.load(Ordering::SeqCst), 1, "createSpace ran once");
 
     // A later request returns the stored ref without creating again.
-    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23open").await;
+    let (s, body) = get_as(fx.web, &bearer, "/api/v1/media-space?channel=%23open").await;
     assert_eq!(s, 200);
     assert_eq!(body["space"].as_str().unwrap(), space);
+    assert_eq!(fx.created.load(Ordering::SeqCst), 1);
+
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+/// Minting a space writes to the operator's PDS, so only a member may cause
+/// one. A public channel is readable by anyone, which is exactly why the
+/// read rule alone is not enough here.
+#[tokio::test]
+async fn only_members_can_mint_a_space() {
+    let (fx, h, bearer) = fixture_with_member().await;
+
+    let (status, _) = get(fx.web, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(
+        status, 401,
+        "an anonymous caller must not be able to create a space"
+    );
+    assert_eq!(fx.created.load(Ordering::SeqCst), 0, "nothing was created");
+
+    let (status, _) = get_as(
+        fx.web,
+        "not-a-real-bearer",
+        "/api/v1/media-space?channel=%23open",
+    )
+    .await;
+    assert_eq!(status, 401, "an unknown bearer must not either");
+    assert_eq!(fx.created.load(Ordering::SeqCst), 0);
+
+    // The member can.
+    let (status, _) = get_as(fx.web, &bearer, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(status, 200);
     assert_eq!(fx.created.load(Ordering::SeqCst), 1);
 
     h.quit(None).await.ok();
@@ -558,10 +705,15 @@ async fn space_key_survives_a_server_restart() {
     let db_path = dir.path().join("media.db").to_str().unwrap().to_string();
     let (pds_addr, created) = mock_pds().await;
     let authority_key = PrivateKey::generate_secp256k1();
+    let member_key = PrivateKey::generate_ed25519();
     let mut docs: HashMap<String, DidDocument> = HashMap::new();
     docs.insert(
         AUTHORITY_DID.to_string(),
         make_test_did_document(AUTHORITY_DID, &authority_key.public_key_multibase()),
+    );
+    docs.insert(
+        MEMBER_DID.to_string(),
+        make_test_did_document(MEMBER_DID, &member_key.public_key_multibase()),
     );
     let config = || freeq_server::config::ServerConfig {
         listen_addr: "127.0.0.1:0".to_string(),
@@ -583,23 +735,8 @@ async fn space_key_survives_a_server_restart() {
     .start_with_web()
     .await
     .unwrap();
-    let cfg = ConnectConfig {
-        server_addr: irc.to_string(),
-        nick: "guest1".to_string(),
-        user: "guest1".to_string(),
-        realname: "test".to_string(),
-        ..Default::default()
-    };
-    let (h, mut events) = client::connect(cfg, None);
-    expect_event(
-        &mut events,
-        |e| matches!(e, Event::Registered { .. }),
-        "registered",
-    )
-    .await;
-    h.join("#open").await.unwrap();
-    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
-    let (s, body) = get(web, "/api/v1/media-space?channel=%23open").await;
+    let (h, bearer) = join_as_member(&irc, MEMBER_DID, &member_key, "member", "#open").await;
+    let (s, body) = get_as(web, &bearer, "/api/v1/media-space?channel=%23open").await;
     assert_eq!(s, 200);
     let space = body["space"].as_str().unwrap().to_string();
     h.quit(None).await.ok();
@@ -609,12 +746,13 @@ async fn space_key_survives_a_server_restart() {
     // Second boot: the channel has no history, topic, or modes — only its
     // space key. The empty-channel prune must keep it, and the same space
     // ref must come back without another createSpace on the PDS.
-    let (_irc2, web2, server2) =
+    let (irc2, web2, server2) =
         freeq_server::server::Server::with_resolver(config(), DidResolver::static_map(docs))
             .start_with_web()
             .await
             .unwrap();
-    let (s, body) = get(web2, "/api/v1/media-space?channel=%23open").await;
+    let (h2, bearer2) = join_as_member(&irc2, MEMBER_DID, &member_key, "member", "#open").await;
+    let (s, body) = get_as(web2, &bearer2, "/api/v1/media-space?channel=%23open").await;
     assert_eq!(s, 200, "channel with a space must survive the boot prune");
     assert_eq!(
         body["space"].as_str().unwrap(),
@@ -622,6 +760,7 @@ async fn space_key_survives_a_server_restart() {
         "space key must persist"
     );
     assert_eq!(created.load(Ordering::SeqCst), 1, "no second createSpace");
+    h2.quit(None).await.ok();
     server2.abort();
 }
 
@@ -703,12 +842,7 @@ async fn check_user_access_follows_live_channel_membership() {
     };
     let (alice, mut alice_events) =
         client::connect(alice_cfg, Some(signer_for(alice_did, &alice_key)));
-    expect_event(
-        &mut alice_events,
-        |e| matches!(e, Event::Authenticated { .. }),
-        "auth",
-    )
-    .await;
+    let alice_bearer = wait_for_bearer(&mut alice_events).await;
     expect_event(
         &mut alice_events,
         |e| matches!(e, Event::Registered { .. }),
@@ -723,7 +857,7 @@ async fn check_user_access_follows_live_channel_membership() {
     )
     .await;
 
-    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23open").await;
+    let (s, body) = get_as(fx.web, &alice_bearer, "/api/v1/media-space?channel=%23open").await;
     assert_eq!(s, 200);
     let space = body["space"].as_str().unwrap().to_string();
     let jwt = service_jwt(&fx.authority_key, &managing_app(), LXM, 60);

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -250,6 +250,45 @@ async fn did_web_document_names_the_managing_app_service() {
     fx.server.abort();
 }
 
+// ── OAuth scope surface ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
+    let fx = fixture_with_ids(&[]).await;
+    let (s, meta) = get(fx.web, "/client-metadata.json").await;
+    assert_eq!(s, 200);
+    let scope = meta["scope"].as_str().unwrap();
+    let expected = format!("space:at.freeq.media?authority={AUTHORITY_DID}&collection=*");
+    assert!(
+        scope.split_whitespace().any(|t| t == expected),
+        "feature-on metadata must advertise the space scope; got: {scope}"
+    );
+    fx.server.abort();
+
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: "test-media-off".to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(":memory:".to_string()),
+        ..Default::default()
+    };
+    let (_irc, web, server) = freeq_server::server::Server::with_resolver(
+        config,
+        DidResolver::static_map(HashMap::new()),
+    )
+    .start_with_web()
+    .await
+    .unwrap();
+    let (s, meta) = get(web, "/client-metadata.json").await;
+    assert_eq!(s, 200);
+    assert!(
+        !meta["scope"].as_str().unwrap().contains("space:"),
+        "feature-off metadata must not advertise any space scope"
+    );
+    server.abort();
+}
+
 // ── Lazy creation via the space-ref API ────────────────────────────────
 
 #[tokio::test]

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -1,0 +1,582 @@
+//! Private media spaces: the feature flag, lazy exactly-once space creation,
+//! the space-ref API, and the checkUserAccess membership callback with
+//! service-auth verification.
+//!
+//! The spaces PDS is mocked with a local HTTP server; the DID directory is a
+//! static resolver, so no network leaves the machine.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use freeq_sdk::auth::{ChallengeSigner, KeySigner};
+use freeq_sdk::client::{self, ConnectConfig};
+use freeq_sdk::crypto::PrivateKey;
+use freeq_sdk::did::{DidDocument, DidResolver, make_test_did_document};
+use freeq_sdk::event::Event;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+const AUTHORITY_DID: &str = "did:plc:mediaauthority";
+const SERVER_NAME: &str = "test-media";
+const LXM: &str = "com.atproto.simplespace.checkUserAccess";
+
+fn managing_app() -> String {
+    format!("did:web:{SERVER_NAME}#freeq_media")
+}
+
+/// A mock spaces PDS: createSession always succeeds, createSpace succeeds and
+/// counts its calls.
+async fn mock_pds() -> (std::net::SocketAddr, Arc<AtomicUsize>) {
+    let created = Arc::new(AtomicUsize::new(0));
+    let counter = created.clone();
+    let app = axum::Router::new()
+        .route(
+            "/xrpc/com.atproto.server.createSession",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({
+                    "accessJwt": "test-token",
+                    "refreshJwt": "test-refresh",
+                    "did": AUTHORITY_DID,
+                    "handle": "media.test",
+                }))
+            }),
+        )
+        .route(
+            "/xrpc/com.atproto.simplespace.createSpace",
+            axum::routing::post(move || {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    axum::Json(serde_json::json!({ "uri": "at://created" }))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (addr, created)
+}
+
+struct Fixture {
+    web: std::net::SocketAddr,
+    irc: std::net::SocketAddr,
+    created: Arc<AtomicUsize>,
+    authority_key: PrivateKey,
+    server: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+/// Boot a server with the feature on: a mock spaces PDS, an authority DID
+/// with a known secp256k1 key, and `extra_ids` resolvable for SASL.
+async fn fixture_with_ids(extra_ids: &[(&str, &PrivateKey)]) -> Fixture {
+    let (pds_addr, created) = mock_pds().await;
+    let authority_key = PrivateKey::generate_secp256k1();
+    let mut docs: HashMap<String, DidDocument> = HashMap::new();
+    docs.insert(
+        AUTHORITY_DID.to_string(),
+        make_test_did_document(AUTHORITY_DID, &authority_key.public_key_multibase()),
+    );
+    for (did, key) in extra_ids {
+        docs.insert(
+            did.to_string(),
+            make_test_did_document(did, &key.public_key_multibase()),
+        );
+    }
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: SERVER_NAME.to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(":memory:".to_string()),
+        media_space_did: Some(AUTHORITY_DID.to_string()),
+        media_space_password: Some("hunter2".to_string()),
+        media_space_pds: Some(format!("http://{pds_addr}")),
+        ..Default::default()
+    };
+    let (irc, web, server) =
+        freeq_server::server::Server::with_resolver(config, DidResolver::static_map(docs))
+            .start_with_web()
+            .await
+            .unwrap();
+    Fixture {
+        web,
+        irc,
+        created,
+        authority_key,
+        server,
+    }
+}
+
+fn signer_for(did: &str, key: &PrivateKey) -> Arc<dyn ChallengeSigner> {
+    let key = PrivateKey::ed25519_from_bytes(&key.secret_bytes()).unwrap();
+    Arc::new(KeySigner::new(did.to_string(), key))
+}
+
+async fn expect_event(
+    events: &mut mpsc::Receiver<Event>,
+    pred: impl Fn(&Event) -> bool,
+    what: &str,
+) {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Some(e) if pred(&e) => return,
+                Some(_) => continue,
+                None => panic!("stream ended waiting for {what}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timeout waiting for {what}"));
+}
+
+fn b64(data: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+/// Mint a service-auth JWT the way the spaces PDS does: signed by `key`,
+/// issued by the authority, addressed to this server's managing app.
+fn service_jwt(key: &PrivateKey, aud: &str, lxm: &str, exp_offset_secs: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let header = b64(br#"{"typ":"JWT","alg":"ES256K"}"#);
+    let payload = b64(serde_json::json!({
+        "iss": AUTHORITY_DID,
+        "aud": aud,
+        "lxm": lxm,
+        "exp": now + exp_offset_secs,
+    })
+    .to_string()
+    .as_bytes());
+    let signing_input = format!("{header}.{payload}");
+    let sig = key.sign(signing_input.as_bytes());
+    format!("{signing_input}.{}", b64(&sig))
+}
+
+async fn get(web: std::net::SocketAddr, path: &str) -> (u16, serde_json::Value) {
+    let r = reqwest::Client::new()
+        .get(format!("http://{web}{path}"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    (
+        status,
+        serde_json::from_str(&body).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+async fn check_access(
+    web: std::net::SocketAddr,
+    jwt: Option<&str>,
+    space: &str,
+    user: &str,
+) -> (u16, serde_json::Value) {
+    let url = format!(
+        "http://{web}/xrpc/com.atproto.simplespace.checkUserAccess?space={}&user={}",
+        urlencoding_encode(space),
+        urlencoding_encode(user),
+    );
+    let mut req = reqwest::Client::new()
+        .get(url)
+        .timeout(Duration::from_secs(5));
+    if let Some(jwt) = jwt {
+        req = req.bearer_auth(jwt);
+    }
+    let r = req.send().await.unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    (
+        status,
+        serde_json::from_str(&body).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Minimal percent-encoding for the query values used here.
+fn urlencoding_encode(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('#', "%23")
+        .replace(':', "%3A")
+        .replace('/', "%2F")
+}
+
+// ── Feature off ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn feature_off_answers_404_everywhere() {
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: "test-media-off".to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(":memory:".to_string()),
+        ..Default::default()
+    };
+    let (_irc, web, server) = freeq_server::server::Server::with_resolver(
+        config,
+        DidResolver::static_map(HashMap::new()),
+    )
+    .start_with_web()
+    .await
+    .unwrap();
+
+    let (s1, _) = get(web, "/.well-known/did.json").await;
+    let (s2, _) = get(web, "/api/v1/media-space?channel=%23open").await;
+    let (s3, _) = check_access(web, None, "at://x/space/at.freeq.media/k", "did:plc:x").await;
+    assert_eq!((s1, s2, s3), (404, 404, 404));
+    server.abort();
+}
+
+// ── did:web document ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn did_web_document_names_the_managing_app_service() {
+    let fx = fixture_with_ids(&[]).await;
+    let (status, doc) = get(fx.web, "/.well-known/did.json").await;
+    assert_eq!(status, 200);
+    assert_eq!(doc["id"], format!("did:web:{SERVER_NAME}"));
+    assert_eq!(doc["service"][0]["id"], "#freeq_media");
+    assert_eq!(
+        doc["service"][0]["serviceEndpoint"],
+        format!("https://{SERVER_NAME}")
+    );
+    fx.server.abort();
+}
+
+// ── Lazy creation via the space-ref API ────────────────────────────────
+
+#[tokio::test]
+async fn first_use_creates_exactly_one_space_and_persists_it() {
+    let fx = fixture_with_ids(&[]).await;
+
+    // A guest keeps #open resident.
+    let config = ConnectConfig {
+        server_addr: fx.irc.to_string(),
+        nick: "guest1".to_string(),
+        user: "guest1".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(config, None);
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join("#open").await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+
+    // Two concurrent first requests race the creation.
+    let (a, b) = tokio::join!(
+        get(fx.web, "/api/v1/media-space?channel=%23open"),
+        get(fx.web, "/api/v1/media-space?channel=%23open"),
+    );
+    assert_eq!(a.0, 200, "first: {:?}", a.1);
+    assert_eq!(b.0, 200, "second: {:?}", b.1);
+    assert_eq!(
+        a.1["space"], b.1["space"],
+        "both callers must see one space"
+    );
+    assert_eq!(a.1["type"], "at.freeq.media");
+    let space = a.1["space"].as_str().unwrap().to_string();
+    assert!(
+        space.starts_with(&format!("at://{AUTHORITY_DID}/space/at.freeq.media/")),
+        "unexpected space ref: {space}"
+    );
+    assert_eq!(fx.created.load(Ordering::SeqCst), 1, "createSpace ran once");
+
+    // A later request returns the stored ref without creating again.
+    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(s, 200);
+    assert_eq!(body["space"].as_str().unwrap(), space);
+    assert_eq!(fx.created.load(Ordering::SeqCst), 1);
+
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+#[tokio::test]
+async fn space_key_survives_a_server_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("media.db").to_str().unwrap().to_string();
+    let (pds_addr, created) = mock_pds().await;
+    let authority_key = PrivateKey::generate_secp256k1();
+    let mut docs: HashMap<String, DidDocument> = HashMap::new();
+    docs.insert(
+        AUTHORITY_DID.to_string(),
+        make_test_did_document(AUTHORITY_DID, &authority_key.public_key_multibase()),
+    );
+    let config = || freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: SERVER_NAME.to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(db_path.clone()),
+        media_space_did: Some(AUTHORITY_DID.to_string()),
+        media_space_password: Some("hunter2".to_string()),
+        media_space_pds: Some(format!("http://{pds_addr}")),
+        ..Default::default()
+    };
+
+    // First boot: hold #open resident, mint its space.
+    let (irc, web, server) = freeq_server::server::Server::with_resolver(
+        config(),
+        DidResolver::static_map(docs.clone()),
+    )
+    .start_with_web()
+    .await
+    .unwrap();
+    let cfg = ConnectConfig {
+        server_addr: irc.to_string(),
+        nick: "guest1".to_string(),
+        user: "guest1".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(cfg, None);
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join("#open").await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    let (s, body) = get(web, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(s, 200);
+    let space = body["space"].as_str().unwrap().to_string();
+    h.quit(None).await.ok();
+    server.abort();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Second boot: the channel has no history, topic, or modes — only its
+    // space key. The empty-channel prune must keep it, and the same space
+    // ref must come back without another createSpace on the PDS.
+    let (_irc2, web2, server2) =
+        freeq_server::server::Server::with_resolver(config(), DidResolver::static_map(docs))
+            .start_with_web()
+            .await
+            .unwrap();
+    let (s, body) = get(web2, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(s, 200, "channel with a space must survive the boot prune");
+    assert_eq!(
+        body["space"].as_str().unwrap(),
+        space,
+        "space key must persist"
+    );
+    assert_eq!(created.load(Ordering::SeqCst), 1, "no second createSpace");
+    server2.abort();
+}
+
+#[tokio::test]
+async fn space_ref_api_refuses_anonymous_reads_of_restricted_channels() {
+    let fx = fixture_with_ids(&[]).await;
+    let config = ConnectConfig {
+        server_addr: fx.irc.to_string(),
+        nick: "own".to_string(),
+        user: "own".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(config, None);
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join("#priv").await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+    h.mode("#priv", "+k", Some("sekrit")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let (status, _) = get(fx.web, "/api/v1/media-space?channel=%23priv").await;
+    assert_eq!(
+        status, 403,
+        "anonymous caller got a restricted channel's space ref"
+    );
+    assert_eq!(
+        fx.created.load(Ordering::SeqCst),
+        0,
+        "no space for refused request"
+    );
+
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+// ── checkUserAccess ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_user_access_follows_live_channel_membership() {
+    let alice_key = PrivateKey::generate_ed25519();
+    let alice_did = "did:plc:alicemedia";
+    let fx = fixture_with_ids(&[(alice_did, &alice_key)]).await;
+
+    // A guest creates and holds #open (guest founder: nobody's DID owns it),
+    // then authenticated alice joins.
+    let guest_cfg = ConnectConfig {
+        server_addr: fx.irc.to_string(),
+        nick: "holder".to_string(),
+        user: "holder".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (guest, mut guest_events) = client::connect(guest_cfg, None);
+    expect_event(
+        &mut guest_events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    guest.join("#open").await.unwrap();
+    expect_event(
+        &mut guest_events,
+        |e| matches!(e, Event::Joined { .. }),
+        "joined",
+    )
+    .await;
+
+    let alice_cfg = ConnectConfig {
+        server_addr: fx.irc.to_string(),
+        nick: "alice".to_string(),
+        user: "alice".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (alice, mut alice_events) =
+        client::connect(alice_cfg, Some(signer_for(alice_did, &alice_key)));
+    expect_event(
+        &mut alice_events,
+        |e| matches!(e, Event::Authenticated { .. }),
+        "auth",
+    )
+    .await;
+    expect_event(
+        &mut alice_events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    alice.join("#open").await.unwrap();
+    expect_event(
+        &mut alice_events,
+        |e| matches!(e, Event::Joined { .. }),
+        "joined",
+    )
+    .await;
+
+    let (s, body) = get(fx.web, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(s, 200);
+    let space = body["space"].as_str().unwrap().to_string();
+    let jwt = service_jwt(&fx.authority_key, &managing_app(), LXM, 60);
+
+    // Member: authorized.
+    let (s, body) = check_access(fx.web, Some(&jwt), &space, alice_did).await;
+    assert_eq!(s, 200);
+    assert_eq!(
+        body["authorized"], true,
+        "member must be authorized: {body}"
+    );
+
+    // A DID that never joined: denied.
+    let (s, body) = check_access(fx.web, Some(&jwt), &space, "did:plc:stranger").await;
+    assert_eq!(s, 200);
+    assert_eq!(body["authorized"], false, "stranger must be denied");
+
+    // A space this server is not the authority for: denied.
+    let (s, body) = check_access(
+        fx.web,
+        Some(&jwt),
+        "at://did:plc:other/space/at.freeq.media/xyz",
+        alice_did,
+    )
+    .await;
+    assert_eq!(s, 200);
+    assert_eq!(body["authorized"], false, "foreign space must be denied");
+
+    // Alice parts: access ends with membership.
+    alice.raw("PART #open").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let (s, body) = check_access(fx.web, Some(&jwt), &space, alice_did).await;
+    assert_eq!(s, 200);
+    assert_eq!(
+        body["authorized"], false,
+        "departed member must be denied: {body}"
+    );
+
+    alice.quit(None).await.ok();
+    guest.quit(None).await.ok();
+    fx.server.abort();
+}
+
+#[tokio::test]
+async fn check_user_access_rejects_bad_service_auth() {
+    let fx = fixture_with_ids(&[]).await;
+    let space = format!("at://{AUTHORITY_DID}/space/at.freeq.media/somekey");
+
+    // No token.
+    let (s, _) = check_access(fx.web, None, &space, "did:plc:x").await;
+    assert_eq!(s, 401);
+
+    // Signed by the wrong key.
+    let wrong = PrivateKey::generate_secp256k1();
+    let (s, _) = check_access(
+        fx.web,
+        Some(&service_jwt(&wrong, &managing_app(), LXM, 60)),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 401, "foreign signature must be rejected");
+
+    // Wrong audience.
+    let (s, _) = check_access(
+        fx.web,
+        Some(&service_jwt(
+            &fx.authority_key,
+            "did:web:elsewhere#other",
+            LXM,
+            60,
+        )),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 401, "wrong-audience token must be rejected");
+
+    // Wrong method binding.
+    let (s, _) = check_access(
+        fx.web,
+        Some(&service_jwt(
+            &fx.authority_key,
+            &managing_app(),
+            "com.atproto.other.method",
+            60,
+        )),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 401, "wrong-lxm token must be rejected");
+
+    // Expired.
+    let (s, _) = check_access(
+        fx.web,
+        Some(&service_jwt(&fx.authority_key, &managing_app(), LXM, -60)),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 401, "expired token must be rejected");
+
+    fx.server.abort();
+}

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use axum::response::IntoResponse;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use freeq_sdk::auth::{ChallengeSigner, KeySigner};
@@ -31,8 +32,19 @@ fn managing_app() -> String {
 /// A mock spaces PDS: createSession always succeeds, createSpace succeeds and
 /// counts its calls.
 async fn mock_pds() -> (std::net::SocketAddr, Arc<AtomicUsize>) {
+    mock_pds_inner(false).await
+}
+
+/// Same as above, but the first createSpace fails the way an aged-out session
+/// does: a 400 carrying `ExpiredToken`.
+async fn mock_pds_expiring_session() -> (std::net::SocketAddr, Arc<AtomicUsize>) {
+    mock_pds_inner(true).await
+}
+
+async fn mock_pds_inner(expire_first: bool) -> (std::net::SocketAddr, Arc<AtomicUsize>) {
     let created = Arc::new(AtomicUsize::new(0));
     let counter = created.clone();
+    let expired_once = Arc::new(AtomicUsize::new(0));
     let app = axum::Router::new()
         .route(
             "/xrpc/com.atproto.server.createSession",
@@ -49,9 +61,20 @@ async fn mock_pds() -> (std::net::SocketAddr, Arc<AtomicUsize>) {
             "/xrpc/com.atproto.simplespace.createSpace",
             axum::routing::post(move || {
                 let counter = counter.clone();
+                let expired_once = expired_once.clone();
                 async move {
+                    if expire_first && expired_once.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            axum::Json(serde_json::json!({
+                                "error": "ExpiredToken",
+                                "message": "Token has expired",
+                            })),
+                        )
+                            .into_response();
+                    }
                     counter.fetch_add(1, Ordering::SeqCst);
-                    axum::Json(serde_json::json!({ "uri": "at://created" }))
+                    axum::Json(serde_json::json!({ "uri": "at://created" })).into_response()
                 }
             }),
         );
@@ -290,6 +313,73 @@ async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
 }
 
 // ── Serving space media ────────────────────────────────────────────────
+
+/// The PDS reports an aged-out session as a 400 carrying `ExpiredToken`.
+/// The stale token is dropped and the request made again.
+#[tokio::test]
+async fn an_expired_authority_session_is_renewed_and_the_space_still_created() {
+    let (pds_addr, created) = mock_pds_expiring_session().await;
+    let authority_key = PrivateKey::generate_secp256k1();
+    let mut docs: HashMap<String, DidDocument> = HashMap::new();
+    docs.insert(
+        AUTHORITY_DID.to_string(),
+        make_test_did_document(AUTHORITY_DID, &authority_key.public_key_multibase()),
+    );
+    let config = freeq_server::config::ServerConfig {
+        listen_addr: "127.0.0.1:0".to_string(),
+        web_addr: Some("127.0.0.1:0".to_string()),
+        server_name: SERVER_NAME.to_string(),
+        challenge_timeout_secs: 60,
+        db_path: Some(":memory:".to_string()),
+        media_space_did: Some(AUTHORITY_DID.to_string()),
+        media_space_password: Some("hunter2".to_string()),
+        media_space_pds: Some(format!("http://{pds_addr}")),
+        ..Default::default()
+    };
+    let (irc, web, server) =
+        freeq_server::server::Server::with_resolver(config, DidResolver::static_map(docs))
+            .start_with_web()
+            .await
+            .unwrap();
+
+    let cfg = ConnectConfig {
+        server_addr: irc.to_string(),
+        nick: "guest1".to_string(),
+        user: "guest1".to_string(),
+        realname: "test".to_string(),
+        ..Default::default()
+    };
+    let (h, mut events) = client::connect(cfg, None);
+    expect_event(
+        &mut events,
+        |e| matches!(e, Event::Registered { .. }),
+        "registered",
+    )
+    .await;
+    h.join("#open").await.unwrap();
+    expect_event(&mut events, |e| matches!(e, Event::Joined { .. }), "joined").await;
+
+    let (status, body) = get(web, "/api/v1/media-space?channel=%23open").await;
+    assert_eq!(
+        status, 200,
+        "an expired session must not fail the request: {body}"
+    );
+    assert!(body["space"].as_str().unwrap().contains("at.freeq.media"));
+    assert_eq!(created.load(Ordering::SeqCst), 1, "created after the retry");
+
+    h.quit(None).await.ok();
+    server.abort();
+}
+
+#[tokio::test]
+async fn space_media_urls_carry_no_spaces() {
+    let name = freeq_server::media_store::sanitize_filename("Image filename with spaces.png");
+    assert!(
+        !name.contains(' '),
+        "sanitized filename kept a space: {name}"
+    );
+    assert!(name.ends_with(".png"), "extension must survive: {name}");
+}
 
 /// base64url-encode a record URI the way the serve route expects it.
 fn encode_ref(uri: &str) -> String {

--- a/freeq-server/tests/media_space.rs
+++ b/freeq-server/tests/media_space.rs
@@ -369,6 +369,18 @@ async fn client_metadata_advertises_the_space_scope_only_when_enabled() {
         scope.split_whitespace().any(|t| t == expected),
         "feature-on metadata must advertise the space scope; got: {scope}"
     );
+    // The whole point of the metadata document is that a PDS refuses any
+    // scope it does not list. Every token the step-up will request must be
+    // in there, or the flow dies at the consent screen.
+    for token in freeq_server::server::OauthPurpose::MediaSpace
+        .requested_scope(Some(AUTHORITY_DID))
+        .split_whitespace()
+    {
+        assert!(
+            scope.split_whitespace().any(|t| t == token),
+            "metadata is missing `{token}`, which the media_space step-up requests; got: {scope}"
+        );
+    }
     fx.server.abort();
 
     let config = freeq_server::config::ServerConfig {
@@ -961,5 +973,206 @@ async fn check_user_access_rejects_bad_service_auth() {
     .await;
     assert_eq!(s, 401, "expired token must be rejected");
 
+    fx.server.abort();
+}
+
+/// Mint a service-auth JWT with a chosen `alg` header, so the algorithm
+/// check can be exercised independently of the signature.
+fn service_jwt_with_alg(
+    key: &PrivateKey,
+    alg: &str,
+    aud: &str,
+    lxm: &str,
+    exp_offset_secs: i64,
+) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let header = b64(serde_json::json!({ "typ": "JWT", "alg": alg }).to_string().as_bytes());
+    let payload = b64(serde_json::json!({
+        "iss": AUTHORITY_DID,
+        "aud": aud,
+        "lxm": lxm,
+        "exp": now + exp_offset_secs,
+    })
+    .to_string()
+    .as_bytes());
+    let signing_input = format!("{header}.{payload}");
+    let sig = key.sign(signing_input.as_bytes());
+    format!("{signing_input}.{}", b64(&sig))
+}
+
+/// `alg: none` is the classic JWT bypass, and an HMAC alg invites key
+/// confusion. Both are refused before a key is ever consulted, even when the
+/// rest of the token is otherwise perfect.
+#[tokio::test]
+async fn service_auth_rejects_algorithms_we_do_not_verify() {
+    let fx = fixture_with_ids(&[]).await;
+    let space = format!("at://{AUTHORITY_DID}/space/at.freeq.media/somekey");
+    for alg in ["none", "HS256", "RS256", "ES256K "] {
+        let (s, _) = check_access(
+            fx.web,
+            Some(&service_jwt_with_alg(
+                &fx.authority_key,
+                alg,
+                &managing_app(),
+                LXM,
+                60,
+            )),
+            &space,
+            "did:plc:x",
+        )
+        .await;
+        assert_eq!(s, 401, "alg `{alg}` must not be accepted");
+    }
+    // The real algorithm still works, so the check is a filter and not a wall.
+    let (s, body) = check_access(
+        fx.web,
+        Some(&service_jwt_with_alg(
+            &fx.authority_key,
+            "ES256K",
+            &managing_app(),
+            LXM,
+            60,
+        )),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 200, "a properly signed ES256K token is still honoured");
+    assert_eq!(body["authorized"], false, "and the answer is a real answer");
+    fx.server.abort();
+}
+
+/// atproto mints service auth for a minute or two. A token claiming to be
+/// good for a day is either broken or an attempt to make a captured token
+/// durable; either way we do not honour it.
+#[tokio::test]
+async fn service_auth_rejects_an_implausibly_distant_expiry() {
+    let fx = fixture_with_ids(&[]).await;
+    let space = format!("at://{AUTHORITY_DID}/space/at.freeq.media/somekey");
+    let (s, _) = check_access(
+        fx.web,
+        Some(&service_jwt(&fx.authority_key, &managing_app(), LXM, 86_400)),
+        &space,
+        "did:plc:x",
+    )
+    .await;
+    assert_eq!(s, 401, "a day-long service auth token must be rejected");
+    fx.server.abort();
+}
+
+/// A file goes to exactly one destination. The space branch returns before
+/// the PDS-share path, so silently accepting both would drop the public copy
+/// the user asked for without telling them.
+#[tokio::test]
+async fn a_file_cannot_go_to_a_space_and_a_public_copy_at_once() {
+    let (fx, h, _bearer) = fixture_with_member().await;
+    for (field, value) in [("share_pds", "true"), ("share_bluesky", "true")] {
+        let form = reqwest::multipart::Form::new()
+            .text("did", MEMBER_DID.to_string())
+            .text("channel", "#open".to_string())
+            .text("space_media", "true".to_string())
+            .text(field, value.to_string())
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(b"not really a png".to_vec())
+                    .file_name("x.png")
+                    .mime_str("image/png")
+                    .unwrap(),
+            );
+        let r = reqwest::Client::new()
+            .post(format!("http://{}/api/v1/upload", fx.web))
+            .multipart(form)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+        let status = r.status().as_u16();
+        let body = r.text().await.unwrap_or_default();
+        assert_eq!(status, 400, "space + {field} must be refused: {body}");
+        assert!(
+            body.contains("not both"),
+            "the refusal must say why: {body}"
+        );
+    }
+    assert_eq!(fx.created.load(Ordering::SeqCst), 0, "nothing was created");
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+/// Space media sits unencrypted in the author's repo and is proxied in the
+/// clear through this server. That is precisely what `+E` exists to prevent,
+/// so the rule lives on the server and not only in the web client's UI.
+#[tokio::test]
+async fn encrypted_only_channels_refuse_space_media() {
+    let key = PrivateKey::generate_ed25519();
+    let fx = fixture_with_ids(&[(MEMBER_DID, &key)]).await;
+    let (h, _bearer) = join_as_member(&fx.irc, MEMBER_DID, &key, "member", "#vault").await;
+    h.mode("#vault", "+E", None).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let form = reqwest::multipart::Form::new()
+        .text("did", MEMBER_DID.to_string())
+        .text("channel", "#vault".to_string())
+        .text("space_media", "true".to_string())
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(b"not really a png".to_vec())
+                .file_name("x.png")
+                .mime_str("image/png")
+                .unwrap(),
+        );
+    let r = reqwest::Client::new()
+        .post(format!("http://{}/api/v1/upload", fx.web))
+        .multipart(form)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .unwrap();
+    let status = r.status().as_u16();
+    let body = r.text().await.unwrap_or_default();
+    assert_eq!(status, 403, "+E must refuse space media: {body}");
+    assert!(
+        body.contains("+E") || body.contains("Encrypted"),
+        "the refusal must name the reason: {body}"
+    );
+    assert_eq!(
+        fx.created.load(Ordering::SeqCst),
+        0,
+        "a refused upload must not mint a space"
+    );
+    h.quit(None).await.ok();
+    fx.server.abort();
+}
+
+/// A public channel's media URL carries no bearer, and every miss costs two
+/// round trips against the *uploader's* PDS plus up to 10 MB of their
+/// bandwidth. Without metering that URL is an amplifier pointed at a third
+/// party, so the route is behind the same IP limiter as the other expensive
+/// REST reads.
+#[tokio::test]
+async fn space_media_reads_are_rate_limited_per_ip() {
+    let fx = fixture_with_ids(&[]).await;
+    // Deliberately not one of ours: the ref check is cheap and comes after
+    // the limiter, so the only thing this measures is the limiter.
+    let path = format!(
+        "/api/v1/space-media/{}/x.png",
+        encode_ref("at://did:plc:someoneelse/space/at.freeq.media/K1/did:plc:a/c/3k")
+    );
+    let mut saw_limit = false;
+    for i in 0..40 {
+        let (status, _) = get(fx.web, &path).await;
+        if status == 429 {
+            saw_limit = true;
+            break;
+        }
+        assert_eq!(status, 400, "request {i} should be a plain refusal");
+    }
+    assert!(
+        saw_limit,
+        "an unauthenticated caller must eventually be rate limited"
+    );
     fx.server.abort();
 }

--- a/freeq-server/tests/oauth_scope.rs
+++ b/freeq-server/tests/oauth_scope.rs
@@ -232,6 +232,58 @@ fn media_space_needs_both_the_space_and_blob_halves() {
     ));
 }
 
+/// A PDS echoes a grant back in whatever shape it likes. Matching the space
+/// scope as a literal string turned a reordered query into an endless
+/// step-up loop; it is matched by parts instead.
+#[test]
+fn media_space_scope_survives_a_pds_reordering_the_parameters() {
+    for granted in [
+        "atproto blob:*/* space:*?authority=did:plc:a&collection=*",
+        "atproto blob:*/* space:*?collection=*&authority=did:plc:a",
+        // A grant narrowed to the exact type and collection we use is at
+        // least as strong as the wildcard we asked for.
+        "atproto blob:*/* space:at.freeq.media?authority=did:plc:a&collection=at.freeq.media.item",
+    ] {
+        assert!(
+            scope_satisfies_purpose(granted, OauthPurpose::MediaSpace, Some("did:plc:a")),
+            "should satisfy: {granted}"
+        );
+    }
+}
+
+/// A grant over someone else's spaces buys nothing here, and the authority
+/// is the one thing a wildcard must not stand in for.
+#[test]
+fn media_space_scope_must_name_our_own_authority() {
+    for granted in [
+        // Another server's authority.
+        "atproto blob:*/* space:*?authority=did:plc:someoneelse&collection=*",
+        // A wildcard authority is not the same as ours.
+        "atproto blob:*/* space:*?authority=*&collection=*",
+        // No authority at all.
+        "atproto blob:*/* space:*?collection=*",
+        // A space type we do not use.
+        "atproto blob:*/* space:com.example.other?authority=did:plc:a&collection=*",
+        // A collection in someone else's namespace.
+        "atproto blob:*/* space:*?authority=did:plc:a&collection=com.example.other",
+        // Not a space scope at all.
+        "atproto blob:*/* spaceship:*?authority=did:plc:a&collection=*",
+        // No query, so nothing is named.
+        "atproto blob:*/* space:*",
+    ] {
+        assert!(
+            !scope_satisfies_purpose(granted, OauthPurpose::MediaSpace, Some("did:plc:a")),
+            "must not satisfy: {granted}"
+        );
+    }
+    // And with no authority configured, nothing satisfies the purpose.
+    assert!(!scope_satisfies_purpose(
+        "atproto blob:*/* space:*?authority=did:plc:a&collection=*",
+        OauthPurpose::MediaSpace,
+        None
+    ));
+}
+
 #[test]
 fn requested_scopes_are_narrow_not_transition_generic() {
     for p in [
@@ -441,6 +493,10 @@ async fn metadata_scope_contains_every_requested_purpose_scope() {
         OauthPurpose::Login,
         OauthPurpose::BlobUpload,
         OauthPurpose::BlueskyPost,
+        // MediaSpace is only advertised when the feature is configured; the
+        // media_space integration suite covers that case against a server
+        // that has it on. Here the fixture has it off, so the purpose is
+        // checked against the same metadata with no authority.
     ] {
         for token in p.requested_scope(None).split_whitespace() {
             assert!(

--- a/freeq-server/tests/oauth_scope.rs
+++ b/freeq-server/tests/oauth_scope.rs
@@ -193,6 +193,27 @@ fn purpose_round_trips_through_string() {
     assert_eq!(OauthPurpose::parse("nonsense"), None);
 }
 
+/// An upload is two PDS calls, uploadBlob then createRecord, so it takes the
+/// blob scope and the space scope together. Holding one without the other is
+/// insufficient, and the client re-prompts.
+#[test]
+fn media_space_needs_both_the_space_and_blob_halves() {
+    let full = "atproto blob:*/* space:*?authority=did:plc:a&collection=*";
+    assert!(scope_satisfies_purpose(full, OauthPurpose::MediaSpace));
+
+    let space_only = "atproto space:*?authority=did:plc:a&collection=*";
+    assert!(
+        !scope_satisfies_purpose(space_only, OauthPurpose::MediaSpace),
+        "a space grant without blob access cannot upload"
+    );
+
+    let blob_only = "atproto blob:*/*";
+    assert!(!scope_satisfies_purpose(
+        blob_only,
+        OauthPurpose::MediaSpace
+    ));
+}
+
 #[test]
 fn requested_scopes_are_narrow_not_transition_generic() {
     for p in [

--- a/freeq-server/tests/oauth_scope.rs
+++ b/freeq-server/tests/oauth_scope.rs
@@ -199,8 +199,9 @@ fn requested_scopes_are_narrow_not_transition_generic() {
         OauthPurpose::Login,
         OauthPurpose::BlobUpload,
         OauthPurpose::BlueskyPost,
+        OauthPurpose::MediaSpace,
     ] {
-        let s = p.requested_scope();
+        let s = p.requested_scope(Some("did:plc:testauthority"));
         assert!(
             !s.contains("transition:generic"),
             "purpose {:?} requests legacy scope: {s}",
@@ -387,7 +388,7 @@ async fn metadata_scope_contains_every_requested_purpose_scope() {
         OauthPurpose::BlobUpload,
         OauthPurpose::BlueskyPost,
     ] {
-        for token in p.requested_scope().split_whitespace() {
+        for token in p.requested_scope(None).split_whitespace() {
             assert!(
                 metadata_scope.contains(token),
                 "client-metadata.json scope ({:?}) is missing token `{token}` requested by purpose {:?}; \

--- a/freeq-server/tests/oauth_scope.rs
+++ b/freeq-server/tests/oauth_scope.rs
@@ -122,10 +122,15 @@ async fn step_up_refuses_login_purpose() {
 
 #[test]
 fn scope_satisfies_login_with_granular_grant() {
-    assert!(scope_satisfies_purpose("atproto", OauthPurpose::Login));
+    assert!(scope_satisfies_purpose(
+        "atproto",
+        OauthPurpose::Login,
+        None
+    ));
     assert!(scope_satisfies_purpose(
         "atproto blob:image/*",
-        OauthPurpose::Login
+        OauthPurpose::Login,
+        None
     ));
 }
 
@@ -135,22 +140,26 @@ fn scope_satisfies_blob_upload_with_granular_grant() {
     // grant — the upload path creates a record alongside the blob.
     assert!(scope_satisfies_purpose(
         "atproto blob:image/* repo:blue.irc.media?action=create",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "atproto blob:*/* repo:blue.irc.media?action=create",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
     // Identity-only grant must NOT be enough for upload.
     assert!(!scope_satisfies_purpose(
         "atproto",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
     // Blob grant alone (no record) must NOT be enough — record creation
     // would fail at the PDS.
     assert!(!scope_satisfies_purpose(
         "atproto blob:image/*",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
 }
 
@@ -160,11 +169,13 @@ fn scope_satisfies_legacy_transition_generic_for_anything() {
     // Treat that as satisfying any purpose for backward compatibility.
     assert!(scope_satisfies_purpose(
         "atproto transition:generic",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "atproto transition:generic",
-        OauthPurpose::BlueskyPost
+        OauthPurpose::BlueskyPost,
+        None
     ));
 }
 
@@ -172,11 +183,13 @@ fn scope_satisfies_legacy_transition_generic_for_anything() {
 fn scope_does_not_satisfy_bluesky_post_with_blob_only() {
     assert!(!scope_satisfies_purpose(
         "atproto blob:image/*",
-        OauthPurpose::BlueskyPost
+        OauthPurpose::BlueskyPost,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "atproto repo:app.bsky.feed.post",
-        OauthPurpose::BlueskyPost
+        OauthPurpose::BlueskyPost,
+        None
     ));
 }
 
@@ -199,18 +212,23 @@ fn purpose_round_trips_through_string() {
 #[test]
 fn media_space_needs_both_the_space_and_blob_halves() {
     let full = "atproto blob:*/* space:*?authority=did:plc:a&collection=*";
-    assert!(scope_satisfies_purpose(full, OauthPurpose::MediaSpace));
+    assert!(scope_satisfies_purpose(
+        full,
+        OauthPurpose::MediaSpace,
+        Some("did:plc:a")
+    ));
 
     let space_only = "atproto space:*?authority=did:plc:a&collection=*";
     assert!(
-        !scope_satisfies_purpose(space_only, OauthPurpose::MediaSpace),
+        !scope_satisfies_purpose(space_only, OauthPurpose::MediaSpace, Some("did:plc:a")),
         "a space grant without blob access cannot upload"
     );
 
     let blob_only = "atproto blob:*/*";
     assert!(!scope_satisfies_purpose(
         blob_only,
-        OauthPurpose::MediaSpace
+        OauthPurpose::MediaSpace,
+        Some("did:plc:a")
     ));
 }
 
@@ -245,14 +263,17 @@ fn scope_predicate_handles_extra_whitespace() {
     assert!(scope_satisfies_purpose(
         "atproto    blob:image/*    repo:blue.irc.media?action=create",
         OauthPurpose::BlobUpload,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "atproto\tblob:image/*\trepo:blue.irc.media?action=create",
         OauthPurpose::BlobUpload,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "\n  atproto  \n",
-        OauthPurpose::Login
+        OauthPurpose::Login,
+        None
     ));
 }
 
@@ -261,27 +282,35 @@ fn scope_predicate_is_case_sensitive_per_spec() {
     // OAuth scope strings are case-sensitive. ATPROTO (uppercase) is not
     // a valid scope; predicate must reject so we don't wrongly accept a
     // typo or a confused PDS.
-    assert!(!scope_satisfies_purpose("ATPROTO", OauthPurpose::Login));
+    assert!(!scope_satisfies_purpose(
+        "ATPROTO",
+        OauthPurpose::Login,
+        None
+    ));
     assert!(!scope_satisfies_purpose(
         "atproto BLOB:image/*",
         OauthPurpose::BlobUpload,
+        None
     ));
 }
 
 #[test]
 fn scope_predicate_rejects_empty_or_unrelated() {
-    assert!(!scope_satisfies_purpose("", OauthPurpose::Login));
+    assert!(!scope_satisfies_purpose("", OauthPurpose::Login, None));
     assert!(!scope_satisfies_purpose(
         "openid email",
-        OauthPurpose::Login
+        OauthPurpose::Login,
+        None
     ));
     assert!(!scope_satisfies_purpose(
         "atproto",
-        OauthPurpose::BlobUpload
+        OauthPurpose::BlobUpload,
+        None
     ));
     assert!(!scope_satisfies_purpose(
         "atproto blob:audio/*",
         OauthPurpose::BlobUpload,
+        None
     ));
 }
 
@@ -296,10 +325,12 @@ fn scope_predicate_accepts_blob_image_subtype_grant() {
     assert!(scope_satisfies_purpose(
         "atproto blob:image/png repo:blue.irc.media?action=create",
         OauthPurpose::BlobUpload,
+        None
     ));
     assert!(scope_satisfies_purpose(
         "atproto blob:image/jpeg repo:blue.irc.media?action=create",
         OauthPurpose::BlobUpload,
+        None
     ));
 }
 
@@ -310,6 +341,7 @@ fn scope_predicate_treats_repo_wildcard_as_satisfying_post() {
     assert!(scope_satisfies_purpose(
         "atproto repo:*",
         OauthPurpose::BlueskyPost,
+        None
     ));
 }
 
@@ -326,7 +358,7 @@ fn legacy_transition_generic_satisfies_all_purposes_for_grace_period() {
         OauthPurpose::BlueskyPost,
     ] {
         assert!(
-            scope_satisfies_purpose("atproto transition:generic", p),
+            scope_satisfies_purpose("atproto transition:generic", p, None),
             "legacy wide grant should satisfy {:?}",
             p
         );
@@ -336,6 +368,7 @@ fn legacy_transition_generic_satisfies_all_purposes_for_grace_period() {
     assert!(scope_satisfies_purpose(
         "transition:generic",
         OauthPurpose::BlobUpload,
+        None
     ));
 }
 

--- a/freeq-server/tests/protocol_ctf.rs
+++ b/freeq-server/tests/protocol_ctf.rs
@@ -313,6 +313,7 @@ async fn ctf_21_plus_e_channel_rejects_plaintext_with_encrypted_tag() {
                 encrypted_only: true,
                 key: None,
                 pins: vec![],
+                media_space_key: None,
             },
         );
     }

--- a/server.toml.example
+++ b/server.toml.example
@@ -88,6 +88,14 @@
 # github_client_secret = "..."
 # broker_shared_secret = "..."
 
+## ── Private media space ────────────────────────────────────────────
+## Leave this unset to keep the private media feature off.
+## The DID is an account on a spaces-capable PDS.
+# media_space_did = "did:plc:..."
+# media_space_password = "..."
+## Optional. Default is resolved from the authority DID's document.
+# media_space_pds = "https://pds.example.com"
+
 ## ── MOTD ───────────────────────────────────────────────────────────
 # motd = "welcome"
 # motd_file = "/etc/freeq/motd.txt"

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -653,6 +653,7 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "507": { description: This server already holds its maximum number of media spaces. }
   /api/v1/space-media/{ref}/{filename}:
     get:
       tags: [media]
@@ -683,6 +684,7 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "429": { description: Rate limit exceeded. }
   /api/v1/media/{id}/{sig}/{filename}:
     get:
       tags: [media]
@@ -1717,6 +1719,11 @@ components:
         av:
           type: boolean
           description: AV built in (`--features av-native`) *and* SFU up.
+        media_spaces:
+          type: boolean
+          description: >-
+            Private media via AT Protocol spaces is configured. Clients use
+            this to decide whether to offer the per-upload option at all.
     ChannelInfo:
       type: object
       required: [name, members]

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -629,6 +629,60 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "413": { description: Body too large. }
+  /api/v1/media-space:
+    get:
+      tags: [media]
+      operationId: getMediaSpace
+      summary: The AT Protocol space backing a channel's private media.
+      description: |
+        Creates the space on first use, so only members may ask. Answers 404
+        unless the server is configured with a media space authority.
+      parameters:
+        - name: channel
+          in: query
+          required: true
+          schema: { type: string }
+      security: [bearerAuth: []]
+      responses:
+        "200":
+          description: The channel's space ref and space type.
+          content:
+            application/json:
+              schema:
+                type: object
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/space-media/{ref}/{filename}:
+    get:
+      tags: [media]
+      operationId: getSpaceMedia
+      summary: Fetch private media held in a member's own repo.
+      description: |
+        `ref` is the record's `at://` URI, base64url-encoded. The server
+        fetches from the uploader's PDS on behalf of a caller who holds the
+        channel; `filename` is cosmetic so clients see the right extension.
+      parameters:
+        - name: ref
+          in: path
+          required: true
+          schema: { type: string }
+        - name: filename
+          in: path
+          required: true
+          schema: { type: string }
+      security: [bearerAuth: []]
+      responses:
+        "200":
+          description: Blob bytes.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/media/{id}/{sig}/{filename}:
     get:
       tags: [media]


### PR DESCRIPTION
This PR adds support for the [atproto spaces](https://atproto.com/blog/atproto-spaces-alpha) alpha. 

It extends the existing PDS upload functionality to give the user an option to upload their media into their spaces-enabled PDS. Media is available to all members who can access the channel, so if a media link is shared outside of freeq in a public channel anyone can view it. If the channel is +k, +i, or +E, then it's restricted to only authenticated users in that channel. Users with a PDS that doesn't support spaces can still view the media, guests cannot.

To enable the feature you'll need a spaces-capable PDS for freeq to use with a DID dedicated to freeq media that will own the space, then add the following to your docker compose environment:
```
FREEQ_MEDIA_SPACE_DID=${FREEQ_MEDIA_SPACE_DID:-}
FREEQ_MEDIA_SPACE_PASSWORD=${FREEQ_MEDIA_SPACE_PASSWORD:-}
```

The space type is at.freeq.media, which would ultimately need a _lexicon.freeq.at TXT record and a published schema to resolve. Could also add a config value for it so that self-hosters don't necessarily need to depend on freeq.at at all.

The upload screen with the private upload option:
<img width="435" height="159" alt="Screenshot 2026-08-28 at 17 10 08" src="https://github.com/user-attachments/assets/637519bd-0b29-4bb6-9358-0ac03897bf77" />

When a guest can't view media in a protected channel:
<img width="462" height="72" alt="Screenshot 2026-08-28 at 17 18 10" src="https://github.com/user-attachments/assets/8a7c829b-df8f-4bac-9de5-ec2a83525fb5" />

## Notes:
 - Deleting a message doesn't delete it from the repo
 - DMs aren't supported
 - There's no refresh token kept, so the PDS grant will need to be re-requested after an hour or so.
