### PR TITLE
freeq-pi: handoffs that survive a distracted agent

### DIFF
--- a/freeq-bot-kit-js/package-lock.json
+++ b/freeq-bot-kit-js/package-lock.json
@@ -32,14 +32,15 @@
         "idb": "^8.0.3"
       },
       "devDependencies": {
+        "fake-indexeddb": "^6.2.5",
         "typescript": "~5.9.3",
         "vitest": "^4.1.2"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -750,6 +751,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/freeq-pi/README.md
+++ b/freeq-pi/README.md
@@ -67,6 +67,15 @@ Other actions: `peers`, `send`, `say`. See `skills/freeq/SKILL.md`.
 | `/freeq trust <did> <tier>` | grant a peer authority (confirmation required) |
 | `/freeq mute` / `/freeq unmute` | stay connected but say nothing anywhere |
 | `/freeq on` / `/freeq off` | master switch (disconnects) |
+| `/freeq tasks` | what's assigned to you, queued, offered, or open nearby — with ages |
+| `/freeq resume [id]` | re-enter assigned work; no id means everything, capped |
+| `/freeq accept <id>` | take a queued or offered task now |
+| `/freeq decline <id> [reason]` | turn one down, with a reason |
+| `/freeq drop <id> [reason]` | fail work in flight honestly instead of leaving it hanging |
+| `/freeq progress <id> <note>` | report progress by hand |
+
+Ids may be given as the short prefix the notifications print. An ambiguous
+prefix is refused by name rather than guessed.
 
 ## Security model
 
@@ -86,7 +95,7 @@ Every inbound event is classified by the sender's **server-resolved** DID
 | `observe` | visible in your TUI; **never enters model context** | everyone unknown, and all guests |
 | `message` | may be injected as clearly-marked untrusted content | — |
 | `request` | may trigger a turn — i.e. can `ask` you things | — |
-| `handoff` | may offer durable work (not yet implemented) | — |
+| `handoff` | may offer durable work, which an idle session takes on | — |
 | `control` | configuration | you, the owner |
 
 Nothing is granted implicitly. `/freeq trust` requires confirmation, and
@@ -107,7 +116,7 @@ engages when spoken to or handed work), `silent`, `participant`.
 ## Development
 
 ```bash
-npm install && npm test          # 90 unit tests
+npm install && npm test          # 254 unit tests
 npm run verify                   # tests + 3 live harnesses (needs a local server)
 npm run build
 
@@ -155,7 +164,8 @@ participation with humans, and outbound redaction.
 
 **Handoffs work**: durable, signed delegation that survives the recipient
 being offline. Offer work to a peer's DID; if their agent is asleep the offer
-waits and is replayed when they reconnect; their human approves; the signed
+waits and is replayed when they reconnect; an idle session takes it on and a
+busy one queues it; the signed
 `offer → accept → complete` chain lands in the channel as an audit trail.
 This is the capability same-filesystem multiplayer extensions cannot provide.
 
@@ -168,5 +178,40 @@ This is the capability same-filesystem multiplayer extensions cannot provide.
 Lifecycle rules are not reimplemented here: legality and authority come from
 `@freeq/bot-kit`'s transition table, so a third party cannot accept work
 offered to someone else, and only the assignee can complete it.
+
+## Handoffs that survive a distracted agent
+
+Three ways delegation used to die quietly, and the two defaults that end them.
+
+**An offer is auto-accepted when the session is idle and the offerer is
+trusted** at `handoff` or above. Otherwise it goes in a queue that outlives
+the session, and you get one notification naming the id. It is never a
+blocking modal: nobody at the terminal, or a restart while the dialog is
+open, and the offer was simply gone. The queue drains when the session next
+goes idle, and an offer that has waited past `offerTtlSecs` is declined with
+a reason — an offerer who is told can re-offer elsewhere, which is strictly
+better than silence. Untrusted offerers are still ignored entirely.
+
+**Stalled work auto-fails with a reason**, rather than hanging. An accepted
+task heartbeats a `progress` event every `progressIntervalSecs` so the
+offerer can see it is alive, and no model activity for `stallSecs` emits
+`fail` naming the stall. A shutdown notes that the session is going down and
+fails nothing — a restart may pick the work back up, and a false failure in a
+signed, permanent log is worse than a gap in it.
+
+**A restart asks the server what is still ours.** On every connect, including
+a reconnect, `/api/v1/actions?assignee=…&state=assigned` is the authority: a
+task it still lists is re-entered through the same path live work uses, and a
+local record it does not list is reported rather than trusted. Capped at
+`maxResume`, oldest first, and it says plainly when more were left.
+
+```json
+{ "autoAcceptWhenIdle": true, "offerTtlSecs": 1800,
+  "progressIntervalSecs": 120, "stallSecs": 900, "maxResume": 3 }
+```
+
+All five are optional in `freeq.json`; a config written before they existed
+keeps working untouched. `autoAccept` is still the stronger, per-DID form —
+it accepts even mid-turn.
 
 To demo or test this, read `DEMO.md`.

--- a/freeq-pi/RESILIENCE-PLAN.md
+++ b/freeq-pi/RESILIENCE-PLAN.md
@@ -1,0 +1,137 @@
+# Making handoffs survive a distracted agent
+
+Brief for an agent run, in `~/src/freeq/freeq-pi`.
+
+Three failures, reported from real use: an agent misses an offer the first
+time and never revisits it; an agent accepts and then hangs forever; and a
+restarted agent has no idea what it was doing. None of them is a model being
+dumb — all three are missing mechanism. Read `src/handoff.ts` (the local
+materialized view and its doc comment), `extensions/freeq.ts`
+(`onHandoffEvent`, `startAssignedWork`, the `/freeq` command switch), and
+`src/connection.ts` (`sendAct`, `onActEvent`) before writing anything.
+
+House rules: match the existing comment voice — say *why*, plain sentences,
+no changelog bullets. Every behaviour that can refuse or give up says so in
+one clear sentence naming the reason. Tests are vitest, colocated as
+`*.test.ts`; the suite is 224 green and must stay green. The lifecycle table
+in `@freeq/bot-kit` is the authority on legal verbs — never restate it.
+
+Owner's two decisions, already made — implement exactly these defaults:
+
+- **An offer is auto-accepted when the session is idle and the offerer is
+  trusted.** Otherwise it queues rather than blocking.
+- **Stalled work auto-fails with a reason**, rather than hanging.
+
+## 1. Intake that cannot drop an offer
+
+Today an inbound offer addressed to us goes straight to `ctx.ui.confirm(...)`
+— a blocking modal. Nobody at the terminal, or a restart while it is open,
+and the offer is gone: the task sits `offered` forever and nothing revisits
+it. Replay does not help; the event arrived, we simply dropped it.
+
+Replace with a queue plus a policy:
+
+- **Auto-accept** when `ctx.isIdle()` is true AND the offerer's tier is
+  `handoff` or above (`tierAtLeast`). The existing `cfg.autoAccept` list
+  stays as an explicit per-DID override that accepts even when busy.
+- **Otherwise queue it** — persisted alongside the handoff view so it
+  survives a restart — and notify once, naming the id and how to act on it
+  (`/freeq accept <id>`). Never a blocking modal; a modal is what loses work.
+- **Drain the queue when the session goes idle.** Poll `ctx.isIdle()` on a
+  modest timer (5 s is plenty); on the transition to idle, accept the oldest
+  queued offer from a trusted offerer.
+- **Offers expire.** A queued offer older than `offerTtlSecs` (default 30
+  min, configurable) is declined with a reason — an offerer learns quickly
+  and can re-offer elsewhere, which is strictly better than silence. Respect
+  the task's own `deadline` when it is sooner.
+- Untrusted offerers are still ignored entirely, exactly as now.
+
+## 2. A watchdog on accepted work
+
+`startAssignedWork()` sets a presence label, injects a prompt, and ends.
+Nothing tracks the work after that, so a wandering model leaves the task
+`assigned` until the server's expiry sweep days later.
+
+- Record `startedAt` and `lastProgressAt` per in-flight task.
+- **Heartbeat**: every `progressIntervalSecs` (default 120) while a task is
+  in flight, emit a `progress` act event with a short note. `progress` is
+  additive in the transition table, so this is free observability and the
+  offerer can see the work is alive.
+- **Stall**: no completion and no model activity for `stallSecs` (default 900)
+  → emit `fail` with a reason naming the stall
+  (`"no progress for 15m — the session stopped working on it"`), clear the
+  work label, and notify. This is the owner's chosen default; do not prompt.
+- **Clean shutdown**: on extension teardown, any in-flight task gets a
+  `progress` note saying the session is going down, so the record shows why
+  it stopped rather than simply going quiet. Do not `fail` on shutdown — a
+  restart may resume it (§3), and a false failure is worse than a gap.
+- All three timers must be cancelled on teardown and must never fire twice
+  for one task.
+
+## 3. Resume — pick up where it left off
+
+There is no resume path at all today. On start the view is loaded and
+nothing asks the server what is still ours.
+
+- On connect (and on reconnect), fetch
+  `GET /api/v1/actions?assignee=<self did>&state=assigned` from the server's
+  HTTP origin (`httpOriginFor(cfg.server)`, as `verifyActEvent` already
+  does), reconcile against the local view, and for anything still assigned to
+  us re-enter work through `startAssignedWork()` — the same path the live
+  route uses, so there is one way to start work, not two.
+- The server is the authority here; a local record the server does not list
+  is stale and must be reconciled, not trusted.
+- Announce the resume in one line per task, so it is visible rather than
+  spooky: `freeq: resuming <id> — <title>`.
+- Cap it: resume at most `maxResume` (default 3) tasks, oldest first, and say
+  plainly if more were skipped.
+
+## 4. Commands
+
+Add to the `/freeq` switch in `extensions/freeq.ts`, each with a usage line
+matching the existing style, and each listed in the help output:
+
+| Command | Does |
+|---|---|
+| `tasks` | what is assigned to me, what is queued/offered, what is open nearby — with ages |
+| `resume [id]` | re-enter assigned work; no id = everything, capped as above |
+| `accept <id>` | accept a queued or offered task now |
+| `decline <id>` | decline it with an optional reason |
+| `drop <id> [reason]` | `fail` an in-flight task honestly instead of leaving it hanging |
+| `progress <id> <note>` | manual heartbeat |
+
+Ids may be given as the short prefix the notifications print (first 10
+chars); resolve a unique prefix, and refuse an ambiguous one by name.
+
+## 5. Config
+
+New keys, all optional with the defaults above, parsed and validated in
+`src/config.ts` beside `autoAccept` (unknown keys must not break older
+configs, and older configs must keep working untouched):
+
+`autoAcceptWhenIdle` (bool, default true), `offerTtlSecs` (1800),
+`progressIntervalSecs` (120), `stallSecs` (900), `maxResume` (3).
+
+## Tests
+
+Extend the existing files rather than inventing new patterns; pure logic
+should be pure functions that can be tested without a live connection:
+
+- an offer arriving while busy queues rather than prompting, and is accepted
+  on the transition to idle
+- an offer from an untrusted DID is ignored, queued or not
+- a queued offer past its TTL is declined with a reason
+- a stalled task emits exactly one `fail`, with a reason, and never twice
+- the heartbeat emits `progress` while in flight and stops on completion
+- resume re-enters only tasks the SERVER still lists as assigned to us,
+  respects `maxResume`, and is idempotent across two calls
+- id-prefix resolution: unique prefix resolves, ambiguous prefix refuses by
+  name
+
+## Done means
+
+`npm run build` clean, `npx vitest run` green including the new tests, and a
+short note appended to `README.md` describing the new commands and the two
+defaults (auto-accept when idle and trusted; auto-fail on stall). Commit in
+small commits on a branch `pi-handoff-resilience`, in the house voice. Do not
+push.

--- a/freeq-pi/extensions/freeq.ts
+++ b/freeq-pi/extensions/freeq.ts
@@ -32,11 +32,21 @@ import { deriveInstallSlug, defaultNick, isDid } from "../src/identity.js";
 import { collectSessionMeta, describeMeta } from "../src/presence.js";
 import { FreeqConnection, type InboundAsk } from "../src/connection.js";
 import { ConnectionLock } from "../src/lock.js";
+import { isTerminal } from "@freeq/bot-kit";
 import {
   HandoffStore,
+  OfferQueue,
+  WorkWatchdog,
   hashBrief,
   describeHandoff,
   noteVerification,
+  decideOffer,
+  sweepOfferQueue,
+  planResume,
+  fetchAssignedTasks,
+  resolveTaskRef,
+  formatAge,
+  formatDuration,
   HANDOFF_KIND,
   type HandoffRecord,
 } from "../src/handoff.js";
@@ -151,6 +161,224 @@ export default function (pi: ExtensionAPI): void {
     await store.load();
     handoffs = store;
     return store;
+  }
+
+  // ── resilience ──────────────────────────────────────────────────────────
+  //
+  // Three things a distracted agent used to get wrong: it missed an offer and
+  // never went back to it, it accepted work and then hung, and a restart had
+  // no idea what it had been doing. See src/handoff.ts for the mechanisms;
+  // this is where they are driven.
+
+  /** Offers waiting for this session to be free. Survives a restart. */
+  let offers: OfferQueue | undefined;
+  /** Clocks on work we accepted. */
+  let watchdog: WorkWatchdog | undefined;
+  /**
+   * One interval drives both. Two would have to be torn down in the same two
+   * places anyway, and a single cancel is one thing to get right rather than
+   * three.
+   */
+  let maintenanceTimer: NodeJS.Timeout | undefined;
+  const MAINTENANCE_MS = 5_000;
+  /**
+   * Armed on the transition to idle and disarmed by taking an offer, so a
+   * session that is still settling cannot be handed two tasks in ten seconds.
+   */
+  let idleAcceptArmed = true;
+  /** Tasks this session has already re-entered — resume must be idempotent. */
+  const resumed = new Set<string>();
+
+  async function ensureOffers(): Promise<OfferQueue> {
+    if (offers) return offers;
+    const q = new OfferQueue(OfferQueue.pathFor(agentDir));
+    await q.load();
+    offers = q;
+    return q;
+  }
+
+  function ensureWatchdog(cfg: FreeqConfig): WorkWatchdog {
+    watchdog ??= new WorkWatchdog({
+      progressIntervalSecs: cfg.progressIntervalSecs,
+      stallSecs: cfg.stallSecs,
+    });
+    return watchdog;
+  }
+
+  function startMaintenance(ctx: ExtensionContext, cfg: FreeqConfig): void {
+    if (maintenanceTimer) return;
+    maintenanceTimer = setInterval(() => {
+      void maintain(ctx, cfg);
+    }, MAINTENANCE_MS);
+    maintenanceTimer.unref?.();
+  }
+
+  function stopMaintenance(): void {
+    if (!maintenanceTimer) return;
+    clearInterval(maintenanceTimer);
+    maintenanceTimer = undefined;
+  }
+
+  /** One pass: drain what we can take, retire what waited too long, tick the clocks. */
+  async function maintain(ctx: ExtensionContext, cfg: FreeqConfig): Promise<void> {
+    if (!conn || conn.state !== "online") return;
+    const store = await ensureHandoffs();
+    const queue = await ensureOffers();
+
+    const idle = ctx.isIdle();
+    if (!idle) idleAcceptArmed = true;
+
+    const sweep = sweepOfferQueue({
+      entries: queue.all(),
+      lookup: (id) => store.get(id),
+      trusted: (did) => tierAtLeast(tierFor(cfg, did), "handoff"),
+      idle: idle && idleAcceptArmed,
+      now: Date.now(),
+      ttlSecs: cfg.offerTtlSecs,
+    });
+
+    for (const entry of sweep.drop) queue.remove(entry.taskId);
+    for (const { entry, record, reason } of sweep.expire) {
+      queue.remove(entry.taskId);
+      await declineOffer(ctx, record, reason);
+    }
+    if (sweep.accept) {
+      idleAcceptArmed = false;
+      queue.remove(sweep.accept.entry.taskId);
+      await acceptOffer(ctx, cfg, sweep.accept.record, sweep.accept.record.lastActor ?? "freeq");
+    }
+    await queue.save();
+
+    for (const action of ensureWatchdog(cfg).tick()) {
+      if (action.kind === "progress") {
+        await conn.sendAct(action.task.channel, "progress", action.task.taskId, {
+          note: action.note,
+        });
+        continue;
+      }
+      await conn.sendAct(action.task.channel, "fail", action.task.taskId, {
+        note: action.reason,
+      });
+      if (workTask === action.task.taskId) {
+        workLabel = undefined;
+        workTask = undefined;
+        pushStatus("active", undefined, undefined, true);
+      }
+      notify(
+        ctx,
+        `freeq: gave up on ${action.task.taskId.slice(0, 10)} — ${action.reason}. ` +
+          `The offerer has been told.`,
+        "warning",
+      );
+    }
+  }
+
+  /** Accept an offer and start the work. The one place either happens. */
+  async function acceptOffer(
+    ctx: ExtensionContext,
+    cfg: FreeqConfig,
+    rec: HandoffRecord,
+    fromNick: string,
+  ): Promise<void> {
+    const sent = await conn?.sendAct(rec.channel, "accept", rec.id, {});
+    if (!sent) {
+      // Put it back: an accept we could not send is not an acceptance, and
+      // the next sweep will try again or let the TTL retire it.
+      notify(ctx, `freeq: could not accept ${rec.id.slice(0, 10)} — will retry`, "warning");
+      const queue = await ensureOffers();
+      queue.add(rec.id);
+      await queue.save();
+      return;
+    }
+    notify(ctx, `freeq: accepted handoff ${rec.id.slice(0, 10)} — ${rec.title}`, "info");
+    startAssignedWork(ctx, cfg, rec, fromNick);
+  }
+
+  /** Decline an offer, always with a reason — silence teaches an offerer nothing. */
+  async function declineOffer(
+    ctx: ExtensionContext,
+    rec: HandoffRecord,
+    reason: string,
+  ): Promise<void> {
+    await conn?.sendAct(rec.channel, "decline", rec.id, { note: reason });
+    notify(ctx, `freeq: declined ${rec.id.slice(0, 10)} — ${reason}`, "info");
+  }
+
+  /**
+   * Ask the server what is still assigned to us, and take it back up.
+   *
+   * Called on every connect, including a reconnect after a dropped socket:
+   * the gap is exactly when work goes quiet without anybody deciding it
+   * should. `resumed` makes a second pass a no-op rather than a second start.
+   */
+  async function resumeAssigned(
+    ctx: ExtensionContext,
+    cfg: FreeqConfig,
+    only?: string,
+  ): Promise<string> {
+    const me = conn?.did;
+    if (!conn || conn.state !== "online" || !me) return "freeq: offline — cannot ask the server";
+
+    const answer = await fetchAssignedTasks({ origin: httpOriginFor(cfg.server), did: me });
+    if (!answer.ok) {
+      // An outage is not "nothing to resume", and reporting it that way is how
+      // a session quietly abandons work it still holds.
+      return `freeq: could not ask the server what is still yours — ${answer.reason}`;
+    }
+
+    const store = await ensureHandoffs();
+    // Work already in flight here is not work to resume. A reconnect on a
+    // flapping link would otherwise inject the same task's brief again on
+    // every recovery.
+    const running = new Set([...resumed, ...(watchdog?.inFlight().map((t) => t.taskId) ?? [])]);
+    const plan = planResume({
+      serverTasks: answer.tasks,
+      known: store.all(),
+      me,
+      // Filter to a named task AFTER planning, so the cap cannot decide the
+      // oldest task is the one you asked for.
+      max: only ? answer.tasks.length : cfg.maxResume,
+      already: running,
+    });
+
+    const wanted = only
+      ? plan.resume.filter((r) => r.id === only || r.id.startsWith(only))
+      : plan.resume;
+    if (only && !wanted.length) {
+      return running.has(only) || [...running].some((id) => id.startsWith(only))
+        ? `freeq: ${only} is already in flight here`
+        : `freeq: the server does not list ${only} as assigned to you`;
+    }
+
+    const lines: string[] = [];
+    for (const rec of wanted) {
+      resumed.add(rec.id);
+      if (!store.get(rec.id)) store.put(rec);
+      lines.push(`freeq: resuming ${rec.id.slice(0, 10)} — ${rec.title}`);
+      notify(ctx, `freeq: resuming ${rec.id.slice(0, 10)} — ${rec.title}`, "info");
+      // Say so on the wire too: the offerer watched this go quiet, and a
+      // progress note is how they learn it did not stay that way.
+      await conn.sendAct(rec.channel, "progress", rec.id, {
+        note: "resumed after the assignee's session restarted",
+      });
+      startAssignedWork(ctx, cfg, rec, rec.lastActor ?? "freeq");
+    }
+    await store.save();
+
+    if (!only && plan.skipped > 0) {
+      lines.push(
+        `freeq: ${plan.skipped} more still assigned to you, not started ` +
+          `(cap is maxResume=${cfg.maxResume}) — /freeq resume <id> to take one`,
+      );
+    }
+    for (const rec of plan.stale) {
+      lines.push(
+        `freeq: ${rec.id.slice(0, 10)} is not in the server's list of your assigned work ` +
+          `— not resuming it`,
+      );
+    }
+    if (!lines.length) return "freeq: nothing to resume";
+    return lines.join("\n");
   }
 
   const notify = (
@@ -384,6 +612,16 @@ export default function (pi: ExtensionAPI): void {
         })();
       },
 
+      // Every connect, including a reconnect after a dropped socket — the gap
+      // is exactly when accepted work goes quiet without anybody deciding it
+      // should.
+      onOnline: () => {
+        void (async () => {
+          const message = await resumeAssigned(ctx, cfg);
+          if (message !== "freeq: nothing to resume") notify(ctx, message, "info");
+        })();
+      },
+
       onAsk: (ask) => {
         deliver(
           ctx,
@@ -406,6 +644,7 @@ export default function (pi: ExtensionAPI): void {
     });
 
     await conn.start();
+    startMaintenance(ctx, cfg);
     return `freeq: ${conn.describe()}`;
   }
 
@@ -421,6 +660,7 @@ export default function (pi: ExtensionAPI): void {
     // server replays channel history on join, so offers made overnight land
     // as replayed act events; anything still open is reported once here.
     const store = await ensureHandoffs();
+    await ensureOffers();
     setTimeout(() => {
       const me = conn?.did;
       const waiting = store.inboxFor(me);
@@ -429,7 +669,7 @@ export default function (pi: ExtensionAPI): void {
           ctx,
           `freeq: ${waiting.length} handoff(s) waiting for you:\n` +
             waiting.map((r) => `  ${describeHandoff(r, me)}`).join("\n") +
-            `\nUse the freeq tool (action 'handoffs') to review.`,
+            `\n/freeq tasks to review, /freeq accept <id> to take one.`,
           "warning",
         );
       }
@@ -437,6 +677,18 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", async () => {
+    stopMaintenance();
+    // Say why the work stopped rather than letting it simply go quiet. NOT a
+    // failure: a restart may pick it straight back up (see resumeAssigned),
+    // and a false failure in a signed, permanent log is worse than a gap.
+    for (const action of watchdog?.shutdown() ?? []) {
+      if (action.kind !== "progress") continue;
+      await conn?.sendAct(action.task.channel, "progress", action.task.taskId, {
+        note: action.note,
+      });
+    }
+    await offers?.save();
+    await handoffs?.save();
     await conn?.stop("pi session ended");
     conn = undefined;
     if (lockTimer) {
@@ -449,13 +701,19 @@ export default function (pi: ExtensionAPI): void {
   });
 
   // Report "working" for the whole run, and go quiet again when it settles.
+  // A run also counts as life, which is what the stall timeout measures.
   pi.on("agent_start", async () => {
+    watchdog?.touch();
     pushStatus("executing", workLabel ?? "working", workTask, true);
   });
 
   // Name the current tool so a watcher sees movement, not just a spinner,
   // and note anything that counts as a consequence for the log.
   pi.on("tool_call", async (event) => {
+    // A tool call is the model doing something, which is exactly what the
+    // stall timer needs to hear about — otherwise long, quiet work looks
+    // stalled and gets failed out from under itself.
+    watchdog?.touch();
     const e = event as { toolName?: string; input?: Record<string, unknown> };
     if (!e.toolName) return;
     pushStatus("executing", workLabel ? `${workLabel} · ${e.toolName}` : e.toolName, workTask);
@@ -532,8 +790,9 @@ export default function (pi: ExtensionAPI): void {
    * What a pi session does when a handoff moves.
    *
    * The only branch with teeth is an inbound offer: accepting it means
-   * agreeing to do someone else's work, so it is HUMAN-GATED by default.
-   * Auto-accept must be opted into per-DID.
+   * agreeing to do someone else's work. The gate is the offerer's tier plus
+   * the owner's idle policy — never a modal, because a modal is what loses
+   * work when nobody is at the terminal.
    */
   async function onHandoffEvent(
     ctx: ExtensionContext,
@@ -544,10 +803,26 @@ export default function (pi: ExtensionAPI): void {
   ): Promise<void> {
     const me = conn?.did;
 
+    // Work of ours that ended, however it ended. Stop the clocks before
+    // anything else, so a completed task can never be failed for stalling.
+    if (rec.assignee === me && isTerminal(rec.kind, rec.state)) {
+      if (watchdog?.finish(rec.id) && workTask === rec.id) {
+        workLabel = undefined;
+        workTask = undefined;
+        pushStatus("active", undefined, undefined, true);
+      }
+      resumed.delete(rec.id);
+    }
+    // An offer we were holding has been answered by someone, somewhere.
+    if (!created && offers?.has(rec.id) && rec.state !== "offered") {
+      offers.remove(rec.id);
+      await offers.save();
+    }
+
     // We just became the assignee — by claiming an open task, or by our own
     // accept echoing back. Either way the work is now ours, so start it.
-    // (An accept we initiated via the confirm dialog already injected; guard
-    // on the verb so we do not do it twice.)
+    // (An accept we initiated already injected; guard on the verb so we do
+    // not do it twice.)
     if (!created && ev.verb === "claim" && rec.assignee === me) {
       startAssignedWork(ctx, cfg, rec, ev.from);
       return;
@@ -587,52 +862,56 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    const tier = tierFor(cfg, rec.offerer);
-    if (!tierAtLeast(tier, "handoff")) {
-      // Below handoff tier we do not even prompt — an unknown DID must not be
-      // able to raise a dialog in your terminal, let alone queue you work.
+    const decision = decideOffer({
+      tier: tierFor(cfg, rec.offerer),
+      idle: ctx.isIdle(),
+      autoAcceptDid: !!cfg.autoAccept?.includes(rec.offerer),
+      autoAcceptWhenIdle: cfg.autoAcceptWhenIdle,
+    });
+
+    if (decision.action === "ignore") {
+      // An unknown DID must not be able to raise a dialog in your terminal,
+      // queue you work, or cost you a notification you have to read.
       notify(
         ctx,
-        `freeq: ignoring handoff from ${rec.offerer} (tier '${tier}', needs 'handoff'). ` +
-          `/freeq handoffs to review, /freeq trust <did> handoff to allow.`,
+        `freeq: ignoring handoff from ${rec.offerer} — ${decision.reason}. ` +
+          `/freeq tasks to review, /freeq trust <did> handoff to allow.`,
         "warning",
       );
       return;
     }
 
-    const age = rec.fromReplay || ev.replayed ? " (offered while you were offline)" : "";
-    const auto = cfg.autoAccept?.includes(rec.offerer);
-
-    if (!auto) {
-      // Blocked on a human decision — say so, rather than looking idle or busy.
-      pushStatus("waiting_for_input", `handoff offer: ${rec.title}`.slice(0, 80), rec.id, true);
-      const ok = await ctx.ui.confirm(
-        "freeq: incoming handoff",
-        `${rec.title}${age}\n\n` +
-          `from:     ${rec.offerer}\n` +
-          `task:     ${rec.id}\n` +
-          `context:  ${rec.ctxHash ?? "(none)"}\n` +
-          `deadline: ${rec.deadline ? new Date(rec.deadline * 1000).toISOString() : "(none)"}\n\n` +
-          `Accepting means this session takes on the work.`,
-      );
-      if (!ok) {
-        await conn?.sendAct(rec.channel, "decline", rec.id, {}, undefined);
-        notify(ctx, `freeq: declined handoff ${rec.id.slice(0, 10)}`, "info");
-        return;
-      }
+    if (decision.action === "accept") {
+      await acceptOffer(ctx, cfg, rec, ev.from);
+      return;
     }
 
-    await conn?.sendAct(rec.channel, "accept", rec.id, {}, undefined);
-    notify(ctx, `freeq: accepted handoff ${rec.id.slice(0, 10)} — ${rec.title}`, "info");
-    startAssignedWork(ctx, cfg, rec, ev.from);
+    // Queued. Notify ONCE, naming the id and how to act on it — a queue
+    // nobody is told about is just a slower way of dropping the offer.
+    const queue = await ensureOffers();
+    const fresh = !queue.has(rec.id);
+    queue.add(rec.id);
+    await queue.save();
+    if (!fresh) return;
+
+    const age = rec.fromReplay || ev.replayed ? " (offered while you were offline)" : "";
+    notify(
+      ctx,
+      `freeq: handoff ${rec.id.slice(0, 10)} from ${rec.offerer} — ${rec.title}${age}\n` +
+        `  ${decision.reason}; it will be taken when this session is free, or ` +
+        `declined after ${formatDuration(cfg.offerTtlSecs)}.\n` +
+        `  /freeq accept ${rec.id.slice(0, 10)} · /freeq decline ${rec.id.slice(0, 10)}`,
+      "info",
+    );
   }
 
   /**
    * Begin work that is now assigned to this session.
    *
-   * Shared by the directed path (offer → confirm → accept) and the open path
-   * (post → claim), so both report presence identically and both enter the
-   * model through the same tier-gated pipeline.
+   * Shared by the directed path (offer → accept), the open path
+   * (post → claim), and a resume after a restart, so all three report
+   * presence identically, arm the same clocks, and enter the model through
+   * the same tier-gated pipeline. There is one way to start work, not three.
    */
   function startAssignedWork(
     ctx: ExtensionContext,
@@ -644,6 +923,11 @@ export default function (pi: ExtensionAPI): void {
     workLabel = `handoff: ${rec.title}`.slice(0, 80);
     workTask = rec.id;
     pushStatus("executing", workLabel, workTask, true);
+
+    // Start the clocks. Nothing tracked the work past this point before, so a
+    // model that wandered off left the task assigned until the server's
+    // expiry sweep noticed, days later.
+    ensureWatchdog(cfg).start({ taskId: rec.id, channel: rec.channel, title: rec.title });
 
     deliver(ctx, {
       kind: "chat",
@@ -1239,6 +1523,187 @@ export default function (pi: ExtensionAPI): void {
           return;
         }
 
+        case "tasks": {
+          const store = await ensureHandoffs();
+          const queue = await ensureOffers();
+          const me = conn?.did;
+          const now = Date.now();
+          const age = (r: HandoffRecord) => formatAge(now - r.updatedAt);
+
+          const mine = store
+            .all()
+            .filter((r) => r.assignee === me && !isTerminal(r.kind, r.state));
+          const queued = queue
+            .all()
+            .flatMap((e) => {
+              const rec = store.get(e.taskId);
+              return rec ? [{ rec, queuedAt: e.queuedAt }] : [];
+            });
+          const queuedIds = new Set(queued.map((q) => q.rec.id));
+          const waiting = store
+            .all()
+            .filter(
+              (r) => r.state === "offered" && r.offeree === me && !queuedIds.has(r.id),
+            );
+          const nearby = store.all().filter((r) => r.state === "open" && r.offerer !== me);
+
+          const sections = [
+            mine.length
+              ? `Assigned to you:\n` +
+                mine
+                  .map(
+                    (r) =>
+                      `  ${describeHandoff(r, me)}  ${age(r)}` +
+                      (watchdog?.has(r.id) ? "  [in flight]" : "  [not being worked on]"),
+                  )
+                  .join("\n")
+              : "",
+            queued.length
+              ? `Queued for when this session is free:\n` +
+                queued
+                  .map(
+                    (q) =>
+                      `  ${describeHandoff(q.rec, me)}  queued ${formatAge(now - q.queuedAt)}`,
+                  )
+                  .join("\n")
+              : "",
+            waiting.length
+              ? `Offered to you:\n` +
+                waiting.map((r) => `  ${describeHandoff(r, me)}  ${age(r)}`).join("\n")
+              : "",
+            nearby.length
+              ? `Open nearby (anyone may claim):\n` +
+                nearby
+                  .map(
+                    (r) =>
+                      `  ${describeHandoff(r, me)}  ${age(r)}` +
+                      (r.caps ? `  caps: ${r.caps}` : ""),
+                  )
+                  .join("\n")
+              : "",
+          ].filter(Boolean);
+
+          ctx.ui.notify(
+            sections.length
+              ? sections.join("\n\n")
+              : "freeq: nothing assigned, queued, offered, or open nearby",
+            "info",
+          );
+          return;
+        }
+
+        case "resume": {
+          ctx.ui.notify(await resumeAssigned(ctx, cfg, rest[0]), "info");
+          return;
+        }
+
+        case "accept":
+        case "decline": {
+          if (!rest[0]) {
+            ctx.ui.notify(
+              `usage: /freeq ${sub} <id>${sub === "decline" ? " [reason]" : ""}`,
+              "warning",
+            );
+            return;
+          }
+          const store = await ensureHandoffs();
+          const found = resolveTaskRef(store.all(), rest[0]);
+          if (!found.ok) {
+            ctx.ui.notify(`freeq: ${found.reason}`, "warning");
+            return;
+          }
+          const rec = found.record;
+          if (rec.state !== "offered") {
+            ctx.ui.notify(
+              `freeq: ${rec.id.slice(0, 10)} is '${rec.state}', not an open offer`,
+              "warning",
+            );
+            return;
+          }
+          const queue = await ensureOffers();
+          queue.remove(rec.id);
+          await queue.save();
+          // No tier check on either: the owner typed this, and the trust map
+          // exists to decide what happens WITHOUT them, not to overrule them.
+          if (sub === "accept") {
+            await acceptOffer(ctx, cfg, rec, rec.lastActor ?? "freeq");
+          } else {
+            await declineOffer(ctx, rec, rest.slice(1).join(" ") || "declined by the operator");
+          }
+          return;
+        }
+
+        case "drop": {
+          if (!rest[0]) {
+            ctx.ui.notify("usage: /freeq drop <id> [reason]", "warning");
+            return;
+          }
+          const store = await ensureHandoffs();
+          const found = resolveTaskRef(store.all(), rest[0]);
+          if (!found.ok) {
+            ctx.ui.notify(`freeq: ${found.reason}`, "warning");
+            return;
+          }
+          const rec = found.record;
+          if (rec.assignee !== conn?.did || rec.state !== "assigned") {
+            ctx.ui.notify(
+              `freeq: ${rec.id.slice(0, 10)} is not work in flight here ` +
+                `(state '${rec.state}') — nothing to drop`,
+              "warning",
+            );
+            return;
+          }
+          const reason = rest.slice(1).join(" ") || "dropped by the operator";
+          watchdog?.finish(rec.id);
+          resumed.delete(rec.id);
+          const ok = await conn?.sendAct(rec.channel, "fail", rec.id, { note: reason });
+          if (workTask === rec.id) {
+            workLabel = undefined;
+            workTask = undefined;
+            pushStatus("active", undefined, undefined, true);
+          }
+          ctx.ui.notify(
+            ok
+              ? `freeq: dropped ${rec.id.slice(0, 10)} — ${reason}. The offerer has been told.`
+              : `freeq: could not send the failure for ${rec.id.slice(0, 10)}`,
+            ok ? "info" : "warning",
+          );
+          return;
+        }
+
+        case "progress": {
+          const note = rest.slice(1).join(" ");
+          if (!rest[0] || !note) {
+            ctx.ui.notify("usage: /freeq progress <id> <note>", "warning");
+            return;
+          }
+          const store = await ensureHandoffs();
+          const found = resolveTaskRef(store.all(), rest[0]);
+          if (!found.ok) {
+            ctx.ui.notify(`freeq: ${found.reason}`, "warning");
+            return;
+          }
+          const rec = found.record;
+          if (rec.assignee !== conn?.did || rec.state !== "assigned") {
+            ctx.ui.notify(
+              `freeq: only the assignee of work in flight can report progress on it ` +
+                `(${rec.id.slice(0, 10)} is '${rec.state}')`,
+              "warning",
+            );
+            return;
+          }
+          // A manual heartbeat is also a sign of life: it resets the stall clock.
+          watchdog?.touch(Date.now(), rec.id);
+          const ok = await conn?.sendAct(rec.channel, "progress", rec.id, { note });
+          ctx.ui.notify(
+            ok
+              ? `freeq: reported progress on ${rec.id.slice(0, 10)}`
+              : `freeq: could not send the progress note`,
+            ok ? "info" : "warning",
+          );
+          return;
+        }
+
         case "peers": {
           const peers = conn?.peers() ?? [];
           if (!peers.length) {
@@ -1300,10 +1765,22 @@ export default function (pi: ExtensionAPI): void {
 
         default:
           ctx.ui.notify(
-            "/freeq [status | login <did> | join #c | leave #c | peers | " +
-              "handoffs | mode #c <silent|addressed|participant> | " +
-              "trust <did> <tier> | provenance <tier> | mute | unmute | " +
-              "takeover | on | off]",
+            [
+              "/freeq [status | login <did> | join #c | leave #c | peers |",
+              "        handoffs | mode #c <silent|addressed|participant> |",
+              "        trust <did> <tier> | provenance <tier> | mute | unmute |",
+              "        takeover | on | off]",
+              "",
+              "work:",
+              "  tasks                    what is assigned, queued, offered, or open nearby",
+              "  resume [id]              re-enter assigned work (all of it, capped, if no id)",
+              "  accept <id>              take a queued or offered task now",
+              "  decline <id> [reason]    turn one down, with a reason",
+              "  drop <id> [reason]       fail work in flight honestly instead of leaving it hanging",
+              "  progress <id> <note>     report progress by hand",
+              "",
+              "Ids may be the short prefix the notifications print.",
+            ].join("\n"),
             "info",
           );
       }

--- a/freeq-pi/package-lock.json
+++ b/freeq-pi/package-lock.json
@@ -2417,9 +2417,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,9 +2518,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,9 +2532,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,9 +2546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,9 +2560,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2589,9 +2574,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,9 +2588,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2623,9 +2602,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2640,9 +2616,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2657,9 +2630,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2674,9 +2644,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2691,9 +2658,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,9 +2672,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2725,9 +2686,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2849,6 +2807,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3225,6 +3184,7 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3418,6 +3378,7 @@
       "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3465,6 +3426,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/freeq-pi/skills/freeq/SKILL.md
+++ b/freeq-pi/skills/freeq/SKILL.md
@@ -91,8 +91,16 @@ Write the `brief` as if the other agent has none of your context, because it
 doesn't: name the interface, the branch, and what "done" looks like. The brief
 is hashed and the hash is signed, so it is tamper-evident.
 
-The recipient is **not** obliged to take it. Their human is asked to approve,
-and they may decline. A handoff is a request, not a command.
+The recipient is **not** obliged to take it. A trusted offer to an idle
+session is taken up straight away; a busy one queues it, and an offer nobody
+answers is declined with a reason rather than left in silence. A handoff is a
+request, not a command.
+
+Because of that, an accepted task reports back while it runs: a `progress`
+heartbeat says the work is alive, and work this session stops touching fails
+with a reason instead of hanging. If you are the assignee and you have to
+abandon something, say so — `freeq({ action: "complete" })` when it is done,
+and `/freeq drop <id> <reason>` when it is not.
 
 - `freeq({ action: "handoffs" })` — what you owe and what you are owed.
 - `freeq({ action: "complete", taskId: "...", message: "what you did" })` —

--- a/freeq-pi/src/config.test.ts
+++ b/freeq-pi/src/config.test.ts
@@ -8,6 +8,10 @@ import {
   tierFor,
   tierAtLeast,
   DEFAULT_MODE,
+  DEFAULT_OFFER_TTL_SECS,
+  DEFAULT_PROGRESS_INTERVAL_SECS,
+  DEFAULT_STALL_SECS,
+  DEFAULT_MAX_RESUME,
 } from "./config.js";
 
 describe("normalizeConfig", () => {
@@ -134,5 +138,72 @@ describe("mute", () => {
 
   it("is not settable from project config", () => {
     expect(projectOverrides({ muted: true })).not.toHaveProperty("muted");
+  });
+});
+
+describe("resilience settings", () => {
+  it("defaults to accepting trusted work when idle, and to the documented timings", () => {
+    const cfg = defaultConfig();
+    expect(cfg.autoAcceptWhenIdle).toBe(true);
+    expect(cfg.offerTtlSecs).toBe(DEFAULT_OFFER_TTL_SECS);
+    expect(cfg.progressIntervalSecs).toBe(DEFAULT_PROGRESS_INTERVAL_SECS);
+    expect(cfg.stallSecs).toBe(DEFAULT_STALL_SECS);
+    expect(cfg.maxResume).toBe(DEFAULT_MAX_RESUME);
+  });
+
+  it("leaves a config written before these keys existed exactly as it was", () => {
+    // The whole point: an older freeq.json must keep working untouched.
+    const older = { ownerDid: "did:plc:me", channels: ["#a"], autoAccept: ["did:plc:mate"] };
+    const cfg = normalizeConfig(older);
+    expect(cfg.ownerDid).toBe("did:plc:me");
+    expect(cfg.autoAccept).toEqual(["did:plc:mate"]);
+    expect(cfg.stallSecs).toBe(DEFAULT_STALL_SECS);
+    expect(cfg.autoAcceptWhenIdle).toBe(true);
+  });
+
+  it("keeps explicit values", () => {
+    const cfg = normalizeConfig({
+      autoAcceptWhenIdle: false,
+      offerTtlSecs: 60,
+      progressIntervalSecs: 30,
+      stallSecs: 120,
+      maxResume: 0,
+    });
+    expect(cfg.autoAcceptWhenIdle).toBe(false);
+    expect(cfg.offerTtlSecs).toBe(60);
+    expect(cfg.progressIntervalSecs).toBe(30);
+    expect(cfg.stallSecs).toBe(120);
+    expect(cfg.maxResume).toBe(0);
+  });
+
+  it("falls back on values that would break the mechanism", () => {
+    // A zero stall timeout fails every task the moment it starts; a negative
+    // resume cap is not a smaller cap, it is nonsense.
+    const cfg = normalizeConfig({
+      offerTtlSecs: 0,
+      progressIntervalSecs: -5,
+      stallSecs: "900",
+      maxResume: -1,
+      autoAcceptWhenIdle: "yes",
+    });
+    expect(cfg.offerTtlSecs).toBe(DEFAULT_OFFER_TTL_SECS);
+    expect(cfg.progressIntervalSecs).toBe(DEFAULT_PROGRESS_INTERVAL_SECS);
+    expect(cfg.stallSecs).toBe(DEFAULT_STALL_SECS);
+    expect(cfg.maxResume).toBe(DEFAULT_MAX_RESUME);
+    expect(cfg.autoAcceptWhenIdle).toBe(true);
+  });
+
+  it("ignores unknown keys rather than failing the load", () => {
+    expect(() => normalizeConfig({ somethingFromTheFuture: 1 })).not.toThrow();
+    expect(normalizeConfig({ somethingFromTheFuture: 1 })).not.toHaveProperty(
+      "somethingFromTheFuture",
+    );
+  });
+
+  it("is not settable from project config", () => {
+    // A cloned repo must not be able to hand you a 1-second stall timeout.
+    for (const key of ["autoAcceptWhenIdle", "offerTtlSecs", "stallSecs", "maxResume"]) {
+      expect(projectOverrides({ [key]: 1 })).not.toHaveProperty(key);
+    }
   });
 });

--- a/freeq-pi/src/config.ts
+++ b/freeq-pi/src/config.ts
@@ -70,9 +70,36 @@ export interface FreeqConfig {
   provenance?: ProvenanceTier;
   /** Where provenance goes. Defaults to the first joined channel. */
   provenanceChannel?: string;
+
+  /**
+   * Accept an offer straight away when this session is idle and the offerer
+   * is trusted at `handoff` or above. The alternative is a queue, and a queue
+   * only pays off when somebody eventually looks at it — an idle session that
+   * declines to start trusted work is just a slower way of dropping it.
+   * `autoAccept` above is the stronger, per-DID form: it accepts even mid-turn.
+   */
+  autoAcceptWhenIdle: boolean;
+  /**
+   * How long a queued offer may wait before it is declined with a reason.
+   * Silence teaches an offerer nothing; a decline lets them re-offer
+   * somewhere else while the work still matters.
+   */
+  offerTtlSecs: number;
+  /** How often an in-flight task emits a `progress` heartbeat. */
+  progressIntervalSecs: number;
+  /** How long an in-flight task may go without model activity before it fails. */
+  stallSecs: number;
+  /** How many assigned tasks a restart re-enters at once. */
+  maxResume: number;
 }
 
 export const DEFAULT_SERVER = "wss://irc.freeq.at/irc";
+
+/** Resilience defaults, named so tests and help text quote one source. */
+export const DEFAULT_OFFER_TTL_SECS = 1800;
+export const DEFAULT_PROGRESS_INTERVAL_SECS = 120;
+export const DEFAULT_STALL_SECS = 900;
+export const DEFAULT_MAX_RESUME = 3;
 
 export function defaultConfig(): FreeqConfig {
   return {
@@ -84,6 +111,11 @@ export function defaultConfig(): FreeqConfig {
     muted: false,
     autoAccept: [],
     provenance: "decisions",
+    autoAcceptWhenIdle: true,
+    offerTtlSecs: DEFAULT_OFFER_TTL_SECS,
+    progressIntervalSecs: DEFAULT_PROGRESS_INTERVAL_SECS,
+    stallSecs: DEFAULT_STALL_SECS,
+    maxResume: DEFAULT_MAX_RESUME,
   };
 }
 
@@ -134,6 +166,14 @@ export function normalizeConfig(raw: unknown): FreeqConfig {
       (d): d is string => typeof d === "string" && d.startsWith("did:"),
     );
   }
+  if (typeof o.autoAcceptWhenIdle === "boolean") base.autoAcceptWhenIdle = o.autoAcceptWhenIdle;
+  // A config written before these keys existed simply keeps the defaults, and
+  // a nonsensical value (zero, negative, a string) does too — a stall timeout
+  // of 0 would fail every task the instant it started.
+  base.offerTtlSecs = duration(o.offerTtlSecs, base.offerTtlSecs);
+  base.progressIntervalSecs = duration(o.progressIntervalSecs, base.progressIntervalSecs);
+  base.stallSecs = duration(o.stallSecs, base.stallSecs);
+  base.maxResume = count(o.maxResume, base.maxResume);
   base.channels = normalizeChannels(o.channels);
 
   if (o.modes && typeof o.modes === "object") {
@@ -151,6 +191,18 @@ export function normalizeConfig(raw: unknown): FreeqConfig {
     }
   }
   return base;
+}
+
+/** A positive number of seconds, or the default. */
+function duration(raw: unknown, fallback: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) return fallback;
+  return Math.round(raw);
+}
+
+/** A non-negative count — zero is meaningful here (resume nothing). */
+function count(raw: unknown, fallback: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return fallback;
+  return Math.floor(raw);
 }
 
 function normalizeChannels(raw: unknown): string[] {

--- a/freeq-pi/src/connection.test.ts
+++ b/freeq-pi/src/connection.test.ts
@@ -190,6 +190,33 @@ describe("transport state handling (the churn regression)", () => {
     bot.emit("connectionStateChanged", "disconnected");
     expect(notices.filter((n) => /dropped/.test(n.text)).length).toBe(0);
   });
+
+  it("reports coming online once per gap, not once per event", async () => {
+    // The host resumes assigned work here. bot.start() returning and the
+    // transport's own 'connected' both mean online, and a resume that ran
+    // twice for one connect would re-enter every task twice.
+    const online: number[] = [];
+    const { conn, bot } = mk({ onOnline: () => online.push(1) });
+    await conn.start();
+    bot.emit("connectionStateChanged", "connected");
+    bot.emit("connectionStateChanged", "connected");
+    expect(online).toHaveLength(1);
+
+    bot.emit("connectionStateChanged", "disconnected");
+    bot.emit("connectionStateChanged", "connected");
+    expect(online).toHaveLength(2); // a real gap closed — resume again
+  });
+
+  it("survives a throwing online handler", async () => {
+    const { conn, notices } = mk({
+      onOnline: () => {
+        throw new Error("resume exploded");
+      },
+    });
+    await expect(conn.start()).resolves.toBeUndefined();
+    expect(conn.state).toBe("online");
+    expect(notices.some((n) => /online handler error/.test(n.text))).toBe(true);
+  });
 });
 
 describe("peer discovery", () => {

--- a/freeq-pi/src/connection.ts
+++ b/freeq-pi/src/connection.ts
@@ -125,6 +125,14 @@ export interface ConnectionOptions {
   onAsk?: (ask: InboundAsk) => void;
   /** A `freeq.at/act` task event (handoffs). */
   onActEvent?: (ev: ActEventPayload) => void;
+  /**
+   * We are online, on the first connect and after every reconnect.
+   *
+   * The transport recovers a dropped socket on its own, so nothing above here
+   * otherwise learns that a gap happened — and a session that was cut off
+   * mid-task needs to ask the server what is still assigned to it.
+   */
+  onOnline?: () => void;
 }
 
 export interface InboundAsk {
@@ -279,7 +287,7 @@ export class FreeqConnection {
       // ghost-mode churn and re-registration, and peers saw a hello storm.
       bot.on("connectionStateChanged", (s: string) => {
         if (s === "connected") {
-          this.#state = "online";
+          this.#goOnline();
           this.#noticed.delete("offline");
         } else if (s === "connecting") {
           if (this.#state === "online") this.#state = "connecting";
@@ -299,7 +307,7 @@ export class FreeqConnection {
       });
 
       await bot.start();
-      this.#state = "online";
+      this.#goOnline();
       this.#retry = RECONNECT_INITIAL_MS;
     } catch (err) {
       // Only the INITIAL connect is retried here. Once a bot exists, the
@@ -315,6 +323,25 @@ export class FreeqConnection {
       this.#scheduleInitialRetry();
     } finally {
       this.#starting = false;
+    }
+  }
+
+  /**
+   * Become online, telling the host once per gap.
+   *
+   * Both `bot.start()` returning and the transport's own 'connected' event
+   * land here, and a reconnect fires the second one again — so the transition
+   * is what is reported, not the event. A handler that resumes work would
+   * otherwise run twice for one connect.
+   */
+  #goOnline(): void {
+    const wasOnline = this.#state === "online";
+    this.#state = "online";
+    if (wasOnline) return;
+    try {
+      this.#opts.onOnline?.();
+    } catch (err) {
+      this.#opts.onNotice?.(`freeq: online handler error: ${(err as Error).message}`, "error");
     }
   }
 

--- a/freeq-pi/src/handoff.test.ts
+++ b/freeq-pi/src/handoff.test.ts
@@ -12,6 +12,7 @@ import {
   offerExpiry,
   formatDuration,
   resolveTaskRef,
+  WorkWatchdog,
   type ActEventLike,
   type HandoffRecord,
   type OfferPolicy,
@@ -667,5 +668,107 @@ describe("formatDuration", () => {
     expect(formatDuration(3600)).toBe("1h");
     expect(formatDuration(5400)).toBe("1.5h");
     expect(formatDuration(86_400)).toBe("1d");
+  });
+});
+
+describe("the watchdog on accepted work", () => {
+  const task = { taskId: "01WORK00000000000000000000", channel: "#work", title: "Port it" };
+  const dog = () => new WorkWatchdog({ progressIntervalSecs: 120, stallSecs: 900 });
+
+  it("says nothing while the work is fresh", () => {
+    const w = dog();
+    w.start(task, 0);
+    expect(w.tick(1000)).toEqual([]);
+  });
+
+  it("heartbeats while in flight, at the configured interval", () => {
+    const w = dog();
+    w.start(task, 0);
+    expect(w.tick(119_000)).toEqual([]);
+    const beat = w.tick(120_000);
+    expect(beat).toHaveLength(1);
+    expect(beat[0].kind).toBe("progress");
+    // The next beat is an interval later, not on every tick after the first.
+    expect(w.tick(121_000)).toEqual([]);
+    expect(w.tick(240_000)).toHaveLength(1);
+  });
+
+  it("stops heartbeating once the task is finished", () => {
+    const w = dog();
+    w.start(task, 0);
+    expect(w.tick(120_000)).toHaveLength(1);
+    expect(w.finish(task.taskId)).toBe(true);
+    expect(w.tick(240_000)).toEqual([]);
+    expect(w.tick(10_000_000)).toEqual([]); // and never fails afterwards either
+    expect(w.inFlight()).toEqual([]);
+  });
+
+  it("fails a stalled task exactly once, with a reason naming the stall", () => {
+    const w = dog();
+    w.start(task, 0);
+    const out = w.tick(900_000);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("fail");
+    if (out[0].kind === "fail") {
+      expect(out[0].reason).toBe("no progress for 15m — the session stopped working on it");
+      expect(out[0].task.taskId).toBe(task.taskId);
+    }
+    // Never twice: the task is gone the moment it fails.
+    expect(w.tick(900_001)).toEqual([]);
+    expect(w.tick(1_800_000)).toEqual([]);
+    expect(w.has(task.taskId)).toBe(false);
+  });
+
+  it("counts model activity as progress, not the heartbeats it emits", () => {
+    // Otherwise the heartbeat keeps its own task alive forever and the stall
+    // timeout never fires — the exact hang this is here to end.
+    const w = dog();
+    const fails = (out: ReturnType<WorkWatchdog["tick"]>) => out.filter((a) => a.kind === "fail");
+    w.start(task, 0);
+    w.tick(120_000);
+    w.tick(240_000);
+    expect(fails(w.tick(899_000))).toEqual([]);
+    w.touch(899_500); // the model did something
+    expect(fails(w.tick(900_000))).toEqual([]); // so the stall clock restarted
+    expect(fails(w.tick(1_799_499))).toEqual([]);
+    expect(fails(w.tick(1_799_500))).toHaveLength(1); // and now it has run out again
+  });
+
+  it("watches several tasks independently", () => {
+    const w = dog();
+    const other = { taskId: "01OTHER0000000000000000000", channel: "#work", title: "And this" };
+    w.start(task, 0);
+    w.start(other, 500_000);
+    const out = w.tick(900_000);
+    expect(out.filter((a) => a.kind === "fail").map((a) => a.task.taskId)).toEqual([task.taskId]);
+    expect(w.inFlight().map((t) => t.taskId)).toEqual([other.taskId]);
+  });
+
+  it("starting the same task twice does not double up on it", () => {
+    const w = dog();
+    w.start(task, 0);
+    w.start(task, 500_000); // e.g. resume racing a live accept
+    expect(w.inFlight()).toHaveLength(1);
+    expect(w.inFlight()[0].startedAt).toBe(0);
+    // The second start marked it alive, so the stall clock runs from there.
+    expect(w.tick(900_000).filter((a) => a.kind === "fail")).toEqual([]);
+    expect(w.tick(1_400_000).filter((a) => a.kind === "fail")).toHaveLength(1);
+  });
+
+  it("notes a shutdown rather than failing the work", () => {
+    // A restart may pick this straight back up; a false failure in a signed,
+    // permanent log is worse than a gap in it.
+    const w = dog();
+    w.start(task, 0);
+    const out = w.shutdown(60_000);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("progress");
+    if (out[0].kind === "progress") expect(out[0].note).toMatch(/shutting down/);
+    expect(w.inFlight()).toEqual([]);
+    expect(w.tick(10_000_000)).toEqual([]);
+  });
+
+  it("has nothing to say on a shutdown with no work in flight", () => {
+    expect(dog().shutdown(1000)).toEqual([]);
   });
 });

--- a/freeq-pi/src/handoff.test.ts
+++ b/freeq-pi/src/handoff.test.ts
@@ -13,6 +13,10 @@ import {
   formatDuration,
   resolveTaskRef,
   WorkWatchdog,
+  planResume,
+  parseServerTasks,
+  fetchAssignedTasks,
+  type ServerTask,
   type ActEventLike,
   type HandoffRecord,
   type OfferPolicy,
@@ -770,5 +774,176 @@ describe("the watchdog on accepted work", () => {
 
   it("has nothing to say on a shutdown with no work in flight", () => {
     expect(dog().shutdown(1000)).toEqual([]);
+  });
+});
+
+describe("resume — the server says what is still ours", () => {
+  function known(over: Partial<HandoffRecord> = {}): HandoffRecord {
+    return {
+      id: "01AAAAAAAA0000000000000000",
+      kind: "handoff",
+      state: "assigned",
+      offerer: ALICE,
+      offeree: BOB,
+      assignee: BOB,
+      title: "Port the auth change",
+      channel: "#work",
+      fromReplay: false,
+      signed: true,
+      createdAt: 1000,
+      updatedAt: 1000,
+      log: [],
+      ...over,
+    };
+  }
+  function row(over: Partial<ServerTask> = {}): ServerTask {
+    return {
+      id: "01AAAAAAAA0000000000000000",
+      kind: "handoff",
+      state: "assigned",
+      venue: "#work",
+      offerer: ALICE,
+      offeree: BOB,
+      assignee: BOB,
+      ...over,
+    };
+  }
+  const plan = (over: Partial<Parameters<typeof planResume>[0]>) =>
+    planResume({ serverTasks: [], known: [], me: BOB, max: 3, already: new Set(), ...over });
+
+  it("re-enters work the server still lists as assigned to us", () => {
+    const out = plan({ serverTasks: [row()], known: [known()] });
+    expect(out.resume.map((r) => r.id)).toEqual(["01AAAAAAAA0000000000000000"]);
+    expect(out.skipped).toBe(0);
+    expect(out.stale).toEqual([]);
+  });
+
+  it("does NOT re-enter a local record the server no longer lists as ours", () => {
+    // The view is a cache. Work somebody else has since taken must not be
+    // restarted here just because our copy still says it is ours.
+    const out = plan({ serverTasks: [], known: [known()] });
+    expect(out.resume).toEqual([]);
+    expect(out.stale.map((r) => r.id)).toEqual(["01AAAAAAAA0000000000000000"]);
+  });
+
+  it("ignores rows assigned to somebody else, or in another state", () => {
+    const out = plan({
+      serverTasks: [
+        row({ id: "01OTHERS000000000000000000", assignee: MALLORY }),
+        row({ id: "01OPEN00000000000000000000", state: "open", assignee: undefined }),
+        row({ id: "01DONE00000000000000000000", state: "completed" }),
+        row({ id: "01BOUNTY000000000000000000", kind: "bounty" }),
+      ],
+    });
+    expect(out.resume).toEqual([]);
+  });
+
+  it("resumes work it has no local memory of, from the server row alone", () => {
+    // A lost view, or work accepted on another machine. The row names the
+    // venue, which is all the lifecycle needs to carry on.
+    const out = plan({ serverTasks: [row({ updated: 5 })] });
+    expect(out.resume).toHaveLength(1);
+    expect(out.resume[0].channel).toBe("#work");
+    expect(out.resume[0].assignee).toBe(BOB);
+    expect(out.resume[0].title).toMatch(/not in the server's listing/);
+  });
+
+  it("will not invent a venue it cannot post the lifecycle back into", () => {
+    const out = plan({ serverTasks: [row({ venue: "dm:did:key:zA,did:key:zB" })] });
+    expect(out.resume).toEqual([]);
+    expect(out.skipped).toBe(1); // counted, not silently dropped
+  });
+
+  it("caps the resume at maxResume, oldest first, and says how many are left", () => {
+    const ids = ["01C", "01A", "01B"];
+    const out = plan({
+      max: 2,
+      serverTasks: ids.map((id) => row({ id })),
+      known: ids.map((id, i) => known({ id, createdAt: [300, 100, 200][i] })),
+    });
+    expect(out.resume.map((r) => r.id)).toEqual(["01A", "01B"]);
+    expect(out.skipped).toBe(1);
+  });
+
+  it("resumes nothing at all when the cap is zero", () => {
+    const out = plan({ max: 0, serverTasks: [row()], known: [known()] });
+    expect(out.resume).toEqual([]);
+    expect(out.skipped).toBe(1);
+  });
+
+  it("is idempotent — a second call re-enters nothing", () => {
+    const serverTasks = [row()];
+    const first = plan({ serverTasks, known: [known()] });
+    expect(first.resume).toHaveLength(1);
+
+    const already = new Set(first.resume.map((r) => r.id));
+    const second = plan({ serverTasks, known: [known()], already });
+    expect(second.resume).toEqual([]);
+    expect(second.skipped).toBe(0); // already running is not "skipped"
+    expect(second.stale).toEqual([]);
+  });
+});
+
+describe("reading the server's task listing", () => {
+  it("keeps the task's own state, not this server's reading of it", () => {
+    // 'orphaned' says a federation link is down, not that the work moved.
+    const tasks = parseServerTasks({
+      tasks: [
+        {
+          act_id: "01A",
+          kind: "handoff",
+          venue: "#work",
+          state: "orphaned",
+          stored_state: "assigned",
+          assignee: BOB,
+          updated: 1700,
+        },
+      ],
+    });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].state).toBe("assigned");
+    expect(tasks[0].updated).toBe(1_700_000); // seconds on the wire, ms here
+  });
+
+  it("drops rows it cannot make sense of instead of failing the resume", () => {
+    expect(parseServerTasks({ tasks: [null, 7, {}, { act_id: "01A" }] })).toEqual([]);
+    expect(parseServerTasks({})).toEqual([]);
+    expect(parseServerTasks("nope")).toEqual([]);
+  });
+
+  it("asks only for work assigned to us", async () => {
+    let asked = "";
+    const out = await fetchAssignedTasks({
+      origin: "https://irc.example/",
+      did: BOB,
+      fetchImpl: (async (url: string) => {
+        asked = url;
+        return { ok: true, json: async () => ({ tasks: [] }) };
+      }) as unknown as typeof fetch,
+    });
+    expect(out.ok).toBe(true);
+    expect(asked).toBe(
+      `https://irc.example/api/v1/actions?assignee=${encodeURIComponent(BOB)}&state=assigned`,
+    );
+  });
+
+  it("reports an outage as an outage, not as an empty answer", async () => {
+    const down = await fetchAssignedTasks({
+      origin: "https://irc.example",
+      did: BOB,
+      fetchImpl: (async () => {
+        throw new Error("connect ECONNREFUSED");
+      }) as unknown as typeof fetch,
+    });
+    expect(down.ok).toBe(false);
+    if (!down.ok) expect(down.reason).toMatch(/ECONNREFUSED/);
+
+    const rejected = await fetchAssignedTasks({
+      origin: "https://irc.example",
+      did: BOB,
+      fetchImpl: (async () => ({ ok: false, status: 503 })) as unknown as typeof fetch,
+    });
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) expect(rejected.reason).toMatch(/503/);
   });
 });

--- a/freeq-pi/src/handoff.test.ts
+++ b/freeq-pi/src/handoff.test.ts
@@ -2,7 +2,20 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { HandoffStore, hashBrief, describeHandoff, type ActEventLike } from "./handoff.js";
+import {
+  HandoffStore,
+  hashBrief,
+  describeHandoff,
+  decideOffer,
+  OfferQueue,
+  sweepOfferQueue,
+  offerExpiry,
+  formatDuration,
+  resolveTaskRef,
+  type ActEventLike,
+  type HandoffRecord,
+  type OfferPolicy,
+} from "./handoff.js";
 
 const ALICE = "did:key:zAlice";
 const BOB = "did:key:zBob";
@@ -391,5 +404,268 @@ describe("open (claimable) tasks", () => {
     expect(b.get(id)!.state).toBe("open");
     expect(b.get(id)!.caps).toBe("pi/lang:ts");
     expect(b.get(id)!.offeree).toBeUndefined();
+  });
+});
+
+describe("intake — an offer can never be silently dropped", () => {
+  const policy = (over: Partial<OfferPolicy> = {}): OfferPolicy => ({
+    tier: "handoff",
+    idle: true,
+    autoAcceptDid: false,
+    autoAcceptWhenIdle: true,
+    ...over,
+  });
+
+  it("accepts trusted work when the session is idle", () => {
+    const d = decideOffer(policy());
+    expect(d.action).toBe("accept");
+    expect(d.reason).toMatch(/idle/);
+  });
+
+  it("queues rather than interrupting a session that is busy", () => {
+    const d = decideOffer(policy({ idle: false }));
+    expect(d.action).toBe("queue");
+    expect(d.reason).toMatch(/busy/);
+  });
+
+  it("accepts an auto-accept DID even mid-turn — that is what the list is for", () => {
+    expect(decideOffer(policy({ idle: false, autoAcceptDid: true })).action).toBe("accept");
+  });
+
+  it("queues when the idle default is switched off", () => {
+    expect(decideOffer(policy({ autoAcceptWhenIdle: false })).action).toBe("queue");
+  });
+
+  it("ignores an untrusted offerer entirely — idle or busy, queue or no queue", () => {
+    for (const tier of ["observe", "message", "request"] as const) {
+      for (const idle of [true, false]) {
+        const d = decideOffer(policy({ tier, idle, autoAcceptWhenIdle: true }));
+        expect(d.action, `${tier} while ${idle ? "idle" : "busy"}`).toBe("ignore");
+        expect(d.reason).toContain(tier);
+      }
+    }
+  });
+
+  it("does not let the auto-accept list smuggle past the trust gate", () => {
+    // A DID can be on the list and later have its tier revoked. Tier wins.
+    expect(decideOffer(policy({ tier: "observe", autoAcceptDid: true })).action).toBe("ignore");
+  });
+});
+
+describe("the offer queue", () => {
+  function rec(over: Partial<HandoffRecord> = {}): HandoffRecord {
+    return {
+      id: "01AAAAAAAA0000000000000000",
+      kind: "handoff",
+      state: "offered",
+      offerer: ALICE,
+      offeree: BOB,
+      title: "Port the auth change",
+      channel: "#work",
+      fromReplay: false,
+      signed: true,
+      createdAt: 1000,
+      updatedAt: 1000,
+      log: [],
+      ...over,
+    };
+  }
+
+  const trusted = () => true;
+  const sweep = (over: Partial<Parameters<typeof sweepOfferQueue>[0]>) =>
+    sweepOfferQueue({
+      entries: [],
+      lookup: () => undefined,
+      trusted,
+      idle: true,
+      now: 0,
+      ttlSecs: 1800,
+      ...over,
+    });
+
+  it("holds an offer while busy and takes it on the transition to idle", () => {
+    const r = rec();
+    const entries = [{ taskId: r.id, queuedAt: 0 }];
+    const lookup = (id: string) => (id === r.id ? r : undefined);
+
+    const busy = sweep({ entries, lookup, idle: false, now: 1000 });
+    expect(busy.accept).toBeUndefined();
+    expect(busy.expire).toEqual([]);
+    expect(busy.drop).toEqual([]);
+
+    const idle = sweep({ entries, lookup, idle: true, now: 1000 });
+    expect(idle.accept?.record.id).toBe(r.id);
+  });
+
+  it("takes the oldest queued offer first, and only one per pass", () => {
+    const old = rec({ id: "01OLD00000000000000000000A" });
+    const recent = rec({ id: "01NEW00000000000000000000B" });
+    const byId = new Map([old, recent].map((r) => [r.id, r]));
+    const out = sweep({
+      entries: [
+        { taskId: recent.id, queuedAt: 500 },
+        { taskId: old.id, queuedAt: 100 },
+      ],
+      lookup: (id) => byId.get(id),
+      now: 1000,
+    });
+    expect(out.accept?.record.id).toBe(old.id);
+  });
+
+  it("declines a queued offer past its TTL, with a reason", () => {
+    const r = rec();
+    const out = sweep({
+      entries: [{ taskId: r.id, queuedAt: 0 }],
+      lookup: () => r,
+      ttlSecs: 60,
+      now: 61_000,
+    });
+    expect(out.accept).toBeUndefined();
+    expect(out.expire).toHaveLength(1);
+    expect(out.expire[0].reason).toMatch(/no decision for 1m/);
+  });
+
+  it("expires rather than accepts, even when we are free at that very moment", () => {
+    const r = rec();
+    const out = sweep({
+      entries: [{ taskId: r.id, queuedAt: 0 }],
+      lookup: () => r,
+      ttlSecs: 60,
+      now: 999_999,
+      idle: true,
+    });
+    expect(out.accept).toBeUndefined();
+    expect(out.expire).toHaveLength(1);
+  });
+
+  it("honours the task's own deadline when it is sooner than the TTL", () => {
+    const r = rec({ deadline: 30 }); // unix seconds
+    const e = offerExpiry(r, 0, 1800);
+    expect(e.at).toBe(30_000);
+    expect(e.reason).toMatch(/deadline/);
+
+    const out = sweep({ entries: [{ taskId: r.id, queuedAt: 0 }], lookup: () => r, now: 31_000 });
+    expect(out.expire[0].reason).toMatch(/deadline/);
+  });
+
+  it("keeps the TTL when the deadline is further out", () => {
+    expect(offerExpiry(rec({ deadline: 9_999 }), 0, 60).at).toBe(60_000);
+  });
+
+  it("forgets an entry whose task moved on without us", () => {
+    const gone = rec({ id: "01GONE0000000000000000000A", state: "cancelled" });
+    const out = sweep({
+      entries: [{ taskId: gone.id, queuedAt: 0 }, { taskId: "01VANISHED000000000000000", queuedAt: 0 }],
+      lookup: (id) => (id === gone.id ? gone : undefined),
+      now: 1000,
+    });
+    expect(out.drop.map((e) => e.taskId)).toEqual([gone.id, "01VANISHED000000000000000"]);
+    expect(out.expire).toEqual([]);
+    expect(out.accept).toBeUndefined();
+  });
+
+  it("will not act on an offer whose offerer lost trust while it waited", () => {
+    const r = rec();
+    const out = sweep({
+      entries: [{ taskId: r.id, queuedAt: 0 }],
+      lookup: () => r,
+      trusted: () => false,
+      now: 1000,
+    });
+    expect(out.accept).toBeUndefined();
+    expect(out.drop).toEqual([]); // still on the books; the TTL will retire it
+  });
+
+  it("survives a restart — a queue that dies with the session is not a queue", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "offer-queue-"));
+    const path = join(dir, "q.json");
+    const a = new OfferQueue(path);
+    a.add("01AAAAAAAA0000000000000000", 100);
+    a.add("01BBBBBBBB0000000000000000", 200);
+    a.add("01AAAAAAAA0000000000000000", 300); // a duplicate is not a second entry
+    await a.save();
+
+    const b = new OfferQueue(path);
+    await b.load();
+    expect(b.all().map((e) => e.taskId)).toEqual([
+      "01AAAAAAAA0000000000000000",
+      "01BBBBBBBB0000000000000000",
+    ]);
+    expect(b.all()[0].queuedAt).toBe(100);
+    expect(b.has("01BBBBBBBB0000000000000000")).toBe(true);
+
+    b.remove("01AAAAAAAA0000000000000000");
+    expect(b.has("01AAAAAAAA0000000000000000")).toBe(false);
+  });
+
+  it("tolerates a corrupt queue file rather than failing the session", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "offer-queue-bad-"));
+    const path = join(dir, "q.json");
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(path, "not json at all");
+    const q = new OfferQueue(path);
+    await expect(q.load()).resolves.toBeUndefined();
+    expect(q.all()).toEqual([]);
+  });
+});
+
+describe("resolving the short id a notification printed", () => {
+  function rec(id: string): HandoffRecord {
+    return {
+      id,
+      kind: "handoff",
+      state: "offered",
+      offerer: ALICE,
+      title: "T",
+      channel: "#work",
+      fromReplay: false,
+      signed: true,
+      createdAt: 0,
+      updatedAt: 0,
+      log: [],
+    };
+  }
+  const records = [rec("01ABCDEF0000000000000000AA"), rec("01ABCDEF0000000000000000BB"), rec("01ZZZZ")];
+
+  it("resolves a unique prefix", () => {
+    const r = resolveTaskRef(records, "01ZZ");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.record.id).toBe("01ZZZZ");
+  });
+
+  it("resolves a full id even when it is also a prefix of others", () => {
+    const r = resolveTaskRef(records, "01ABCDEF0000000000000000AA");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.record.id).toBe("01ABCDEF0000000000000000AA");
+  });
+
+  it("refuses an ambiguous prefix by naming the candidates", () => {
+    const r = resolveTaskRef(records, "01ABCDEF00");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/matches 2 tasks/);
+      expect(r.reason).toContain("01ABCDEF000000");
+    }
+  });
+
+  it("says plainly when nothing matches", () => {
+    const r = resolveTaskRef(records, "01NOPE");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/no task on record starts with '01NOPE'/);
+  });
+
+  it("refuses an empty reference instead of picking something", () => {
+    expect(resolveTaskRef(records, "   ").ok).toBe(false);
+  });
+});
+
+describe("formatDuration", () => {
+  it("reads the way a person says it", () => {
+    expect(formatDuration(45)).toBe("45s");
+    expect(formatDuration(900)).toBe("15m");
+    expect(formatDuration(1800)).toBe("30m");
+    expect(formatDuration(3600)).toBe("1h");
+    expect(formatDuration(5400)).toBe("1.5h");
+    expect(formatDuration(86_400)).toBe("1d");
   });
 });

--- a/freeq-pi/src/handoff.ts
+++ b/freeq-pi/src/handoff.ts
@@ -610,6 +610,142 @@ export function formatAge(ms: number): string {
   return `${formatDuration(ms / 1000)} ago`;
 }
 
+// ── a watchdog on work we accepted ────────────────────────────────────────
+//
+// Accepting used to be the last thing that happened: a presence label, a
+// prompt, and then nothing tracked the work at all. A model that wanders off
+// leaves the task `assigned` until the server's expiry sweep notices, days
+// later, and the offerer has no way to tell a busy agent from a dead one.
+//
+// Two clocks fix that. A heartbeat says the work is alive; a stall timeout
+// says honestly that it is not. `progress` is additive in the transition
+// table, so the heartbeat costs the task nothing.
+
+/** A task this session is working on right now. */
+export interface WatchedTask {
+  taskId: string;
+  channel: string;
+  title: string;
+  startedAt: number;
+  /** Last sign of life from the model — a turn starting, a tool running. */
+  lastProgressAt: number;
+  /** Last heartbeat we emitted, so beats are spaced rather than repeated. */
+  lastBeatAt: number;
+}
+
+/** Something the watchdog wants said on the wire. The caller emits it. */
+export type WatchdogAction =
+  | { kind: "progress"; task: WatchedTask; note: string }
+  | { kind: "fail"; task: WatchedTask; reason: string };
+
+/**
+ * The clocks on in-flight work.
+ *
+ * Deliberately has no timer of its own: the caller ticks it. That keeps the
+ * decision — beat, fail, or nothing — testable at any point in time without
+ * waiting fifteen real minutes for a stall, and it means teardown is a single
+ * `clearInterval` in one place rather than two timers per task to chase.
+ */
+export class WorkWatchdog {
+  #tasks = new Map<string, WatchedTask>();
+  #progressIntervalMs: number;
+  #stallMs: number;
+
+  constructor(opts: { progressIntervalSecs: number; stallSecs: number }) {
+    this.#progressIntervalMs = opts.progressIntervalSecs * 1000;
+    this.#stallMs = opts.stallSecs * 1000;
+  }
+
+  /** Begin watching. Starting a task we already watch only marks it alive. */
+  start(task: { taskId: string; channel: string; title: string }, now = Date.now()): void {
+    const existing = this.#tasks.get(task.taskId);
+    if (existing) {
+      existing.lastProgressAt = now;
+      return;
+    }
+    this.#tasks.set(task.taskId, {
+      taskId: task.taskId,
+      channel: task.channel,
+      title: task.title,
+      startedAt: now,
+      lastProgressAt: now,
+      lastBeatAt: now,
+    });
+  }
+
+  /** The model did something. Named `touch` because it only moves a clock. */
+  touch(now = Date.now(), taskId?: string): void {
+    for (const t of this.#tasks.values()) {
+      if (taskId && t.taskId !== taskId) continue;
+      t.lastProgressAt = now;
+    }
+  }
+
+  /** Stop watching — the task completed, failed, or is no longer ours. */
+  finish(taskId: string): boolean {
+    return this.#tasks.delete(taskId);
+  }
+
+  has(taskId: string): boolean {
+    return this.#tasks.has(taskId);
+  }
+
+  inFlight(): WatchedTask[] {
+    return [...this.#tasks.values()];
+  }
+
+  /**
+   * Advance the clocks.
+   *
+   * A stalled task is dropped as it fails, so the failure can only ever be
+   * emitted once however often this is called afterwards.
+   */
+  tick(now = Date.now()): WatchdogAction[] {
+    const out: WatchdogAction[] = [];
+    for (const task of [...this.#tasks.values()]) {
+      if (now - task.lastProgressAt >= this.#stallMs) {
+        this.#tasks.delete(task.taskId);
+        out.push({
+          kind: "fail",
+          task,
+          reason:
+            `no progress for ${formatDuration(this.#stallMs / 1000)} — ` +
+            `the session stopped working on it`,
+        });
+        continue;
+      }
+      if (now - task.lastBeatAt >= this.#progressIntervalMs) {
+        task.lastBeatAt = now;
+        out.push({
+          kind: "progress",
+          task,
+          note: `still on it — ${formatDuration((now - task.startedAt) / 1000)} so far`,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * The session is going down.
+   *
+   * Every in-flight task gets a note saying so, and none of them fails: a
+   * restart may pick the work straight back up, and a false failure in a
+   * signed, permanent log is worse than a gap in it.
+   */
+  shutdown(now = Date.now()): WatchdogAction[] {
+    const out: WatchdogAction[] = this.inFlight().map((task) => ({
+      kind: "progress" as const,
+      task,
+      note:
+        `the pi session working on this is shutting down after ` +
+        `${formatDuration((now - task.startedAt) / 1000)} — not finished`,
+    }));
+    this.#tasks.clear();
+    return out;
+  }
+}
+
 // ── referring to a task by the short id the notifications print ────────────
 
 export type TaskRef =

--- a/freeq-pi/src/handoff.ts
+++ b/freeq-pi/src/handoff.ts
@@ -34,6 +34,7 @@ import {
   refusalDescription,
   type Task,
 } from "@freeq/bot-kit";
+import { tierAtLeast, type Tier } from "./config.js";
 
 /**
  * The verb a home server uses to acknowledge an event it filed. bot-kit does
@@ -369,4 +370,275 @@ export function describeHandoff(r: HandoffRecord, selfDid?: string): string {
 function short(did: string | undefined): string | undefined {
   if (!did) return undefined;
   return did.length > 22 ? `${did.slice(0, 18)}…` : did;
+}
+
+// ── intake: what a session does about an offer addressed to it ─────────────
+//
+// The old answer was a blocking modal, and a modal is exactly what loses
+// work: nobody at the terminal, or a restart while it is open, and the offer
+// is gone — the task sits `offered` forever and nothing ever revisits it.
+// Replay does not help, because the event did arrive; we dropped it.
+//
+// So an offer either starts now or goes in a queue that outlives the session.
+
+export type OfferAction =
+  /** Not even worth telling the user about — an untrusted DID. */
+  | "ignore"
+  /** Accept it now. */
+  | "accept"
+  /** Hold it until this session is free, or until it expires. */
+  | "queue";
+
+export interface OfferDecision {
+  action: OfferAction;
+  /** One sentence naming why, for the notification and the tests. */
+  reason: string;
+}
+
+export interface OfferPolicy {
+  /** The offerer's authority tier. */
+  tier: Tier;
+  /** Is this session free right now? */
+  idle: boolean;
+  /** The offerer is on `cfg.autoAccept` — an explicit per-DID override. */
+  autoAcceptDid: boolean;
+  /** `cfg.autoAcceptWhenIdle`. */
+  autoAcceptWhenIdle: boolean;
+}
+
+/**
+ * Decide what to do with an offer addressed to us.
+ *
+ * The trust gate comes first and is absolute: an unknown DID must not be able
+ * to raise a dialog in your terminal, put anything in your queue, or cost you
+ * a notification. Everything after it is about timing, not authority.
+ */
+export function decideOffer(p: OfferPolicy): OfferDecision {
+  if (!tierAtLeast(p.tier, "handoff")) {
+    return {
+      action: "ignore",
+      reason: `offerer is tier '${p.tier}', below 'handoff' — ignored entirely`,
+    };
+  }
+  if (p.autoAcceptDid) {
+    return { action: "accept", reason: "the offerer is on your auto-accept list" };
+  }
+  if (p.autoAcceptWhenIdle && p.idle) {
+    return { action: "accept", reason: "this session is idle and the offerer is trusted" };
+  }
+  return {
+    action: "queue",
+    reason: p.idle
+      ? "auto-accept when idle is off — queued for you to decide"
+      : "this session is busy — queued rather than interrupting the turn",
+  };
+}
+
+/** An offer waiting for this session to be free. */
+export interface QueuedOffer {
+  taskId: string;
+  /** epoch ms this offer was queued. */
+  queuedAt: number;
+}
+
+/**
+ * The queue of offers we have not answered yet.
+ *
+ * Persisted beside the handoff view rather than inside it: the view's on-disk
+ * shape is a plain array that older builds already read, and a queue entry is
+ * a decision we owe, not a fact about a task. The records themselves stay in
+ * `HandoffStore` — an entry here is only an id and a clock.
+ */
+export class OfferQueue {
+  #entries: QueuedOffer[] = [];
+  #path: string;
+  #dirty = false;
+
+  constructor(path: string) {
+    this.#path = path;
+  }
+
+  static pathFor(agentDir: string): string {
+    return join(agentDir, "freeq-offer-queue.json");
+  }
+
+  async load(): Promise<void> {
+    try {
+      const raw = JSON.parse(await readFile(this.#path, "utf8")) as unknown;
+      if (Array.isArray(raw)) {
+        for (const e of raw) {
+          if (!e || typeof e !== "object") continue;
+          const o = e as Record<string, unknown>;
+          if (typeof o.taskId !== "string") continue;
+          this.#entries.push({
+            taskId: o.taskId,
+            queuedAt: typeof o.queuedAt === "number" ? o.queuedAt : Date.now(),
+          });
+        }
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        // Losing the queue costs us pending offers, which is bad — but not as
+        // bad as refusing to start the session over a corrupt cache file.
+        this.#entries = [];
+      }
+    }
+  }
+
+  async save(): Promise<void> {
+    if (!this.#dirty) return;
+    this.#dirty = false;
+    await mkdir(dirname(this.#path), { recursive: true });
+    await writeFile(this.#path, `${JSON.stringify(this.#entries, null, 2)}\n`, { mode: 0o600 });
+  }
+
+  /** Oldest first — the order the queue is drained in. */
+  all(): QueuedOffer[] {
+    return [...this.#entries].sort((a, b) => a.queuedAt - b.queuedAt);
+  }
+
+  has(taskId: string): boolean {
+    return this.#entries.some((e) => e.taskId === taskId);
+  }
+
+  /** Queue an offer. Queuing one twice is a no-op, not a second entry. */
+  add(taskId: string, at = Date.now()): void {
+    if (this.has(taskId)) return;
+    this.#entries.push({ taskId, queuedAt: at });
+    this.#dirty = true;
+  }
+
+  remove(taskId: string): void {
+    const before = this.#entries.length;
+    this.#entries = this.#entries.filter((e) => e.taskId !== taskId);
+    if (this.#entries.length !== before) this.#dirty = true;
+  }
+}
+
+/** What a pass over the queue found to do. */
+export interface QueueSweep {
+  /** The one offer to accept now. At most one: accepting makes us busy. */
+  accept?: { entry: QueuedOffer; record: HandoffRecord };
+  /** Offers to decline, each with the reason to send with the decline. */
+  expire: Array<{ entry: QueuedOffer; record: HandoffRecord; reason: string }>;
+  /** Entries to forget silently — the task moved on without us. */
+  drop: QueuedOffer[];
+}
+
+export interface SweepOptions {
+  entries: QueuedOffer[];
+  /** The current record for a queued id, if the view still has one. */
+  lookup: (taskId: string) => HandoffRecord | undefined;
+  /** Is the offerer still trusted at `handoff` or above? */
+  trusted: (offererDid: string) => boolean;
+  /** Is this session free right now? */
+  idle: boolean;
+  now: number;
+  ttlSecs: number;
+}
+
+/**
+ * One pass over the queue: expire what has waited too long, then take the
+ * oldest thing left if we are free.
+ *
+ * Expiry runs first on purpose. An offer whose deadline has already passed is
+ * not work we can honestly start, so it must not be picked up by the same
+ * sweep that would have retired it.
+ */
+export function sweepOfferQueue(opts: SweepOptions): QueueSweep {
+  const sweep: QueueSweep = { expire: [], drop: [] };
+  const live: Array<{ entry: QueuedOffer; record: HandoffRecord }> = [];
+
+  for (const entry of [...opts.entries].sort((a, b) => a.queuedAt - b.queuedAt)) {
+    const record = opts.lookup(entry.taskId);
+    // A record we no longer hold, or one that has moved on (cancelled by the
+    // offerer, expired by the server, accepted from another window) is not an
+    // open question any more. Forget it without saying anything.
+    if (!record || record.state !== "offered" || isTerminal(record.kind, record.state)) {
+      sweep.drop.push(entry);
+      continue;
+    }
+    const expiry = offerExpiry(record, entry.queuedAt, opts.ttlSecs);
+    if (opts.now >= expiry.at) {
+      sweep.expire.push({ entry, record, reason: expiry.reason });
+      continue;
+    }
+    // Trust can be revoked while an offer sits in the queue. Do not act on it,
+    // but do not decline it either — the offer was legitimate when it arrived
+    // and its TTL will retire it soon enough.
+    if (opts.trusted(record.offerer)) live.push({ entry, record });
+  }
+
+  if (opts.idle && live.length) sweep.accept = live[0];
+  return sweep;
+}
+
+/**
+ * When a queued offer stops being answerable, and what to say about it.
+ *
+ * The task's own deadline wins when it is sooner: accepting work whose
+ * deadline has passed helps nobody, and our TTL is only a floor on how long
+ * we are willing to sit on a decision.
+ */
+export function offerExpiry(
+  rec: HandoffRecord,
+  queuedAt: number,
+  ttlSecs: number,
+): { at: number; reason: string } {
+  const ttlAt = queuedAt + ttlSecs * 1000;
+  const deadlineAt = rec.deadline ? rec.deadline * 1000 : undefined;
+  if (deadlineAt !== undefined && deadlineAt < ttlAt) {
+    return { at: deadlineAt, reason: "the offer's own deadline passed before this session was free" };
+  }
+  return {
+    at: ttlAt,
+    reason: `no decision for ${formatDuration(ttlSecs)} — this session was never free to take it`,
+  };
+}
+
+/** Durations as a human says them: 45s, 15m, 2h, 1d. */
+export function formatDuration(secs: number): string {
+  const s = Math.max(0, Math.round(secs));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86_400) return `${Math.round(s / 360) / 10}h`.replace(".0h", "h");
+  return `${Math.round(s / 8640) / 10}d`.replace(".0d", "d");
+}
+
+/** How long ago, for listings. */
+export function formatAge(ms: number): string {
+  return `${formatDuration(ms / 1000)} ago`;
+}
+
+// ── referring to a task by the short id the notifications print ────────────
+
+export type TaskRef =
+  | { ok: true; record: HandoffRecord }
+  | { ok: false; reason: string };
+
+/**
+ * Resolve the 10-character prefix our notifications print back to one task.
+ *
+ * An ambiguous prefix is refused by name rather than guessed: picking the
+ * newest match would eventually drop, fail, or accept the wrong piece of
+ * somebody's work, and the user is one keystroke from disambiguating it.
+ */
+export function resolveTaskRef(records: HandoffRecord[], ref: string): TaskRef {
+  const needle = ref.trim();
+  if (!needle) return { ok: false, reason: "no task id given" };
+
+  const exact = records.find((r) => r.id === needle);
+  if (exact) return { ok: true, record: exact };
+
+  const lower = needle.toLowerCase();
+  const hits = records.filter((r) => r.id.toLowerCase().startsWith(lower));
+  if (!hits.length) return { ok: false, reason: `no task on record starts with '${needle}'` };
+  if (hits.length === 1) return { ok: true, record: hits[0] };
+  return {
+    ok: false,
+    reason:
+      `'${needle}' matches ${hits.length} tasks (` +
+      hits.map((r) => r.id.slice(0, 14)).join(", ") +
+      `) — give more of the id`,
+  };
 }

--- a/freeq-pi/src/handoff.ts
+++ b/freeq-pi/src/handoff.ts
@@ -746,6 +746,194 @@ export class WorkWatchdog {
   }
 }
 
+// ── resume: picking up where a restarted session left off ─────────────────
+//
+// A restart used to load the view and ask nobody anything, so work this
+// session had accepted simply stopped. The view alone cannot answer the
+// question either: it is a cache, and a cache that says "still mine" about
+// work somebody else has since taken is worse than no answer. So we ask the
+// server, which is the authority on who holds what.
+
+/** One row of `GET /api/v1/actions`, reduced to what a resume needs. */
+export interface ServerTask {
+  id: string;
+  kind: string;
+  state: string;
+  /** Where the task lives — a channel for everything we post. */
+  venue: string;
+  offerer?: string;
+  offeree?: string;
+  assignee?: string;
+  caps?: string;
+  /** Unix seconds. */
+  deadline?: number;
+  /** epoch ms the server last saw it move. */
+  updated?: number;
+}
+
+/**
+ * Read the listing.
+ *
+ * `stored_state` is preferred over `state` where the server sends both:
+ * `state` can read `orphaned`, which is this server's opinion about a task
+ * whose home it has lost contact with, not the task's own record. Our task is
+ * still assigned to us; a federation link being down does not un-assign it.
+ */
+export function parseServerTasks(body: unknown): ServerTask[] {
+  const rows = (body as { tasks?: unknown })?.tasks;
+  if (!Array.isArray(rows)) return [];
+  const out: ServerTask[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    const o = row as Record<string, unknown>;
+    const id = typeof o.act_id === "string" ? o.act_id : undefined;
+    const state = str(o.stored_state) ?? str(o.state);
+    if (!id || !state) continue;
+    out.push({
+      id,
+      kind: str(o.kind) ?? HANDOFF_KIND,
+      state,
+      venue: str(o.venue) ?? "",
+      offerer: str(o.offerer),
+      offeree: str(o.offeree),
+      assignee: str(o.assignee),
+      caps: str(o.caps),
+      deadline: typeof o.deadline === "number" ? o.deadline : undefined,
+      updated: epochMs(o.updated),
+    });
+  }
+  return out;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v ? v : undefined;
+}
+
+/** Timestamps arrive in seconds; everything in this package is in ms. */
+function epochMs(v: unknown): number | undefined {
+  if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+  return v < 1e12 ? v * 1000 : v;
+}
+
+/**
+ * Ask the server what it still holds for us.
+ *
+ * A failure here is an outage, not an answer: it returns nothing and says
+ * why, so the caller reports a resume it could not do rather than concluding
+ * there was nothing to resume.
+ */
+export async function fetchAssignedTasks(opts: {
+  origin: string;
+  did: string;
+  state?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<{ ok: true; tasks: ServerTask[] } | { ok: false; reason: string }> {
+  const url =
+    `${opts.origin.replace(/\/$/, "")}/api/v1/actions` +
+    `?assignee=${encodeURIComponent(opts.did)}&state=${encodeURIComponent(opts.state ?? "assigned")}`;
+  try {
+    const res = await (opts.fetchImpl ?? fetch)(url, {
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 8000),
+    });
+    if (!res.ok) return { ok: false, reason: `the task listing returned ${res.status}` };
+    return { ok: true, tasks: parseServerTasks(await res.json()) };
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message };
+  }
+}
+
+export interface ResumePlan {
+  /** Tasks to re-enter, oldest first. */
+  resume: HandoffRecord[];
+  /** Still assigned to us, but not started by this pass. */
+  skipped: number;
+  /** Local records claiming to be ours that the server does not list. */
+  stale: HandoffRecord[];
+}
+
+export interface ResumeOptions {
+  /** The server's answer, already filtered to `assignee=us&state=assigned`. */
+  serverTasks: ServerTask[];
+  /** What the local view holds. */
+  known: HandoffRecord[];
+  me: string;
+  max: number;
+  /** Tasks this session has already re-entered — resume must be idempotent. */
+  already: ReadonlySet<string>;
+}
+
+/**
+ * Decide what a resume re-enters.
+ *
+ * The server's list is the input, not the view's: a local record it does not
+ * name is stale by definition. Stale records are reported rather than
+ * rewritten — a task in a venue this reader cannot see is absent from the
+ * listing for a reason that has nothing to do with who holds it, and
+ * silently retiring somebody's work over an authorization gap is exactly the
+ * kind of confident wrongness the whole three-way verification rule exists to
+ * avoid.
+ */
+export function planResume(opts: ResumeOptions): ResumePlan {
+  const byId = new Map(opts.known.map((r) => [r.id, r]));
+  const mine = opts.serverTasks.filter(
+    (t) => t.kind === HANDOFF_KIND && t.state === "assigned" && t.assignee === opts.me,
+  );
+
+  const candidates: HandoffRecord[] = [];
+  let unusable = 0;
+  for (const t of mine) {
+    if (opts.already.has(t.id)) continue;
+    const known = byId.get(t.id);
+    if (known) {
+      candidates.push(known);
+      continue;
+    }
+    // Nothing local — a lost view, or work accepted from another machine. The
+    // row is enough to re-enter the work, as long as it names a venue we can
+    // post the lifecycle back into.
+    if (!t.venue.startsWith("#")) {
+      unusable++;
+      continue;
+    }
+    candidates.push(recordFromServer(t, opts.me));
+  }
+
+  candidates.sort((a, b) => a.createdAt - b.createdAt);
+  const resume = candidates.slice(0, Math.max(0, opts.max));
+
+  const listed = new Set(mine.map((t) => t.id));
+  const stale = opts.known.filter(
+    (r) => r.state === "assigned" && r.assignee === opts.me && !listed.has(r.id),
+  );
+
+  return { resume, skipped: candidates.length - resume.length + unusable, stale };
+}
+
+/** A view record built from a server row, for work we have no local memory of. */
+function recordFromServer(t: ServerTask, me: string): HandoffRecord {
+  const at = t.updated ?? Date.now();
+  return {
+    id: t.id,
+    kind: t.kind,
+    state: t.state,
+    offerer: t.offerer ?? "",
+    offeree: t.offeree,
+    assignee: t.assignee ?? me,
+    // The listing carries no title — it was never a signed field the server
+    // keeps for us — so say that plainly rather than inventing one.
+    title: "(title not in the server's listing)",
+    caps: t.caps,
+    deadline: t.deadline,
+    channel: t.venue,
+    fromReplay: false,
+    signed: true,
+    createdAt: at,
+    updatedAt: at,
+    log: [],
+  };
+}
+
 // ── referring to a task by the short id the notifications print ────────────
 
 export type TaskRef =

--- a/freeq-sdk-js/package-lock.json
+++ b/freeq-sdk-js/package-lock.json
@@ -24,7 +24,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -37,19 +36,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -978,6 +964,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1151,6 +1138,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",


### PR DESCRIPTION
Three failures from real use, none of them the model being dumb — all three were missing mechanism:

**An offer was lost if nobody was looking.** An inbound offer went straight to a blocking `ctx.ui.confirm()`. No one at the terminal, or a restart while it was open, and the offer was gone — the task sat `offered` forever and nothing revisited it. Replay didn't help; the event arrived, we dropped it. Offers now **queue** (persisted, so a restart keeps them), and are **auto-accepted when the session is idle and the offerer is trusted** — Chad's chosen default. Busy sessions drain the queue on the transition to idle. Queued offers expire against their own deadline or a TTL and are **declined with a reason**, because an offerer who learns quickly can re-offer elsewhere; silence helps nobody.

**Accepted work could hang forever.** `startAssignedWork()` set a label, injected a prompt, and ended — no watchdog at all, so a wandering session left the task `assigned` until the server's sweep days later. Now: a `progress` heartbeat while in flight (additive in the transition table, so it's free observability), and a stall timeout that **auto-fails with a reason** naming the stall. Shutdown notes the interruption instead of failing, since a restart may resume it.

**A restarted agent had no idea what it was doing.** There was no resume path anywhere. On connect it now asks the server — `GET /api/v1/actions?assignee=<self>&state=assigned` — reconciles against the local view, and re-enters through the same `startAssignedWork()` the live route uses. The server is the authority; a local record it doesn't list is reported, not trusted.

**Six new commands:** `tasks`, `resume [id]`, `accept <id>`, `decline <id>`, `drop <id> [reason]`, `progress <id> <note>` — ids accepted as the short prefix notifications print, with ambiguous prefixes refused by name.

**Tests: 203 → 254.** The sharpest one is `counts model activity as progress, not the heartbeats it emits` — without that distinction the heartbeat feeds its own stall timer and the hang never ends, which is exactly the bug this PR exists to close. Also covered: queue-while-busy, accept-on-idle, TTL decline, trust revoked while queued, stall fails exactly once, resume ignores rows that aren't ours, resume idempotent, prefix resolution.

Implementation by claude-opus-5 against `RESILIENCE-PLAN.md`; verified independently (build clean, 254 green, baseline confirmed at 203 on main). Judgement calls it made and flagged — a sibling queue file rather than migrating the view's on-disk shape, one 5s interval instead of three timer lifetimes, stale local records reported rather than rewritten, and `/freeq accept` skipping the tier gate because the trust map governs what happens *without* the owner, not what the owner may type.